### PR TITLE
add Romanian translation

### DIFF
--- a/book-main_ro.tex
+++ b/book-main_ro.tex
@@ -1,0 +1,260 @@
+% Compile with:
+% > latexmk -lualatex -interaction=nonstopmode --shell-escape -f book-main_ro.tex
+
+
+\documentclass{book}
+% For LuaLaTeX - proper Unicode support for Romanian
+\usepackage{fontspec}
+\usepackage[romanian]{babel}
+
+% Set main font with proper Romanian support
+\setmainfont{Latin Modern Roman}
+
+\usepackage[margin=1in]{geometry}
+
+% Font packages
+\usepackage{bbold}
+\usepackage{pifont}
+
+% Math packages
+\usepackage{amsmath}
+\usepackage{amssymb}
+
+% Figures and colors
+\usepackage{xcolor}
+\usepackage{graphicx}
+\usepackage{caption}
+\usepackage{float}
+\usepackage{subcaption}
+
+% Diagrams and images
+\usepackage{tikz} % General diagram software
+\usepackage{tikz-cd} % Commutative diagrams
+\usepackage{pgfplots} % PGF plots; used to plot functions
+\usetikzlibrary{automata, arrows, angles, calc, intersections, math, decorations.pathmorphing, decorations.markings}
+\usetikzlibrary{positioning}
+%% the following commands are needed for some matlab2tikz features
+\usetikzlibrary{plotmarks}
+\usetikzlibrary{arrows.meta}
+\pgfplotsset{compat=1.16}
+\usepgfplotslibrary{groupplots} % This lets you put multiple functions together in a single plot
+\usepgfplotslibrary{patchplots}
+
+% Tables
+\usepackage{booktabs}
+
+% References and bibliography
+\usepackage[
+backend=biber,
+style=alphabetic,
+sorting=nyt,
+doi=false,
+hyperref=true,
+isbn=false,
+sortcites,
+url=false,
+maxbibnames=99,
+maxalphanames=3,
+minalphanames=3,
+maxcitenames=2,
+mincitenames=1,
+backref=false,
+natbib=true,
+]{biblatex}
+\renewbibmacro{in:}{}
+\AtEveryBibitem{%
+  \clearlist{language}%
+}
+\providecommand{\toplevelprefix}{.}  % necessary for subfile compilation to work with bibliography
+\makeatletter
+% Hack to accommodate texlab users
+\@ifundefined{thiscommandisneverdefined}{
+  \addbibresource{\toplevelprefix/book-references.bib}
+}{
+  \addbibresource{book-references.bib}
+}
+\makeatother
+
+\usepackage{hyperref}
+\hypersetup{
+    colorlinks=true,
+    citecolor={blue!80!black},
+}
+\usepackage{cleveref}
+\crefname{assumption}{ipoteză}{ipoteze}
+\Crefname{assumption}{Ipoteza}{Ipotezele}
+\crefname{exercise}{exercițiu}{exerciții}
+\Crefname{exercise}{Exercițiul}{Exercițiile}
+
+\hyphenation{line-break line-breaks docu-ment triangle cambridge amsthdoc
+  cambridgemods baseline-skip author authors cambridgestyle en-vir-on-ment polar}
+
+\setcounter{tocdepth}{2}% list subsections in the table of contents
+
+% Algorithm packages -- should go after hyperref
+\usepackage{algorithm}
+% \usepackage[spaceRequire=false]{algpseudocodex}
+\usepackage{algpseudocode}
+
+% Math formatting
+\usepackage{mathtools}
+\usepackage{grffile}
+
+% Text formatting
+\usepackage[shortlabels]{enumitem}
+\usepackage{fancyvrb}
+\VerbatimFootnotes
+\allowdisplaybreaks
+
+% Custom packages for the book
+\usepackage{math-macros}  % Custom package
+\usepackage{math-theorems}  % Custom package
+\usepackage{book-macros}  % Custom package for macros in the book
+
+% Add subfiles --- each chapter can now be compiled by itself!
+\usepackage{subfiles}
+
+% Title page customization using titling package
+\usepackage{titling}
+\pretitle{\begin{center}\LARGE\bfseries}
+\posttitle{\end{center}\vskip 0.5em}
+\preauthor{\begin{center}\large}
+\postauthor{\end{center}}
+\predate{\begin{center}\large}
+\postdate{\end{center}}
+
+% Customize vertical spacing
+\setlength{\droptitle}{-8em}
+
+% Add a rule under the title
+\renewcommand{\maketitlehooka}{%
+  \vspace{1em}%
+  \noindent\makebox[\linewidth]{\rule{\textwidth}{0.4pt}}%
+  \vspace{1.5em}%
+}
+
+% Add space after author block
+\renewcommand{\maketitlehookb}{%
+  \vspace{2em}%
+}
+
+% Add space before date
+\renewcommand{\maketitlehookc}{%
+  \vspace{2em}%
+}
+
+% Add footnote content below date
+\renewcommand{\maketitlehookd}{%
+  \vspace{6em}\footnotesize $^*$\,Acești autori au contribuit în mod egal.
+}
+
+\begin{document}
+
+\title{Învățarea Reprezentărilor Profunde\\ ale Distribuțiilor de Date}
+
+\author{\vspace{0.5cm}
+\textbf{Sam Buchanan}$^*$, Institutul Tehnologic Toyota din Chicago \vspace{3mm}\\
+    \textbf{Druv Pai}$^*$, Universitatea din California, Berkeley \vspace{3mm} \\
+    \textbf{Peng Wang}, Universitatea din Michigan \&
+    Universitatea din Macau  \vspace{3mm} \\
+    \textbf{Yi Ma},   Universitatea din California, Berkeley \& Universitatea din Hong Kong
+	\vspace{8cm}\\
+	\footnotesize
+	Acest manuscris este pregătit pentru un curs despre principiile învățării profunde
+  și inteligenței în general, care urmează să fie predat de autori la instituțiile
+  respective. Această versiune pre-publicare este liberă pentru vizualizare și descărcare doar
+  pentru uz personal și nu este destinată redistribuirii, revânzării sau utilizării în lucrări
+  derivate.\\ Drepturi de autor \Pisymbol{psy}{227} 2025 Sam Buchanan, Druv Pai, Peng Wang, Yi
+  Ma
+	%\footnotesize Copyright \Pisymbol{psy}{227}2020 Reserved \\ No
+	%parts of this draft may be reproduced or distributed without written permission
+	%from the authors.\\
+}
+
+\date{\large 18 august 2025}
+
+\frontmatter
+\titlepage
+\thispagestyle{empty}
+\maketitle
+
+\cleardoublepage
+
+% \input{dedication.tex}
+% \cleardoublepage
+
+% \chapter*{Foreword}
+% \addcontentsline{toc}{chapter}{Foreword}
+% %\addcontentsline{toc}{chapter}{\numberline{}Foreword}
+% \input{chapters/Foreword/foreword.tex}
+% \cleardoublepage
+
+% \addcontentsline{toc}{chapter}{Notation}
+% \input{chapters/notation.tex}
+% \cleardoublepage
+
+\addcontentsline{toc}{chapter}{Prefață}
+\subfile{chapters/preface/preface_ro.tex}
+\cleardoublepage
+
+\addcontentsline{toc}{chapter}{Declarație Open Source}
+\subfile{chapters/declaration/declaration_ro.tex}
+\cleardoublepage
+
+\addcontentsline{toc}{chapter}{Mulțumiri}
+\subfile{chapters/acknowledgment/acknowledgment_ro.tex}
+\cleardoublepage
+
+% \chapter*{Acknowledgements}
+% %\addcontentsline{toc}{chapter}{Acknowledgements}
+ % \addcontentsline{toc}{chapter}{\numberline{}Acknowledgements}
+% \input{chapters/Acknowledgement/acknowledgement.tex}
+% \cleardoublepage
+
+\tableofcontents
+\cleardoublepage
+
+
+\setcounter{page}{1}
+\pagenumbering{arabic}
+
+
+\mainmatter
+
+\subfile{chapters/chapter1/introduction_ro}
+
+\subfile{chapters/chapter2/classic-models_ro}
+
+\subfile{chapters/chapter3/compression-principle_ro}
+
+\subfile{chapters/chapter4/deep-networks_ro}
+
+\subfile{chapters/chapter5/consistent_ro}
+
+\subfile{chapters/chapter6/conditional_ro}
+
+\subfile{chapters/chapter7/applications_ro}
+
+\subfile{chapters/chapter8/future_ro}
+
+\newpage
+
+\appendix
+%\part*{Appendices}
+\addcontentsline{toc}{chapter}{Anexe}
+
+\subfile{chapters/appendixA/optimization_ro}
+
+\subfile{chapters/appendixB/entropy_ro}
+
+
+\backmatter
+%insert a blank line to the toc list
+%\addtocontents{toc}{\vspace{\baselineskip}}
+
+\addcontentsline{toc}{chapter}{Bibliografie}
+\printbibliography
+\cleardoublepage
+
+
+\end{document}

--- a/chapters/acknowledgment/acknowledgment_ro.tex
+++ b/chapters/acknowledgment/acknowledgment_ro.tex
@@ -1,0 +1,15 @@
+\providecommand{\toplevelprefix}{../..}
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter*{Mulțumiri}
+Această carte se bazează în principal pe rezultatele cercetărilor care au fost dezvoltate în ultimii opt ani. Datorită fondurilor generoase de pornire de la UC Berkeley (2018) și Universitatea din Hong Kong (2023), Yi Ma a putut să înceapă și să se concentreze pe această nouă direcție de cercetare captivantă în ultimii opt ani. De-a lungul acestor ani, în legătură cu această direcție de cercetare, Yi Ma și echipa sa de cercetare de la Berkeley au fost susținuți de următoarele granturi de cercetare:
+\begin{itemize}
+    \item Proiectul multi-universitar {\em THEORINET} pentru Fundamentele Învățării Profunde, finanțat în comun de Fundația Simons și Fundația Națională pentru Știință (grant DMS \#2031899);
+    \item Proiectul {\em Transcrierea Datelor în Buclă Închisă prin Minimaxarea Reducerii Ratei} finanțat de Biroul de Cercetare Navală (grant N00014-22-1-2102); 
+    \item Proiectul {\em Abordări Principiale ale Învățării Profunde pentru Structuri cu Dimensiuni Reduse} finanțat de Fundația Națională pentru Știință (grant CISE \#2402951).
+\end{itemize} 
+Această carte nu ar fi fost posibilă fără sprijinul financiar pentru aceste proiecte de cercetare. Autorii au primit o inspirație extraordinară din rezultatele cercetărilor colegilor și studenților care au fost implicați în aceste proiecte.
+
+\end{document}

--- a/chapters/appendixA/optimization_ro.tex
+++ b/chapters/appendixA/optimization_ro.tex
@@ -1,0 +1,1023 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Metode de optimizare}
+\label{app:optimization}
+
+\begin{quote}
+``{\em Deoarece construcția întregului univers este perfectă și este creată de înțelepciunea creatorului, nimic nu apare în univers în care să nu putem vedea sensul unui maxim sau minim.}''
+
+$~$\hfill -- L. Euler
+ \end{quote}
+\vspace{5mm}
+
+În acest capitol, oferim o scurtă introducere în unii dintre cei mai elementari, dar importanți algoritmi de optimizare folosiți în această carte. Scopul este doar de a ajuta cititorul să aplice acești algoritmi la problemele studiate în această carte, nu de a obține o înțelegere profundă despre acești algoritmi. Prin urmare, nu vom oferi o justificare completă pentru algoritmii introduși, în ceea ce privește garanțiile de performanță.
+
+\section{Coborârea cea mai abruptă}
+
+
+Optimizarea se ocupă cu întrebarea cum să găsim unde o funcție, să zicem $L(\theta)$, atinge valoarea sa minimă. Matematic, aceasta este enunțată ca o problemă:
+\begin{equation}
+    \argmin_{\theta \in \Theta} \cL(\theta),
+\end{equation}
+unde $\Theta$ reprezintă un domeniu la care argumentul $\x$ este limitat. Adesea (și dacă nu se menționează altfel, în acest capitol) $\Theta$ este pur și simplu $\R^n$. Fără pierderea generalității, presupunem că aici funcția $\cL(\theta)$ este netedă\footnote{În cazul în care funcția \(\cL\) nu este netedă, înlocuim gradientul său cu un așa-numit \textit{subgradient}.}.
+
+Eficiența găsirii minimelor (globale) depinde de ce informații avem despre funcția \(\cL\). Pentru majoritatea problemelor de optimizare considerate în această carte, dimensiunea lui \(\theta\), să zicem \(n\), este foarte mare. Aceasta face ca calcularea sau accesarea informațiilor locale despre \(\ell\) să fie costisitoare. În special, deoarece gradientul \(\nabla \cL\) are \(n\) intrări, este adesea rezonabil de calculat; cu toate acestea, Hessianul \(\nabla^{2} \cL\) are \(n^{2}\) intrări, ceea ce este adesea extrem de nepractic de calculat (și același lucru este valabil pentru derivatele de ordin superior). Prin urmare, este tipic să presupunem că avem informația de ordin zero, adică suntem capabili să evaluăm \(\cL(\theta)\), și informația de prim ordin, adică suntem capabili să evaluăm \(\nabla \cL(\theta)\). Teoreticienii optimizării pot reformula aceasta spunând că avem un ``oracol de \textit{prim ordin}''. Toți algoritmii de optimizare pe care îi introducem în această secțiune folosesc doar un oracol de prim ordin.\footnote{Trimitem cititorii la cartea de \cite{Wright-Ma-2022} pentru o introducere mai sistematică în algoritmii de optimizare într-un spațiu de dimensiune mare, inclusiv algoritmi care presupun oracole de ordin superior.}
+
+\subsection{Coborârea gradientului vanilla pentru probleme netede}
+
+Cea mai simplă și mai utilizată metodă pentru optimizare este \textit{coborârea gradientului} (GD). A fost introdusă pentru prima dată de Cauchy în 1847. Ideea este foarte simplă: pornind de la o stare inițială, facem pași mici iterativ astfel încât fiecare pas să reducă valoarea funcției $\cL(\theta)$.
+
+Să presupunem că starea curentă este $\theta$. Vrem să facem un pas mic, să zicem de distanță $h$, într-o direcție, indicată de un vector $\vv$, pentru a ajunge la o nouă stare $\theta + h\vv$ astfel încât valoarea funcției să scadă:
+\begin{equation}
+    \cL(\theta + h\vv) \leq \cL(\theta).
+\end{equation}
+Pentru a găsi o astfel de direcție $\vv$, putem aproxima $\cL(\theta + h\vv)$ printr-o expansiune Taylor în jurul lui \(h = 0\):
+\begin{equation}
+    \cL(\theta + h\vv) = \cL(\theta) + h\ip{\nabla \cL(\theta)}{\vv} + o(h),
+\end{equation}
+unde produsul scalar aici (și în acest capitol) va fi produsul scalar \(\ell^{2}\), adică \(\ip{\vx}{\vy} = \vx^{\top}\vy\). Pentru a găsi direcția de \textit{coborâre cea mai abruptă}, încercăm să minimizăm această expansiune Taylor printre vectorii unitari \(\vv\). Dacă \(\nabla \cL(\theta) = \vzero\), atunci al doilea termen de mai sus este \(0\) indiferent de valoarea lui \(\vv\), deci nu putem încerca să facem progrese, adică algoritmul a conversat. Pe de altă parte, dacă \(\nabla \cL(\theta) \neq \vzero\) atunci este valabil
+\begin{equation}\label{eq:steepest_descent_l2_norm}
+    \argmin_{\substack{\vv \in \R^{d} \\ \norm{\vv}_{2} = 1}} [\cL(\theta) + h\ip{\nabla \cL(\theta)}{\vv}] = \argmin_{\substack{\vv \in \R^{d} \\ \norm{\vv}_{2} = 1}} \ip{\nabla \cL(\theta)}{\vv} = -\frac{\nabla \cL(\theta)}{\norm{\nabla \cL(\theta)}_{2}},
+\end{equation}
+Cu alte cuvinte, aceasta înseamnă că valoarea lui \(\cL(\theta + h\vv)\) scade cel mai rapid de-a lungul direcției \(\vv = -\nabla \cL(\theta) / \norm{\nabla \cL(\theta)}_{2}\), pentru \(h\) suficient de mic. Aceasta conduce la metoda coborârii gradientului: Din starea curentă $\theta_k$ ($k=0, 1, \ldots$), facem un pas de mărime $h$ în direcția gradientului negativ pentru a ajunge la următoarea iterație,
+\begin{equation}
+    \theta_{k+1} = \theta_k - h \nabla \cL(\theta_k). 
+\end{equation}
+Mărimea pasului \(h\) este numită și \textit{rata de învățare} în contextele de învățare automată.
+
+\subsubsection{Selecția mărimii pasului}
+
+Întrebarea rămasă este care ar trebui să fie mărimea pasului $h$? Dacă alegem $h$ să fie prea mic, valoarea funcției poate scădea foarte încet, așa cum se arată în graficul din mijloc din \Cref{fig:step-size}. Dacă $h$ este prea mare, valoarea ar putea să nici nu scadă deloc, așa cum se arată în graficul din dreapta din \Cref{fig:step-size}.
+
+\begin{figure}[h]
+    \centering
+    \includegraphics[height=3.5cm]{\toplevelprefix/chapters/appendixA/figs/GD-1.png}
+    \hspace{3mm}
+    \includegraphics[height=3.5cm]{\toplevelprefix/chapters/appendixA/figs/GD-2.png}
+    \hspace{3mm}
+    \includegraphics[height=3.5cm]{\toplevelprefix/chapters/appendixA/figs/GD-3.png}
+    \caption{Efectul mărimii pasului $h$ asupra convergenței metodei coborârii gradientului.}
+    \label{fig:step-size}
+\end{figure}
+
+Deci mărimea pasului $h$ ar trebui aleasă pe baza peisajului funcției $\cL(\theta_k)$. Ideal, pentru a alege cea mai bună mărime a pasului $h$, putem rezolva următoarea problemă de optimizare peste o singură variabilă $h$:
+\begin{equation}
+    h = \argmin_{h\geq 0} \cL(\theta_k - h\nabla \cL(\theta_k)).
+\end{equation}
+Această metodă de alegere a mărimii pasului se numește \textit{căutare pe linie}. Cu toate acestea, când funcția $L(\theta_k)$ este complicată, ceea ce este de obicei cazul pentru antrenarea unei rețele neuronale profunde, această optimizare unidimensională este foarte dificil de rezolvat la fiecare iterație a coborârii gradientului.
+
+Atunci cum ar trebui să alegem o mărime adecvată a pasului $h$? O abordare comună și clasică este să încercăm să obținem o bună aproximare a peisajului local în jurul stării curente $\theta$ pe baza unor cunoștințe despre peisajul general al funcției $\cL(\theta)$.
+
+\begin{figure}
+    \centering 
+    \begin{tikzpicture}[scale=0.9]
+        \draw[->] (-0.5,0) -- (6.5,0) node[right] {$\theta$};
+        \draw[->] (0,-0.5) -- (0,5) node[above] {$\cL(\theta)$};
+        
+        \draw[thick, blue] plot[smooth, tension=0.7] coordinates {
+            (0,4) (1,3.2) (2,2.5) (3,3.2) (4,1.5) (5,2.2) (6,3)
+        } node[right] {$\cL(\theta)$};
+        
+        \draw[thick, red, dashed] plot[smooth, tension=0.5] coordinates {
+            (0,4.5) (1,3.7) (2,2.5) (3,3.7) (4,2) (5,3.2) (6,4)
+        } node[right] {$u(\theta)$};
+        
+        \filldraw[blue] (2,2.5) circle (2pt) node[below right] {$\theta_0$};
+        
+        \filldraw[red] (4,1.5) circle (2pt) node[below right] {$\theta_1$};
+        
+        \draw[dashed] (2,0) -- (2,2.5);
+        \draw[dashed] (4,0) -- (4,2);
+    \end{tikzpicture}
+    \caption{\small\textbf{Schema și intuiția majorizării-minimizării.} O funcție \(\cL \colon \Theta \to \R\) are o limită superioară globală \(u \colon \Theta \to \R\) care întâlnește \(L\) în cel puțin un punct \(\theta_{0}\). Apoi, găsirea lui \(\theta_{1}\) care minimizează \(u\) va îmbunătăți valoarea lui \(\cL\) de la \(\cL(\theta_{0})\). Rețineți că rezultate similare pot fi arătate despre limitele superioare locale.}
+    \label{fig:majorization_minimization}
+\end{figure}
+
+Condițiile comune pentru peisajul lui \(\cL(\theta)\) includ:
+\begin{itemize}
+    \item \(\alpha\)-Convexitate puternică. Reamintim că \(\cL\) este \textit{\(\alpha\)-puternic convexă} dacă graficul său se află deasupra unei limite inferioare pătratice globale de pantă \(\alpha\), adică,
+    \begin{equation}
+        \cL(\theta) \geq l_{\theta_{0}, \alpha}(\theta) \doteq \cL(\theta_{0}) + \ip{\nabla \cL(\theta_{0})}{\theta - \theta_{0}} + \frac{\alpha}{2}\norm{\theta - \theta_{0}}_{2}^{2}
+    \end{equation}
+    pentru orice ``punct de bază'' \(\theta_{0}\). Spunem că \(\cL\) este \textit{convexă} dacă este \(0\)-puternic convexă, adică graficul său se află deasupra tangentelor sale. Este ușor de arătat (demonstrația ca exercițiu) că funcțiile puternic convexe au minime globale unice. Un alt fapt important (demonstrația ca exercițiu) este că funcțiile \(\alpha\)-puternic convexe de două ori diferențiabile \(\cL\) au Hessiene (simetrice) \(\nabla^{2}\cL\) a căror valoare proprie minimă este \(\geq \alpha\). Pentru \(\alpha > 0\) aceasta implică că Hessianul este simetric pozitiv definit, iar pentru \(\alpha = 0\) (adică \(\cL\) este convexă) aceasta implică că Hessianul este simetric pozitiv semidefinit.
+    \item \(\beta\)-Gradient Lipschitz (numit și \(\beta\)-Netezime). Reamintim că \(\cL\) are \textit{\(\beta\)-gradient Lipschitz} dacă \(\nabla \cL\) există și este \(\beta\)-Lipschitz, adică,
+    \begin{equation}
+        \norm{\nabla \cL(\theta) - \nabla \cL(\theta_{0})}_{2} \leq \beta \norm{\theta - \theta_{0}}_{2}.
+    \end{equation}
+    pentru orice ``punct de bază'' \(\theta_{0}\). Este ușor de arătat (demonstrația ca exercițiu) că aceasta este echivalentă cu \(\cL\) având o limită superioară pătratică globală de pantă \(\beta\), adică,
+    \begin{equation}
+        \cL(\theta) \leq u_{\theta_{0}, \beta}(\theta) \doteq \cL(\theta_{0}) + \ip{\nabla \cL(\theta_{0})}{\theta - \theta_{0}} + \frac{\beta}{2}\norm{\theta - \theta_{0}}_{2}^{2}.
+    \end{equation}
+    pentru orice ``punct de bază'' \(\theta_{0}\). Un alt fapt important (demonstrația ca exercițiu) este că funcțiile convexe cu \(\beta\)-gradient Lipschitz de două ori diferențiabile au Hessiene (simetrice) \(\nabla^{2}\cL\) a căror valoare proprie cea mai mare este \(\leq \beta\).
+\end{itemize}
+Mai întâi, să presupunem că \(\cL\) are \(\beta\)-gradient Lipschitz (dar nu este neapărat chiar convexă). Vom folosi această ocazie pentru a introduce o temă comună de optimizare: \textit{pentru a minimiza \(\cL\), putem minimiza o limită superioară pe \(L\)}, care este justificată de următoarea lemă vizualizată în \Cref{fig:majorization_minimization}.
+\begin{lemma}[Majorizare-Minimizare]\label{lem:majorization_minimization}
+    Să presupunem că \(u \colon \Theta \to \R\) este o limită superioară globală pe \(\cL\), și anume \(\cL(\theta) \leq u(\theta)\) pentru toți \(\theta \in \Theta\). Să presupunem că se întâlnesc cu egalitate la \(\theta_{0}\), adică \(\cL(\theta_{0}) = u(\theta_{0})\). Atunci
+    \begin{equation}
+        \theta_{1} \in \argmin_{\theta \in \Theta}u(\theta) \implies \cL(\theta_{1}) \leq u(\theta_{1}) \leq u(\theta_{0}) = \cL(\theta_{0}).
+    \end{equation}
+\end{lemma}
+
+Vom folosi această lemă pentru a arăta că putem folosi proprietatea gradientului Lipschitz pentru a ne asigura că fiecare pas de gradient nu poate înrăutăți valoarea lui \(\cL\). Într-adevăr, la fiecare punct de bază \(\theta_{0}\), avem că \(u_{\theta_{0}, \beta}\) este o limită superioară globală pe \(\cL\), și \(u_{\theta_{0}, \beta}(\theta_{0}) = \cL(\theta_{0})\). Prin urmare, prin \Cref{lem:majorization_minimization}
+\begin{equation}
+    \text{dacă \(\theta\) minimizează \(u_{\theta_{0}, \beta}\) atunci} \quad \cL(\theta) \leq u_{\theta_{0}, \beta}(\theta) \leq u_{\theta_{0}, \beta}(\theta_{0}) = \cL(\theta_{0}).
+\end{equation}
+Aceasta ne motivează, când găsim o actualizare pentru a obține \(\theta_{k + 1}\) din \(\theta_{k}\), putem în schimb să minimizăm limita superioară \(u_{\theta_{k}, \beta}\) peste \(\theta\) și să setăm aceasta să fie \(\theta_{k + 1}\). Prin minimizarea \(u_{\theta_{k}, \beta}\) (demonstrația ca exercițiu) obținem
+\begin{equation}\label{eq:GD}
+    \theta_{k + 1} = \theta_{k} - \frac{1}{\beta}\nabla \cL(\theta_{k}) \implies \cL(\theta_{k + 1}) \leq \cL(\theta_{k}).
+\end{equation}
+Aceasta implică că o mărime a pasului \(h = 1/\beta\) este o rată de învățare utilizabilă, dar nu oferă o rată de convergență sau nu certifică că \(L(\theta_{k})\) converge de fapt la \(\min_{\theta}\cL(\theta)\). Aceasta necesită puțin mai multă rigoare, pe care o urmărim acum.
+
+Acum, să presupunem că \(\cL\) este \(\alpha\)-puternic convexă, are \(\beta\)-gradient Lipschitz și are optimul global \(\theta^{\star}\). Vom arăta că \(\theta_{k}\) va converge direct la optimul global unic \(\theta^{\star}\), care este o formă foarte puternică de convergență. În special, vom limita \(\norm{\theta^{\star} - \theta_{k}}_{2}\) folosind atât convexitatea puternică, cât și caracterul Lipschitz al gradientului lui \(\cL\), adică privind vecinătatea în jurul lui \(\theta_{k}\):\footnote{În această demonstrație, pasul de invocare a \(\beta\)-Gradientului Lipschitz este puțin non-trivial. Lăsăm și acest pas ca exercițiu, cu indiciul de a înlocui \(\theta = \theta_{0} - h\nabla \cL(\theta_{0})\) în identitatea gradientului Lipschitz.}
+\begin{align}
+    \norm{\theta^{\star} - \theta_{k + 1}}_{2}^{2}
+    &\leq \norm{\theta^{\star} - \theta_{k} + h\nabla \cL(\theta_{k})}_{2}^{2} \\ 
+    &= \norm{\theta^{\star} - \theta_{k}}_{2}^{2} + 2h\ip{\nabla \cL(\theta_{k})}{\theta^{\star} - \theta_{k}} + h^{2}\norm{\nabla \cL(\theta_{k})}_{2}^{2} \\ 
+    &\leq \norm{\theta^{\star} - \theta_{k}}_{2}^{2} + 2h\bp{\cL(\theta^{\star}) - \cL(\theta_{k}) - \frac{\alpha}{2}\norm{\theta^{\star} - \theta_{k}}_{2}^{2}} + h^{2}\norm{\nabla \cL(\theta_{k})}_{2}^{2} \quad \text{(\(\alpha\)-SC)} \\
+    &= \bp{1 - \alpha h}\norm{\theta^{\star} - \theta_{k}}_{2}^{2} + 2h(\cL(\theta^{\star}) - L(\theta_{k})) + h^{2}\norm{\nabla \cL(\theta_{k})}_{2}^{2} \\
+    &\leq \bp{1 - \alpha h}\norm{\theta^{\star} - \theta_{k}}_{2}^{2} + 2h(\cL(\theta^{k}) - \cL(\theta^{\star})) + 2h^{2}\beta(\cL(\theta_{k}) - \cL(\theta^{\star})) \quad \text{(\(\beta\)-LG)} \\
+    &= \bp{1 - \alpha h}\norm{\theta^{\star} - \theta_{k}}_{2}^{2} - 2h(1 - \beta h)(\cL(\theta_{k}) - \cL(\theta^{\star})).
+\end{align}
+Pentru a ne asigura că iterația coborârii gradientului face progrese, trebuie să alegem mărimea pasului astfel încât \(1 - \beta h \geq 0\), adică \(h \leq 1/\beta\). Dacă apare o astfel de setare, atunci
+\begin{align}
+    \norm{\theta^{\star} - \theta_{k + 1}}_{2}^{2} 
+    &\leq (1 - \alpha h)\norm{\theta^{\star} - \theta_{k}}_{2}^{2} \leq (1 - \alpha h)^{2}\norm{\theta^{\star} - \theta_{k - 1}}_{2}^{2} \leq \cdots \\ 
+    &\leq (1 - \alpha h)^{k + 1}\norm{\theta^{\star} - \theta_{0}}_{2}^{2}.
+\end{align}
+Pentru a minimiza partea dreaptă, putem seta \(h = 1/\beta\), ceea ce obține
+\begin{equation}
+    \norm{\theta^{\star} - \theta_{k + 1}}_{2}^{2} \leq (1 - \alpha/\beta)^{k + 1}\norm{\theta^{\star} - \theta_{0}}_{2}^{2},
+\end{equation}
+arătând convergența la optimul global cu eroare care scade exponențial. Observați că aici am folosit o rată de convergență pentru a obține o \textit{mărime favorabilă a pasului} de \(h = 1/\beta\). Acest motiv va reapărea în această secțiune.
+
+Încheiem această secțiune cu o avertizare: învățarea unui optim global este (de obicei) impracticabil de dificilă. În anumite condiții, putem asigura că iterațiile coborârii gradientului converg la un \textit{optim local}. De asemenea, în condiții mai relaxate, putem asigura convergența \textit{locală}, adică că iterațiile converg la un optim (global sau local) dacă secvența este inițializată suficient de aproape de optim.
+
+
+
+\subsection{Coborârea gradientului precondiționată pentru probleme prost condiționate}
+
+
+\begin{figure}
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/appendixA/figs/hessian_geometry.png}
+    \caption{\small\textbf{Gradientul negativ \(-\nabla \cL_{\lambda}\) și câmpul vectorial precondiționat (pasul metodei lui Newton) \(-[\nabla^{2}\cL_{\lambda}]^{-1}[\nabla \cL_{\lambda}]\)} unde \(\lambda = 19\). Există o secțiune a spațiului unde urmarea câmpului vectorial gradient negativ face foarte puține progrese către găsirea minimului, dar în toate cazurile urmarea câmpului vectorial al metodei lui Newton obține viteză egală de progres către optim, deoarece gradientul este albit. Deoarece Hessianul aici este diagonal, algoritmii de rată de învățare adaptivă (de exemplu, Adam, așa cum va fi discutat mai târziu în secțiune) pot face progrese similare cu metoda lui Newton, dar un Hessian ne-aliniat pe axe poate chiar împiedica Adam să reușească rapid.}
+    \label{fig:hessian_geometry}
+\end{figure}
+
+\subsubsection{Metoda lui Newton}
+
+Există unele probleme netede și probleme puternic convexe pe care coborârea gradientului totuși funcționează destul de prost. De exemplu, fie \(\lambda \geq 0\) și fie \(\cL_{\lambda} \colon \R^{2} \to \R\) de forma
+\begin{equation}
+    \cL_{\lambda}(\theta) = \cL_{\lambda}\rp{\mat{\theta_{1} \\ \theta_{2}}} \doteq \frac{1}{2}\bc{(1 + \lambda) \theta_{1}^{2} + \theta_{2}^{2}} = \frac{1}{2}\theta^{\top}\mat{1 + \lambda & 0 \\ 0 & 1}\theta.
+\end{equation}
+Această problemă este \(1\)-puternic convexă și are \((1 + \lambda)\)-gradient Lipschitz. Rata de convergență este apoi geometrică cu rata \(1 - 1/(1 + \lambda)\). Pentru \(\lambda\) mare, aceasta încă nu este foarte rapidă. În această secțiune, vom introduce o clasă de probleme de optimizare care pot optimiza cu succes astfel de funcții prost condiționate.
+
+Cheia se află în \textit{curbura} obiectivului, care este dată de Hessian. Să presupunem că (ca un contrafactual) am avea un oracol de \textit{ordinul doi} care ne-ar permite să calculăm \(\cL(\theta)\), \(\nabla \cL(\theta)\) și \(\nabla^{2}\cL(\theta)\). Apoi, în loc să alegem o direcție de coborâre \(\vv\) pentru a optimiza expansiunea Taylor de ordinul întâi în jurul lui \(\theta\), am putea optimiza în schimb expansiunea Taylor de ordinul doi. Intuitiv, aceasta ne-ar permite să încorporăm informații despre curbură în actualizare.
+
+Să efectuăm acest calcul. Expansiunea Taylor de ordinul doi a lui \(\cL(\theta + h\vv)\) în jurul lui \(h = 0\) este
+\begin{equation}
+    \cL(\theta + h\vv) = \cL(\theta) + h\ip{\nabla \cL(\theta)}{\vv} + \frac{1}{2}h^{2}\ip{[\nabla^{2}\cL(\theta)]\vv}{\vv} + o(h^{2}).
+\end{equation}
+Apoi putem calcula direcția de coborâre:
+\begin{align}
+    \argmin_{\substack{\vv \in \R^{n} \\ \norm{\vv}_{2} = 1}}\bs{\cL(\theta) + h\ip{\nabla \cL(\theta)}{\vv} + \frac{1}{2}h^{2}\ip{[\nabla^{2}\cL(\theta)]\vv}{\vv}} 
+    &= \argmin_{\substack{\vv \in \R^{n} \\ \norm{\vv}_{2} = 1}}\bs{\ip{\nabla \cL(\theta)}{\vv} + \frac{1}{2}h\ip{[\nabla^{2}\cL(\theta)]\vv}{\vv}}.
+\end{align}
+Această problemă de optimizare este puțin dificil de rezolvat din cauza constrângerii \(\norm{\vv}_{2} = 1\). Dar în practică nu normalizăm niciodată direcția de coborâre \(\vv\) și folosim mărimea pasului \(h\) pentru a controla mărimea actualizării. Deci, să rezolvăm problema de mai sus peste toți vectorii \(\vv \in \R^{n}\):\footnote{Dacă \(\nabla^{2}\cL(\theta)\) nu este inversabil, atunci putem înlocui \([\nabla^{2}\cL(\theta)]^{-1}\) cu pseudoinversa Moore-Penrose a lui \(\nabla^{2}\cL(\theta)\).}
+\begin{equation}
+    \argmin_{\vv \in \R^{n}}\bs{\ip{\nabla \cL(\theta)}{\vv} + \frac{1}{2}h\ip{[\nabla^{2}\cL(\theta)]\vv}{\vv}} = -\frac{1}{h}[\nabla^{2}\cL(\theta)]^{-1}[\nabla \cL(\theta)].
+\end{equation}
+Putem astfel folosi iterația de coborâre cea mai abruptă
+\begin{equation}
+    \theta_{k + 1} = \theta_{k} - [\nabla^{2}\cL(\theta_{k})]^{-1}[\nabla \cL(\theta_{k})],
+\end{equation}
+(aceasta este celebra \textit{metodă a lui Newton}), sau
+\begin{equation}
+    \theta_{k + 1} = \theta_{k} - h[\nabla^{2}\cL(\theta_{k})]^{-1}[\nabla \cL(\theta_{k})],
+\end{equation}
+(care se numește \textit{metoda lui Newton subamortizată}). Deoarece pătratică de ordinul doi \(\cL_{\lambda}\) este egală cu expansiunea sa Taylor de ordinul doi, dacă rulăm metoda lui Newton pentru \textit{un pas}, vom obține minimul global într-\textit{un pas}, indiferent cât de mare este \(\lambda\). \Cref{fig:hessian_geometry} oferă o oarecare intuiție despre funcțiile prost condiționate și pașii de gradient versus pașii lui Newton.
+
+\subsubsection{PGD}
+
+În practică, \textit{nu} avem un oracol de ordinul doi care ne permite să calculăm \(\nabla^{2}\cL(\theta)\). În schimb, putem încerca să \textit{învățăm o aproximare la acesta} alături de actualizarea parametrului \(\theta_{k + 1}\) din \(\theta_{k}\).
+
+Cum învățăm o aproximare la acesta? Vom găsi câteva ecuații pe care le satisface inversa Hessianului și apoi vom încerca să actualizăm aproximarea noastră astfel încât să satisfacă ecuațiile. Mai exact, luând seria Taylor a lui \(\nabla \cL(\theta + \delta_{\theta})\) în jurul punctului \(\theta\), obținem
+\begin{equation}
+    \underbrace{\nabla L(\theta + \delta_{\theta}) - \nabla \cL(\theta)}_{\doteq \delta_{\vg}} = [\nabla^{2} \cL(\theta)]\delta_{\theta} + o(\norm{\delta_{\theta}}_{2}).
+\end{equation}
+În acest caz avem
+\begin{equation}
+    \delta_{\vg} \approx [\nabla^{2}\cL(\theta)]\delta_{\theta} \implies \delta_{\theta} \approx [\nabla^{2}\cL(\theta)]^{-1}\delta_{\vg}
+\end{equation}
+Putem acum încerca să învățăm un precondiționator simetric pozitiv semidefinit \(P \in \R^{n \times n}\) astfel încât
+\begin{equation}
+    \delta_{\theta} \approx P\delta_{\vg},
+\end{equation}
+actualizându-l la fiecare iterație împreună cu \(\theta_{k}\). Mai exact, avem iterația \textit{PSGD}
+\begin{align}
+    P_{k}
+    &= \mathrm{PreconditionerUpdate}(P_{k - 1}; \theta_{k}, \nabla \cL(\theta_{k})) \\ 
+    \theta_{k + 1}
+    &= \theta_{k} - hP_{k}\nabla \cL(\theta_{k}).
+\end{align}
+Această actualizare are două probleme: cum putem chiar folosi \(P\) (deoarece am spus deja că nu putem stoca o matrice \(n \times n\)) și cum putem \textit{actualiza} \(P\) la fiecare iterație? Răspunsurile sunt foarte legate; nu putem niciodată materializa \(P\) în memoria computerului, dar îl putem reprezenta folosind o factorizare de rang mic (sau metode comparabile precum \textit{factorizarea Kronecker} care este deosebit de potrivită pentru forma rețelelor neuronale profunde). Apoi pasul de actualizare a precondiționatorului este proiectat pentru a exploata structura reprezentării precondiționatorului.
+
+Încheiem această subsecțiune cu o avertizare: în învățarea profundă, de exemplu, \(\cL\) nu este o funcție convexă și astfel metoda lui Newton (și aproximările la ea) nu au sens. În acest caz ne uităm la intuiția geometrică a metodei lui Newton pe funcții convexe, să zicem din \Cref{fig:hessian_geometry}: Hessianul invers \textit{albește} gradienții. Astfel, în loc de un precondiționator care aproximează Hessianul, putem ajusta procedurile de mai sus pentru a învăța o transformare de albire mai generală pentru gradient. Aceasta este ideea din spatele propunerii originale a PSGD \cite{li2017preconditioned}, care conține mai multe informații despre cum să stocăm și să actualizăm precondiționatorul, și optimizatori mai moderni precum Muon \cite{liu2025muon}.
+
+
+\subsection{Coborârea gradientului proximal pentru probleme ne-netede}\label{subsec:pgd}
+
+Chiar și în probleme foarte simple, cum ar fi LASSO sau învățarea de dicționar, problema nu este puternic convexă, ci doar convexă, iar obiectivul nu mai este doar neted, ci suma unei funcții netede și a unui regularizator ne-neted (cum ar fi norma \(\ell^{1}\)). Astfel de probleme sunt rezolvate de \textit{algoritmi de optimizare proximală}, care generalizează coborârea cea mai abruptă la obiective ne-netede.
+
+Formal, să spunem că
+\begin{equation}
+    \cL(\theta) \doteq \cS(\theta) + \cR(\theta)
+\end{equation}
+unde \(\cS\) este netedă, să zicem cu \(\beta\)-gradient Lipschitz, și \(\cR\) este ne-netedă (adică aspră). Algoritmul de gradient proximal generalizează algoritmul de coborâre cea mai abruptă, folosind cadrul de majorizare-minimizare (adică \Cref{lem:majorization_minimization}) cu o limită superioară globală diferită. Mai exact, construim o astfel de limită superioară întrebând: ce se întâmplă dacă luăm limita superioară a gradientului Lipschitz a lui \(S\) dar \textit{lăsăm \(R\) în pace}? Mai exact, avem
+\begin{equation}
+    \cL(\theta_{1}) = \cS(\theta_{1}) + \cR(\theta_{1}) \leq u_{\theta_{0}, \beta}(\theta_{1}) \doteq \cS(\theta_{0}) + \ip{\nabla \cS(\theta_{0})}{\theta_{1} - \theta_{0}} + \frac{\beta}{2}\norm{\theta_{1} - \theta_{0}}_{2}^{2} + \cR(\theta_{1}).
+\end{equation}
+Rețineți că (demonstrație ca exercițiu)
+\begin{equation}
+    \argmin_{\theta_{1}}u_{\theta_{0}, \beta}(\theta_{1}) = \argmin_{\theta_{1}}\bs{\frac{\beta}{2}\norm*{\theta_{1} - \bp{\theta_{0} - \frac{1}{\beta}\nabla \cS(\theta_{0})}}_{2}^{2} + \cR(\theta_{1})}.
+\end{equation}
+Acum, dacă încercăm să minimizăm limita superioară \(u_{\theta_{0}, \beta}\), alegem un \(\theta_{1}\) care:
+\begin{itemize}
+    \item este aproape de actualizarea gradientului \(\theta_{0} - \frac{1}{\beta}\nabla \cS(\theta_{0})\);
+    \item are o valoare mică a regularizatorului \(\cR(\theta_{1})\)
+\end{itemize}
+și face un compromis între aceste proprietăți în funcție de parametrul de netezime \(\beta\). În consecință, să definim operatorul proximal
+\begin{equation}
+    \prox_{h, \cR}(\theta) \doteq \argmin_{\theta_{1}}\bs{\frac{1}{2h}\norm{\theta_{1} - \theta}_{2}^{2} + \cR(\theta)}.
+\end{equation}
+Apoi, putem defini iterația \textit{coborârii gradientului proximal} care, la fiecare iterație, minimizează limita superioară \(u_{\theta_{k}, h^{-1}}\), adică,
+\begin{equation}
+    \theta_{k + 1} = \prox_{h, \cR}(\theta_{k} - h\nabla \cS(\theta_{k})).
+\end{equation}
+Demonstrațiile de convergență sunt posibile când \(h \leq 1/\beta\), dar nu oferim niciuna în această secțiune.
+
+O întrebare rămasă este: cum putem calcula operatorul proximal? La prima vedere, pare că am schimbat o problemă de minimizare intractabilă cu alta. Deoarece nu am făcut nicio presupunere asupra lui \(\cR\) până acum, cadrul funcționează chiar și atunci când \(\cR\) este o funcție foarte complexă (cum ar fi o pierdere de rețea neuronală), ceea ce ne-ar cere să rezolvăm o problemă de antrenament a rețelei neuronale pentru a calcula un singur operator proximal. Cu toate acestea, în practică, pentru regularizatori simpli \(\cR\) precum cei pe care îi folosim în acest manuscris, există operatori proximali care sunt ușor de calculat sau chiar în formă închisă. Oferim câțiva mai jos (demonstrațiile sunt un exercițiu).
+
+\begin{example}\label{example:prox-of-characteristic-function}
+    Fie \(\Gamma \subseteq \Theta\) o mulțime, și fie \(\chi_{\Gamma}\) funcția caracteristică pe \(\Gamma\), adică,
+    \begin{equation}
+        \chi_{\Gamma}(\theta) \doteq \casework{0, & \text{dacă}\ \theta \in \Gamma \\ +\infty, & \text{dacă}\ \theta \notin \Gamma.}
+    \end{equation}
+    Atunci operatorul proximal al lui \(\chi_{\Gamma}\) este o proiecție, adică,
+    \begin{equation}
+        \prox_{h, \chi_{\Gamma}}(\theta) = \argmin_{\theta_{1} \in \Gamma}\frac{1}{2}\norm{\theta_{1} - \theta}_{2}^{2} = \argmin_{\theta_{1} \in \Gamma}\norm{\theta_{1} - \theta}_{2}.
+    \end{equation}
+\end{example}
+
+\begin{example}\label{example:prox-of-l1}
+    Norma \(\ell^{1}\) are un operator proximal care efectuează pragarea moale:
+    \begin{equation}
+        S_{h}(\theta) \doteq \prox_{h, \lambda \norm{\cdot}_{1}}(\theta) = \argmin_{\theta_{1}}\bs{\frac{1}{2h}\norm{\theta_{1} - \theta}_{2}^{2} + \lambda\norm{\theta}_{1}}
+    \end{equation}
+    atunci \(S_{h}(\theta)\) este definit de
+    \begin{equation}
+        S_{h}(\theta)_{i} = \casework{\theta_{i} - h\lambda, & \text{dacă}\ \theta_{i} \geq h\lambda \\ 0, & \text{dacă}\ \theta_{i} \in [-h\lambda, h\lambda] \\ \theta_{i} + h\lambda, & \text{dacă}\ \theta_{i} \leq -h\lambda} = \casework{\max\{\abs{\theta_{i}} - h\lambda, 0\}\sign(\theta_{i}), & \text{dacă}\ \abs{\theta_{i}} \geq h\lambda \\ 0, & \text{dacă}\ \abs{\theta_{i}} < h\lambda.}
+    \end{equation}
+    Operația de gradient proximal cu partea netedă a obiectivului fiind cele mai mici pătrate și partea ne-netedă fiind norma \(\ell^{1}\) (prin urmare folosind acest operator proximal de pragare moale) se numește Algoritmul Iterativ de Micșorare-Pragare (ISTA).
+\end{example}
+
+\begin{example}\label{example:prox-of-nonnegative-l1}
+    În \Cref{ch:representation} folosim un operator proximal corespunzător normei \(\ell^{1}\) plus funcția caracteristică pentru ortantul pozitiv \(\R_{+}^{n} \doteq \{\vx \in \R^{n} \colon x_{i} \geq 0\ \forall i\}\), și anume
+    \begin{equation}
+        T_{h}(\theta) \doteq \prox_{h, \lambda\norm{\cdot}_{1} + \chi_{\R_{+}^{n}}}(\theta) = \argmin_{\theta_{1} \in \R_{+}^{n}}\bs{\frac{1}{2h}\norm{\theta_{1} - \theta}_{2}^{2} + \lambda\norm{\theta}_{1}},
+    \end{equation}
+    atunci \(T_{h}\) este definit ca
+    \begin{equation}
+        T_{h}(\theta)_{i} \doteq \max\{\theta_{i} - h\lambda, 0\}.
+    \end{equation}
+    Acest operator proximal produce ISTA ne-negativ care este invocat în \Cref{ch:representation} și dincolo.
+\end{example}
+
+
+
+\subsection{Coborârea gradientului stocastic pentru probleme la scară mare}
+
+
+În învățarea profundă, funcția obiectiv \(\cL\) de obicei nu poate fi calculată exact, și în schimb la fiecare pas de optimizare este \textit{estimată} folosind eșantioane finite (să zicem, folosind un mini-batch). O modalitate comună de a modela această situație este de a defini o \textit{funcție de pierdere stochastică} \(\cL_{\omega}(\theta)\) unde \(\omega\) este o anumită ``sursă de aleatorie''. De exemplu, \(\omega\) ar putea conține indicii eșantioanelor dintr-un batch pe care să calculăm pierderea. Atunci, am dori să minimizăm \(\cL(\theta) \doteq \Ex_{\omega}[\cL_{\omega}(\theta)]\) peste \(\theta\), având acces la un \textit{oracol stochastic de prim ordin}: dat \(\theta\), putem eșantiona \(\omega\) și calcula \(\cL_{\omega}(\theta)\) și \(\nabla_{\theta}\cL_{\omega}(\theta)\). Această problemă de minimizare se numește o \textit{problemă de optimizare stochastică}.
+
+Algoritmul stochastic de bază de prim ordin este \textit{coborârea gradientului stochastic}: la fiecare iterație \(k\) eșantionăm \(\omega_{k}\), definim \(\cL_{k} \doteq \cL_{\omega_{k}}\), și efectuăm un pas de gradient pe \(\cL_{k}\), adică,
+\begin{equation}
+    \theta_{k + 1} = \theta_{k} - h\nabla \cL_{k}(\theta_{k}).
+\end{equation}
+Cu toate acestea, chiar și pentru probleme foarte simple nu ne putem aștepta la același tip de convergență ca cel obținut în coborârea gradientului. De exemplu, să presupunem că există \(m\) valori posibile pentru \(\omega \in \{1, \dots, m\}\) pe care le ia cu probabilitate egală, și există \(m\) ținte posibile \(\xi_{1}, \dots, \xi_{m}\), astfel încât funcția de pierdere \(\cL_{\omega}\) este
+\begin{equation}
+    \cL_{\omega}(\theta) \doteq \frac{1}{2}\norm{\theta - \xi_{\omega}}_{2}^{2}.
+\end{equation}
+Atunci \(\argmin_{\theta}\Ex[\cL_{\omega}(\theta)] = \frac{1}{m}\sum_{i = 1}\xi_{i}\), dar coborârea gradientului stochastic poate ``ricoșa'' în jurul valorii optime globale și să nu convergă, așa cum este vizualizat în \Cref{fig:sgd_nonconvergence}.
+
+\begin{figure}
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/appendixA/figs/sgd_vs_nesterov.png}
+    \centering 
+    \caption{\small\textbf{Coborârea gradientului stochastic poate să nu convergă, chiar și pentru obiective foarte benigne, dar gradientul Nesterov converge.} Chiar și pentru obiective pătratice simple, iterațiile coborârii gradientului stochastic pot ricoșa în jurul optimului global, în timp ce gradienții Nesterov se aliniază pentru a indica valoarea optimă.}
+    \label{fig:sgd_nonconvergence}
+\end{figure}
+
+Pentru a remedia acest lucru, putem fie să mediem parametrii \(\theta_{k}\), fie să mediem gradienții \(\nabla \cL_{k}(\theta_{k})\) în timp. Dacă mediem parametrii \(\theta_{k}\), atunci (folosind \Cref{fig:sgd_nonconvergence} ca model mental) problema ricoșării nu este în mod direct posibilă, deoarece iterația medie se va apropia de centru. Ca atare, majoritatea demonstrațiilor teoretice de convergență consideră convergența iterației medii \(\frac{1}{k}\sum_{i = 0}^{k}\theta_{i}\) la minimul global. Dacă mediem gradienții, vom învăța în cele din urmă un gradient mediu \(\frac{1}{k}\sum_{i = 0}^{k}\nabla \cL_{k}(\theta_{k})\) care nu se schimbă mult la fiecare iterație și, prin urmare, nu ricoșează.
+
+În practică, în loc să folosim o medie aritmetică, luăm o \textit{medie mobilă exponențială} (EMA) a parametrilor (aceasta se numește \textit{momentum Polyak}) sau a gradienților (aceasta se numește \textit{momentum Nesterov}). Momentum-ul Nesterov este mai popular și îl vom studia aici.
+
+O iterație de coborâre a gradientului stochastic cu momentum Nesterov este următoarea:
+\begin{align}
+    \vg_{k}
+    &= \beta\vg_{k - 1} + (1 - \beta)\nabla \cL_{k}(\theta_{k}) \\ 
+    \theta_{k + 1}
+    &= \theta_{k} - h\vg_{k}.
+\end{align}
+Nu parcurgem o demonstrație de convergență (vezi Capitolul 7 din \cite{garrigos2023handbook} pentru un exemplu). Cu toate acestea, momentum-ul Nesterov gestionează cazul nostru simplu din \Cref{fig:sgd_nonconvergence} ușor (vezi figura din dreapta): oprește ricoșarea și în cele din urmă converge la optimul global.
+
+Încheiem cu o avertizare: se poate arăta că momentum-ul Polyak și momentum-ul Nesterov sunt echivalente, pentru anumite alegeri ale setărilor de parametri. Apoi este de asemenea posibil să arătăm că un program de rată de învățare în scădere (adică rata de învățare \(h\) depinde de iterația \(k\), iar limita sa este \(h_{k} \to 0\) când \(k \to \infty\)) cu SGD simplu (sau PSGD) poate imita efectul momentum-ului. Mai exact, \cite{defazio2023optimal} arată că dacă algoritmul SGD durează \(K\) iterații, normele gradientului sunt limitate \(\norm{\nabla \cL(\theta_{k})}_{2} \leq G\), și definim \(D \doteq \norm{\theta_{0} - \theta^{\star}}_{2}\), atunci iterațiile SGD simple \(\theta_{k}\) satisfac rata \(\Ex[\cL(\theta_{k}) - \cL(\theta^{\star})] \leq DG/\sqrt{K}\) --- dar numai atâta timp cât rata de învățare \(h_{k} = (D/[G\sqrt{K}])(1 - k/K)\) scade \textit{liniar} cu timpul. Aceasta se potrivește cu programele de rată de învățare folosite în practică. Într-adevăr, surprinzător, o astfel de teorie a optimizării convexe poate prezice multe fenomene empirice în rețelele profunde \cite{schaipp2025surprising}, în ciuda faptului că optimizarea învățării profunde este extrem de ne-convexă și ne-netedă în cel mai rău caz. Până acum nu este clar de ce este acesta cazul.
+
+
+\subsection{Punând totul împreună: Adam}
+
+Schema coborârii gradientului propune o iterație de forma
+\begin{equation}
+    \theta_{k + 1} = \theta_{k} + h\vv_{k},
+\end{equation}
+unde (reamintim) \(\vv_{k}\) este aleasă să fie (proporțională cu) vectorul de coborâre cea mai abruptă în norma euclidiană:
+\begin{equation}
+    \vv_{k} = -\frac{\nabla \cL(\theta_{k})}{\norm{\nabla \cL(\theta_{k})}_{2}} \in \argmin_{\substack{\vv \in \R^{n} \\ \norm{\vv}_{2} = 1}}\ip{\nabla \cL(\theta_{k})}{\vv}.
+\end{equation}
+Cu toate acestea, în contextul optimizării învățării profunde, nu există absolut nimic care să implice că trebuie să folosim norma euclidiană; într-adevăr, ``geometria naturală'' a spațiului parametrilor nu este bine respectată de norma euclidiană, deoarece schimbări mici în spațiul parametrilor pot duce la diferențe foarte mari în spațiul de ieșire, pentru o anumită intrare fixă în rețea. Dacă am folosi în schimb o normă generică \(\norm{\cdot}\) pe spațiul parametrilor \(\R^{n}\), am obține o altă cantitate corespunzătoare așa-numitei \textit{norme duale}:
+\begin{equation}
+    \vv_{k} \in \argmin_{\substack{\vv \in \R^{n} \\ \norm{\vv} = 1}}\ip{\nabla \cL(\theta_{k})}{\vv}.
+\end{equation}
+De exemplu, dacă am folosi norma \(\ell^{\infty}\), este posibil să arătăm că
+\begin{equation}
+    \vv_{k} = -\sign(\nabla \cL(\theta_{k})) \in \argmin_{\substack{\vv \in \R^{n} \\ \norm{\vv}_{\infty} = 1}}\ip{\nabla \cL(\theta_{k})}{\vv},
+\end{equation}
+unde \(\sign(\vx)_{i} = \sign(x_{i}) \in \{-1, 0, 1\}\). Astfel, dacă am fi atât de înclinați, am putea folosi așa-numita \textit{coborâre a gradientului semn}:
+\begin{equation}\label{eq:sign_gradient_descent}
+    \theta_{k + 1} = \theta_{k} - h\sign(\nabla \cL(\theta_{k})).
+\end{equation}
+Din coborârea gradientului semn, putem deriva celebrul algoritm de optimizare Adam. Rețineți că pentru un scalar \(x \in \R\) putem scrie
+\begin{equation}
+    \sign(x) = \frac{x}{\abs{x}} = \frac{x}{\sqrt{x^{2}}}.
+\end{equation}
+Similar, pentru un vector \(\vx \in \R^{n}\) scriem (unde \(\hada\) și \(\haddiv\) sunt înmulțirea și împărțirea element cu element)
+\begin{equation}
+    \sign(\vx) = \vx \haddiv [\vx^{\hada 2}]^{\hada (1/2)}.
+\end{equation}
+Folosind această reprezentare putem scrie \eqref{eq:sign_gradient_descent} ca
+\begin{equation}
+    \theta_{k + 1} = \theta_{k} - h ([\nabla \cL(\theta_{k})] \haddiv [\nabla
+    \cL(\theta_{k})^{\hada 2}]^{\hada \frac{1}{2}}).
+\end{equation}
+Acum considerați regimul stochastic unde optimizăm o pierdere diferită \(L_{k}\) la fiecare iterație. În SGD, am ``urmărit'' (adică am luat o medie a) gradienților folosind momentum-ul Nesterov. Aici, putem urmări atât gradientul, cât și gradientul pătrat folosind momentum, adică,
+\begin{align}
+    \vg_{k}
+    &= \beta^{1}\vg_{k - 1} + (1 - \beta^{1})\nabla \cL_{k}(\theta_{k}) \\ 
+    \vs_{k}
+    &= \beta^{2}\vs_{k - 1} + (1 - \beta^{2})[\nabla \cL_{k}(\theta_{k})]^{\hada 2}  \\
+    \theta_{k + 1}
+    &= \theta_{k} - h\vg_{k}\haddiv\vs_{k}^{\hada \frac{1}{2}},
+\end{align}
+unde \(\beta^{i} \in [0, 1]\) sunt parametrii de momentum. Algoritmul prezentat de această iterație este celebrul optimizator \textit{Adam},\footnote{Pentru a evita erorile de împărțire la zero, împărțim la \(\vs_{k}^{\hada (1/2)} + \eps \vone_{n}\) unde \(\eps\) este mic, să zicem de ordinul \(10^{-8}\).} care este optimizatorul cel mai utilizat în învățarea profundă. În timp ce demonstrațiile de convergență ale Adam sunt mai complexe, se încadrează în același principiu de coborâre cea mai abruptă pe care l-am folosit până acum, și astfel ar trebui să ne așteptăm că, având o rată de învățare suficient de mică, fiecare actualizare ar trebui să îmbunătățească pierderea.
+
+O altă modalitate de a vedea Adam, care explică parțial succesul său empiric, este că actualizează dinamic ratele de învățare pentru fiecare parametru pe baza gradienților pătrați. În special, observați că putem scrie
+\begin{equation}
+    \theta_{k + 1} = \theta_{k} - \eta_{k} \hada \vg_{k} \qquad \text{unde}
+    \qquad \eta_{k} = h \vs_{k}^{\hada (-\frac{1}{2})}
+\end{equation}
+unde \(\eta_{k}\) este rata de învățare setată adaptiv pe parametru. Această schemă se numește adaptivă deoarece dacă gradientul unui anumit parametru este mare până la iterația \(k\), atunci rata de învățare pentru acest parametru devine mai mică pentru a compensa, și invers, așa cum se poate vedea din ecuația de mai sus.
+
+
+
+
+
+
+
+
+
+\section{Calcularea gradienților prin diferențiere automată}\label{sec:autodiff}
+
+Mai sus, am discutat mai mulți algoritmi de optimizare pentru rețele profunde care presupuneau accesul la un \textit{oracol de prim ordin}, adică un dispozitiv care ne-ar permite să calculăm \(\cL(\theta)\) și \(\nabla \cL(\theta)\).
+Pentru funcții simple \(\cL\), este posibil să facem acest lucru manual.
+Cu toate acestea, pentru rețelele neuronale profunde, aceasta devine rapid plictisitor și împiedică experimentarea rapidă.
+Prin urmare, avem nevoie de un algoritm general care ne-ar permite să calculăm eficient gradienții arhitecturilor de rețea (sub)diferențiabile arbitrare.
+
+În această secțiune, introducem elementele de bază ale \textit{diferențierii automate} (AD sau \textit{autodiff}), care este o modalitate eficientă din punct de vedere computațional de a calcula gradienți și Jacobieni ai funcțiilor generale $f: \R^m \to \R^n$. Vom arăta cum aceasta conduce la algoritmul de backpropagare pentru calcularea gradienților funcțiilor de pierdere care implică rețele neuronale.
+Un rezumat al structurii acestei secțiuni este următorul:
+\begin{enumerate}
+    \item Introducem \textbf{diferențialele}, un formalism convenabil pentru calcularea și organizarea derivatelor funcțiilor între spații de parametri de dimensiune mare (care pot fi ele însele produse ale altor spații care implică matrici, tensori etc.).
+    \item Descriem elementele de bază ale diferențierii automate \textbf{în mod direct} și \textbf{în mod invers}, care implică considerații importante pentru calculul eficient al gradienților/Jacobienilor pentru diferite tipuri de funcții care apar în aplicațiile de învățare automată.
+    \item Descriem \textbf{backpropagarea} în cazul special al unei funcții de pierdere aplicate unei rețele neuronale cu straturi stivuite ca o instanțiere a diferențierii automate în mod invers.
+\end{enumerate}
+
+Tratarea noastră va greși pe partea matematică, pentru a oferi cititorului o înțelegere profundă a matematicii de bază. Cititorul ar trebui să se asigure că cuplează această înțelegere cu o înțelegere puternică a aspectelor practice ale diferențierii automate pentru învățarea profundă, de exemplu, așa cum se manifestă în excelentul tutorial al lui \textcite{karpathy-micrograd}.
+
+\subsection{Diferențiale}
+
+O prezentare completă a acestei subsecțiuni este dată în excelentul ghid \cite{bright2025matrix}.
+Pentru a motiva diferențialele, să considerăm mai întâi exemplul simplu al unei funcții diferențiabile \(\cL \colon \R \to \R\) care acționează asupra unui parametru \(\theta\). Putem scrie
+\begin{equation}
+    \cL(\theta) - \cL(\theta_{0}) = \cL^{\prime}(\theta_{0})\cdot(\theta - \theta_{0}) + o(\abs{\theta - \theta_{0}}).
+\end{equation}
+Dacă luăm \(\delta\theta \doteq \theta - \theta_{0}\) și \(\delta\cL \doteq \cL(\theta_{0} + \delta\theta) - \cL(\theta_{0})\), putem scrie
+\begin{equation}
+    \delta\cL = \cL^{\prime}(\theta_{0})\cdot\delta\theta + o(\abs{\delta\theta}).
+\end{equation}
+Vom defini (ne-riguros) \(\odif{\theta}\) și \(\odif{\cL}\), adică \textit{diferențialele} lui \(\theta\) și \(\cL\), să fie schimbări \textit{infinitezimal de mici} în \(\theta\) și \(\cL\).
+Gândiți-vă la ele ca la ceea ce obțineți atunci când \(\delta\theta\) (și prin urmare \(\delta \cL\)) sunt extrem de mici. Scopul calculului diferențial, într-un anumit sens, este de a studia relațiile dintre diferențialele \(\odif{\theta}\) și \(\odif{\cL}\), adică să vedem cum schimbările mici în intrarea unei funcții schimbă ieșirea. Ar trebui să observăm că diferențiala \(\odif{\theta}\) are \textit{aceeași formă} ca \(\theta\), iar diferențiala \(\odif{\cL}\) are \textit{aceeași formă} ca \(\cL\). În special, putem scrie
+\begin{equation}
+    \odif{\cL} = \cL^{\prime}(\theta)\cdot\odif{\theta},
+\end{equation}
+prin care avem că toate puterile superioare ale \(\abs{\odif{\theta}}\), cum ar fi \((\odif{\theta})^{2}\), sunt \(0\).
+
+Să vedem cum funcționează aceasta pentru dimensiuni mai mari, adică \(\cL \colon \R^{n} \to \R\). Atunci încă avem
+\begin{equation}
+    \odif{\cL} = \cL^{\prime}(\theta)\cdot\odif{\theta}
+\end{equation}
+pentru o anumită noțiune de derivată \(\cL^{\prime}(\theta)\). Deoarece \(\theta\) (prin urmare \(\odif{\theta}\)) este un vector coloană aici și \(\cL\) (prin urmare \(\odif{\cL}\)) este un scalar, trebuie să avem că \(\cL^{\prime}(\theta)\) este un vector linie. În acest caz, \(\cL^{\prime}(\theta)\) este Jacobianul lui \(\cL\) în raport cu \(\theta\). Aici observați că am setat toate puterile și produsele superioare ale coordonatelor lui \(\odif{\theta}\) la \(0\). În rezumat,
+\begin{quote}
+    \centering
+    \textit{Toate produsele și puterile \(\geq 2\) ale diferențialelor sunt egale cu \(0\).}
+\end{quote}
+
+Acum considerați o funcție tensor de ordin superior \(\cL \colon \R^{m \times n} \to \R^{p \times q}\). Atunci ecuația noastră de bază de linearizare este insuficientă pentru acest caz: \(\odif{\cL} = \cL^{\prime}(\theta) \cdot \odif{\theta}\) nu are sens deoarece \(\theta\) este o matrice \(m \times n\) dar \(\odif{\cL}\) este o matrice \(p \times q\), deci nu există o formă posibilă de vector sau matrice pentru \(\cL^{\prime}(\theta)\) care să funcționeze în general (deoarece nicio matrice nu poate înmulți o matrice \(m \times n\) pentru a forma o matrice \(p \times q\) decât dacă \(m = p\)). Deci trebuie să avem o interpretare puțin mai avansată.
+
+Mai exact, considerăm \(\cL^{\prime}(\theta)\) ca o \textit{transformare liniară} a cărei intrare este spațiul-\(\theta\) și a cărei ieșire este spațiul-\(\cL\), care ia o schimbare mică în \(\theta\) și scoate schimbarea mică corespunzătoare în \(\cL\). Mai exact, putem scrie
+\begin{equation}
+    \odif{\cL} = \cL^{\prime}(\theta)[\odif{\theta}].
+\end{equation}
+În cazurile anterioare, \(\cL^{\prime}(\theta)\) a fost mai întâi un operator liniar \(\R \to \R\) a cărui acțiune a fost să înmulțească intrarea sa cu derivata scalară a lui \(\cL\) în raport cu \(\theta\), și apoi un operator liniar \(\R^{n} \to \R\) a cărui acțiune a fost să înmulțească intrarea sa cu derivata Jacobiană a lui \(\cL\) în raport cu \(\theta\). În general \(\cL^{\prime}(\theta)\) este ``derivata'' lui \(\cL\) în raport cu \(\theta\).
+Gândiți-vă la \(\cL^{\prime}\) ca la o versiune generalizată a Jacobianului lui \(\cL\).
+Ca atare, urmează câteva reguli simple de derivare, cel mai important regula lanțului.
+
+\begin{theorem}[Regula lanțului diferențială]
+    Să presupunem că \(\cL = f \circ g\) unde \(f\) și \(g\) sunt diferențiabile. Atunci
+    \begin{equation}
+        \odif{\cL} = f^{\prime}(g(\theta))g^{\prime}(\theta)[\odif{\theta}],
+    \end{equation}
+    unde (ca de obicei) înmulțirea indică compoziția operatorilor liniari. În special,
+    \begin{equation}
+        \cL^{\prime}(\theta) = f^{\prime}(g(\theta))g^{\prime}(\theta)
+    \end{equation}
+    în sensul egalității operatorilor liniari.
+\end{theorem}
+
+Este productiv să ne gândim la regula lanțului multivariată în termeni functoriali: compoziția funcțiilor este ``transformată în'' înmulțirea matricilor de Jacobieni (compoziția operatorilor liniari!).
+Ilustrăm puterea acestui rezultat și a acestei perspective prin mai multe exemple.
+
+\begin{example}
+    Considerați funcția \(f(\vX) = \vW\vX + \vb\vone^{\top}\). Atunci
+    \begin{equation}
+        \odif{f} = f(\vX + \odif{\vX}) - f(\vX) = [\vW(\vX + \odif{\vX}) + \vb\vone^{\top}] - [\vW \vX + \vb \vone^{\top}] = \vW\odif{\vX}.
+    \end{equation}
+    Astfel derivata unei funcții afine în raport cu intrarea sa este
+    \begin{equation}
+        f^{\prime}(\vX)[\odif{\vX}] = \vW\odif{\vX} \implies f^{\prime}(\vX) = \vW.
+    \end{equation}
+    Observați că \(f^{\prime}\) este \textit{constantă}. Pe de altă parte, considerați funcția \(g(\vW, \vb) = \vW\vX + \vb\vone^{\top}\). Atunci
+    \begin{align}
+        \odif{g} 
+        &= g(\vW + \odif{\vW}, \vb + \odif{\vb}) - g(\vW, \vb) = [(\vW + \odif{\vW})\vX + (\vb + \odif{\vb})\vone^{\top}] - [\vW\vX + \vb] \\
+        &= (\odif{\vW})\vX + (\odif{\vb})\vone^{\top} = g^{\prime}(\vW, \vB)[\odif{\vW}, \odif{\vb}].
+    \end{align}
+    Observați că această derivată este \textit{constantă} în \(\vW, \vb\) (ceea ce are sens deoarece \(g\) însăși este liniară) și liniară în intrările diferențiale \(\odif{\vW}, \odif{\vb}\).
+\end{example}
+
+\begin{example}
+    Considerați funcția \(f = gh\) unde \(g, h\) sunt funcții diferențiabile ale căror ieșiri se pot înmulți împreună. Atunci \(f = p \circ v\) unde \(v = (g, h)\) și \(p(a, b) = ab\). Aplicând regula lanțului avem
+    \begin{equation}
+        \odif{f} = p^{\prime}(v(x))v^{\prime}(x)[\odif{x}].
+    \end{equation}
+    Pentru a calcula \(v^{\prime}(x)\) putem calcula
+    \begin{equation}
+        \odif{v} = v^{\prime}(x)[\odif{x}] = v(x + \odif{x}) - v(x) = \mat{g(x + \odif{x}) - g(x) \\ h(x + \odif{x}) - h(x)} = \mat{g^{\prime}(x)[\odif{x}] \\ h^{\prime}(x)[\odif{x}]}.
+    \end{equation}
+    Pentru a calcula \(p^{\prime}\) putem calcula
+    \begin{align}
+        \odif{p} 
+        &= p^{\prime}(a, b)[\odif{a}, \odif{b}] = p(a + \odif{a}, b + \odif{b}) - p(a, b) = (a + \odif{a})(b + \odif{b}) - ab \\
+        &= (\odif{a})b + a(\odif{b}) + (\odif{a})(\odif{b}) = (\odif{a})b + a(\odif{b}),
+    \end{align}
+    unde (reamintim) produsul diferențialelor \(\odif{a}\) și \(\odif{b}\) este setat la \(0\). Prin urmare
+    \begin{equation}
+        p^{\prime}(a, b)[\odif{a}, \odif{b}] = (\odif{a})b + (\odif{b})a.
+    \end{equation}
+    Punând acestea împreună, găsim
+    \begin{align}
+        f^{\prime}(x)[\odif{x}] 
+        &= p^{\prime}(v(x))v^{\prime}(x)[\odif{x}] = p^{\prime}(g(x), h(x))[g^{\prime}(x)[\odif{x}], h^{\prime}(x)[\odif{x}]] \\
+        &= (g^{\prime}(x)[\odif{x}])h(x) + g(x)(h^{\prime}(x)[\odif{x}]).
+    \end{align}
+    Aceasta dă
+    \begin{equation}
+        f^{\prime}(x)[\odif{x}] = (g^{\prime}(x)[\odif{x}])h(x) + g(x)(h^{\prime}(x)[\odif{x}]).
+    \end{equation}
+    Dacă de exemplu spunem că \(f, g, h \colon \R \to \R\) atunci totul comutează deci
+    \begin{equation}
+        f^{\prime}(x)[\odif{x}] = (g^{\prime}(x)h(x) + g(x)h^{\prime}(x))[\odif{x}] \implies f^{\prime}(x) = g^{\prime}(x)h(x) + g(x)h^{\prime}(x)
+    \end{equation}
+    care este regula familiară a produsului.
+\end{example}
+
+\begin{example}
+    Considerați funcția \(f(\vA) = \vA^{\top}\vA\vB\vA\) unde \(\vA\) este o matrice și \(\vB\) este o matrice constantă. Atunci, luând \(f = gh\) unde \(g(\vA) = \vA^{\top}\vA\) și \(h(\vA) = \vB\vA\), putem folosi regula produsului pentru a obține
+    \begin{align}
+        f^{\prime}(\vA)[\odif{\vA}]
+        &= (g^{\prime}(\vA)[\odif{\vA}])h(\vA) + g(\vA)(h^{\prime}(\vA)[\odif{\vA}]) \\
+        &= ((\odif{\vA})^{\top}\vA + \vA^{\top}(\odif{\vA}))\vB\vA + \vA^{\top}\vA\vB(\odif{\vA}).
+    \end{align}
+\end{example}
+
+\begin{example}
+    Considerați funcția \(f \colon \R^{m \times n \times k} \to \R^{m \times n}\) dată de
+    \begin{equation}
+        f(\vA)_{ij} = \sum_{t = 1}^{k}A_{ijt}.
+    \end{equation}
+    Nu putem scrie un Jacobian sau gradient (cu valori matriciale) pentru această funcție. Dar putem calcula diferențiala sa fără probleme:
+    \begin{equation}
+        \odif{f}_{ij} = [f(\vA + \odif{\vA}) - f(\vA)]_{ij} = \sum_{t = 1}^{k}\odif{\vA}_{ijt} = \vone_{k}^{\top}(\odif{\vA})_{ij}.
+    \end{equation}
+    Deci
+    \begin{equation}
+        (f^{\prime}(\vA)[\odif{\vA}])_{ij} = \vone_{k}^{\top}(\odif{\vA})_{ij},
+    \end{equation}
+    care reprezintă o operație de înmulțire a tensorilor de ordin superior care este totuși bine definită.
+\end{example}
+
+Aceasta ne dă toată tehnologia de care avem nevoie pentru a calcula diferențialele oricărui lucru.
+Ultimul lucru pe care îl acoperim în această secțiune este o metodă de a calcula gradienți folosind diferențiala. Mai exact, pentru o funcție \(\cL\) a cărei ieșire este un scalar, gradientul \(\nabla \cL\) este definit ca
+\begin{equation}
+    \odif{\cL} = \cL^{\prime}(\theta)[\odif{\theta}] = \ip{\nabla \cL(\theta)}{\odif{\theta}},
+\end{equation}
+unde produsul scalar aici este produsul scalar ``standard'' pentru obiectele specificate (adică, pentru vectori este produsul scalar \(\ell^{2}\), în timp ce pentru matrici este produsul scalar Frobenius, iar pentru tensori de ordin superior este produsul scalar analog al sumei coordonatelor).
+Această definiție este generalizarea corectă a exemplului ``familiar'' al gradientului unei funcții de la $\R^n$ la $\R$ ca vectorul de derivate parțiale --- o versiune a teoremei lui Taylor pentru funcții generale $f : \R^m \to \R^n$ face această conexiune riguroasă.
+Deci o modalitate de a calcula gradientul \(\nabla \cL\) este de a calcula diferențiala \(\odif{\cL}\) și de a o rescrie în forma \(\ip{\text{ceva}}{\odif{\theta}}\), atunci acel ``ceva'' este gradientul.
+
+
+
+
+
+\subsection{Diferențiere automată}
+
+Ideea principală a AD este de a calcula regula lanțului eficient.
+Problema de bază cu care trebuie să facem față este următoarea. În secțiunea de optimizare a anexei, am considerat că spațiul parametrilor \(\Theta\) era un spațiu euclidian abstract precum \(\R^{n}\). În practică, parametrii sunt de fapt o colecție de vectori, matrici și obiecte de ordin superior: \(\Theta = \R^{m \times n} \times \R^{n} \times \R^{r \times q \times p} \times \R^{r \times q} \times \cdots\). Deși în teorie aceasta este același lucru cu un spațiu mare de parametri \(\R^{n^{\prime}}\) pentru un anumit \(n^{\prime}\) (foarte mare), algoritmii eficienți din punct de vedere computațional pentru diferențiere trebuie să trateze aceste două spații diferit.
+Diferențierea automată în mod direct și în mod invers sunt două scheme diferite pentru efectuarea acestui calcul.
+
+Să facem un exemplu simplu pentru a începe. Fie \(\cL\) definită de \(\cL = a \circ b \circ c\) unde \(a, b, c\) sunt diferențiabile. Atunci \textit{regula lanțului} dă
+\begin{equation}
+    \cL^{\prime}(\theta) = a^{\prime}(b(c(\theta)))b^{\prime}(c(\theta))c^{\prime}(\theta).
+\end{equation}
+Pentru a calcula \(\cL(\theta)\), calculăm mai întâi \(c(\theta)\) apoi \(b(c(\theta))\) apoi \(a(b(c(\theta)))\), și le stocăm pe toate. Există două moduri de a calcula \(\cL^{\prime}(\theta)\). \textit{AD în mod direct} va calcula
+\begin{equation}
+    c^{\prime}(\theta) \implies b^{\prime}(c(\theta))c^{\prime}(\theta) \implies a^{\prime}(b(c(\theta)))b^{\prime}(c(\theta))c^{\prime}(\theta)
+\end{equation}
+adică, calcularea derivatelor ``de jos în sus''. \textit{AD în mod invers} va calcula
+\begin{equation}
+    a^{\prime}(b(c(\theta))) \implies a^{\prime}(b(c(\theta)))b^{\prime}(c(\theta)) \implies a^{\prime}(b(c(\theta)))b^{\prime}(c(\theta))c^{\prime}(\theta),
+\end{equation}
+adică, calcularea derivatelor ``de sus în jos''. Pentru a vedea de ce contează aceasta, să presupunem că \(f \colon \R^{p} \to \R^{s}\) este dată de \(f = a \circ b \circ c\) unde \(a \colon \R^{r} \to \R^{s}\), \(b \colon \R^{q} \to \R^{r}\), \(c \colon \R^{p} \to \R^{q}\). Atunci regula lanțului este:
+\begin{equation}
+    f^{\prime}(\vx) = a^{\prime}(b(c(\vx)))b^{\prime}(c(\vx))c^{\prime}(\vx)
+\end{equation}
+unde (reamintim) \(f^{\prime}\) este derivata, în acest caz Jacobianul (deoarece intrarea și ieșirea fiecărei funcții sunt ambele vectori). Presupunând că calcularea fiecărui Jacobian este trivială și singurul cost este înmulțirea Jacobienilor împreună, AD în mod direct are următoarele costuri computaționale (presupunând că înmulțirea \(A \in \R^{m \times n}, B \in \R^{n \times k}\) ia timpul \(\cO(mnk)\)):
+\begin{align}
+    &\text{calcularea}\ c^{\prime}(\vx) \in \R^{q \times p}\ \text{ia timp neglijabil} \\
+    &\text{calcularea}\ b^{\prime}(c(\vx))c^{\prime}(x) \in \R^{r \times p}\ \text{ia timpul \(\cO(pqr)\)} \\
+    &\text{calcularea}\ a^{\prime}(b(c(\vx)))b^{\prime}(c(\vx))c^{\prime}(\vx) \in \R^{s \times p}\ \text{ia timpul \(\cO(pqr + prs)\).}
+\end{align}
+Între timp, efectuarea AD în mod invers are următoarele costuri computaționale:
+\begin{align}
+    &\text{calcularea}\ a^{\prime}(b(c(\vx))) \in \R^{s \times r}\ \text{ia timp neglijabil} \\
+    &\text{calcularea}\ a^{\prime}(b(c(\vx)))b^{\prime}(c(\vx)) \in \R^{s \times q}\ \text{ia timpul \(\cO(qrs)\)} \\
+    &\text{calcularea}\ a^{\prime}(b(c(\vx)))b^{\prime}(c(\vx))c^{\prime}(\vx) \in \R^{s \times p}\ \text{ia timpul \(\cO(qrs + pqs)\).}
+\end{align}
+În alte cuvinte, AD în mod direct ia timpul \(\cO(p(qr + rs))\), iar AD în mod invers ia timpul \(\cO(s(pq + qr))\). \textit{Acestea iau cantități diferite de timp!}
+
+Mai general, să presupunem că \(f = f^{L} \circ \cdots \circ f^{1}\) unde fiecare \(f^{\ell} \colon \R^{d^{\ell - 1}} \to \R^{d^{\ell}}\), astfel încât \(f \colon \R^{d^{0}} \to \R^{d^{L}}\). Atunci AD în mod direct ia timpul \(\cO(d^{0}(\sum_{\ell = 2}^{L}d^{\ell - 1}d^{\ell}))\) în timp ce AD în mod invers ia timpul \(\cO(d^{L}(\sum_{\ell = 1}^{L - 1}d^{\ell - 1}d^{\ell}))\). Din ratele de mai sus, vedem că toate celelalte fiind egale:
+\begin{itemize}
+    \item Dacă funcția de optimizat are \textit{mai multe ieșiri decât intrări} (adică \(d^{L} > d^{0}\)), folosiți \textit{AD în mod direct}.
+    \item Dacă funcția de optimizat are \textit{mai multe intrări decât ieșiri} (adică \(d^{0} > d^{L}\)), folosiți \textit{AD în mod invers}.
+\end{itemize}
+Într-o rețea neuronală, calculăm gradientul unei \textit{funcții de pierdere} \(\cL \colon \Theta \to \R\), unde spațiul parametrilor \(\Theta\) este de obicei de dimensiune foarte mare. Deci în practică folosim întotdeauna AD în mod invers pentru antrenarea rețelelor neuronale. AD în mod invers, în contextul antrenării rețelelor neuronale, se numește \textit{backpropagare}.
+
+\subsection{Backpropagare}
+\label{app:BP-section}
+În această secțiune, vom discuta backpropagarea algoritmică folosind un exemplu simplu dar complet practic. Să presupunem că fixăm o pereche intrare-etichetă \((\vX, \vy)\), și fixăm o arhitectură de rețea \(f_{\theta} = f_{\theta}^{L} \circ \cdots \circ f_{\theta}^{1} \circ f_{\theta}^{\emb}\) unde \(\theta = (\theta^{\emb}, \theta^{1}, \dots, \theta^{m}, \theta^{\head})\) și cap specific sarcinii \(h_{\theta^{\head}}\), și scriem
+\begin{align}
+    &\vZ_{\theta}^{1}(\vX) \doteq f_{\theta}^{\emb}(\vX), \\ 
+    &\vZ_{\theta}^{\ell + 1}(\vX) \doteq f_{\theta}^{\ell}(\vZ_{\theta}^{\ell}(\vX)), \quad \forall \ell \in \{1, \dots, L\}, \\
+    &\hat{\vy}_{\theta^{\head}}(\vX) \doteq h_{\theta}(\vZ_{\theta}^{L+1}(\vX)).
+\end{align}
+Atunci, putem defini pierderea pe acest singur termen prin 
+\begin{equation}
+    \cL(\theta) \doteq \sfL(\vy, \hat{\vy}_{\theta}(\vX)),
+\end{equation}
+unde \(\sfL\) este o funcție diferențiabilă a celui de-al doilea argument. Atunci AD în mod invers ne instruiește să calculăm derivatele în ordinea \(\theta^{\head}, \theta^{L}, \dots, \theta^{1}, \theta^{\emb}\).
+
+Pentru a efectua acest calcul, să facem câteva modificări la notație. 
+\begin{itemize}
+    \item Întâi, să schimbăm notația pentru a sublinia structura de dependență dintre variabile. Anume, 
+    \begin{align}
+        &\vZ^{1} \doteq f^{\emb}(\vX, \theta^{\emb}) \\ 
+        &\vZ^{\ell + 1} \doteq f^{\ell}(\vZ^{\ell}, \theta^{\ell}), \qquad \forall \ell \in \{1, \dots, L\}, \\
+        &\hat{\vy} \doteq h(\vZ^{L+1}, \theta^{\head}), \\ 
+        &\cL \doteq \sfL(\vy, \hat{\vy}).
+    \end{align}
+    \item Apoi, în loc să avem derivata ca \(f^{\prime}\), notăm explicit variabila independentă și scriem derivata ca \(\odv{f}{\theta^{1}}\), de exemplu. Aceasta deoarece există multe variabile în modelul nostru și ne interesează doar una la un moment dat.
+\end{itemize}
+Putem începe prin calcularea diferențialelor corespunzătoare. Întâi, pentru \(\theta^{\head}\) avem
+\begin{align}
+    \odif{\cL}
+    &= \odif{\sfL} \\ 
+    &= \odv{\sfL}{\hat{\vy}}\cdot\odif{\hat{\vy}} \\ 
+    &= \odv{\sfL}{\hat{\vy}}\cdot\odif{{(h(\vZ^{L + 1}, \theta^{\head}))}} \\ 
+    &= \odv{\sfL}{\hat{\vy}}\bs{\odv{h}{\vZ^{L + 1}}\cdot\odif{\vZ}^{L + 1} + \odv{h}{\theta^{\head}}\cdot\odif{\theta}^{\head}}.
+\end{align}
+Acum, deoarece \(\vZ^{L + 1}\) nu depinde de \(\theta^{\head}\), avem \(\odif{\vZ}^{L + 1} = 0\), așadar în final (folosind faptul că gradientul este transpusa derivatei pentru o funcție \(\sfL\) al cărei codomeniu este \(\R\)):
+\begin{align}
+    \odif{\cL} 
+    &= \odv{\sfL}{\hat{\vy}}\cdot\odv{h}{\theta^{\head}}\cdot\odif{\theta}^{\head} \\ 
+    &= [\nabla_{\hat{\vy}}\sfL]^{\top}\odv{h}{\theta^{\head}}\cdot\odif{\theta}^{\head} \\ 
+    &= \ip*{\nabla_{\hat{\vy}}\sfL}{\odv{h}{\theta^{\head}}\cdot\odif{\theta}^{\head}} \\
+    &= \ip*{\bp{\odv{h}{\theta^{\head}}}^{*}\nabla_{\hat{\vy}}\sfL}{\odif{\theta}^{\head}} \\ 
+    &= \ip{\nabla_{\theta^{\head}}\cL}{\odif{\theta}^{\head}}.
+\end{align}
+Așadar, pentru a calcula \(\nabla_{\theta^{\head}}\cL\), calculăm gradientul \(\nabla_{\hat{\vy}}\sfL\) și \textit{adjuncta}\footnote{Adjuncta este ca o transpusă generalizată pentru transformări liniare mai generale. În particular, pentru o pereche dată de spații cu produs scalar și o transformare liniară \(T\) între aceste spații, adjuncta \(T^{*}\) este definită prin identitatea \(\ip{T\vx}{\vy} = \ip{\vx}{T^{*}\vy}\). În dimensiuni finite (adică toate cazurile relevante pentru această carte) adjuncta există și este unică.} a derivatei \(\odv{h}{\theta^{\head}}\) și înmulțim (adică aplicăm transformarea liniară adjunctă gradientului). În practică, ambele derivate pot fi calculate manual, dar multe framework-uri de calcul moderne pot \textit{automat} defini derivatele (și/sau adjunctele lor) dat fiind codul pentru ``trecerea înainte'', adică calculul funcției de pierdere. Deși extinderea acestei definiții automate de derivate la cât mai multe funcții posibile este o zonă de cercetare activă, resursa \cite{bright2025matrix} descrie o abordare de bază pentru a face acest lucru în detaliu. Apropo, backpropagarea se mai numește și \textit{metoda adjunctă} din acest motiv --- adică că folosim derivate adjuncte pentru a calcula gradientul.
+
+
+Acum să calculăm diferențialele în raport cu un \(\theta^{\ell}\):
+\begin{align}
+    \odif{\cL}
+    &= \odv{\cL}{\vZ^{\ell + 1}}\cdot \odif{\vZ^{\ell + 1}} \\ 
+    &= \odv{\cL}{\vZ^{\ell + 1}}\cdot \odif{{(f^{\ell}(\vZ^{\ell}, \theta^{\ell}))}} \\
+    &= \odv{\cL}{\vZ^{\ell + 1}}\bs{\odv{f^{\ell}}{\vZ^{\ell}}\cdot\odif{\vZ}^{\ell} + \odv{f^{\ell}}{\theta^{\ell}}\cdot\odif{\theta}^{\ell}} \\
+    &= \odv{\cL}{\vZ^{\ell + 1}}\cdot \odv{f^{\ell}}{\theta^{\ell}}\cdot\odif{\theta}^{\ell} \qquad \text{(deoarece~\(\vZ^{\ell}\) nu este funcție de \(\theta^{\ell}\) deci \(\odif{\vZ}^{\ell} = 0\))} \\
+    &= [\nabla_{\vZ^{\ell + 1}}\cL]^{\top}\odv{f^{\ell}}{\theta^{\ell}}\cdot\odif{\theta}^{\ell} \\ 
+    &= \ip*{\nabla_{\vZ^{\ell + 1}}\cL}{\odv{f^{\ell}}{\theta^{\ell}}\cdot\odif{\theta}^{\ell}} \\
+    &= \ip*{\bp{\odv{f^{\ell}}{\theta^{\ell}}}^{*}\nabla_{\vZ^{\ell + 1}}\cL}{\odif{\theta}^{\ell}} \\ 
+    &= \ip{\nabla_{\theta^{\ell}}\cL}{\odif{\theta}^{\ell}}.
+\end{align}
+Așadar, pentru a calcula \(\nabla_{\theta^{\ell}}\cL\) calculăm \(\nabla_{\vZ^{\ell + 1}}\cL\) apoi aplicăm derivata adjunctă \(\bp{\odv{f^{\ell}}{\theta^{\ell}}}^{*}\) la aceasta. Deoarece \(\nabla_{\theta^{\ell}}\cL\) depinde de \(\nabla_{\vZ^{\ell + 1}}\cL\), vrem de asemenea să putem calcula gradienții în raport cu \(\vZ^{\ell}\). Aceștia pot fi calculați exact în același mod:
+\begin{align}
+    \odif{\cL}
+    &= \odv{\cL}{\vZ^{\ell + 1}}\cdot \odif{\vZ^{\ell + 1}} \\ 
+    &= \odv{\cL}{\vZ^{\ell + 1}}\cdot\odif{{(f^{\ell}(\vZ^{\ell}, \theta^{\ell}))}} \\
+    &= \odv{\cL}{\vZ^{\ell + 1}}\bs{\odv{f^{\ell}}{\vZ^{\ell}}\cdot\odif{\vZ}^{\ell} + \odv{f^{\ell}}{\theta^{\ell}}\cdot\odif{\theta}^{\ell}} \\
+    &= \odv{\cL}{\vZ^{\ell + 1}}\cdot\odv{f^{\ell}}{\vZ^{\ell}}\cdot\odif{\vZ}^{\ell} \qquad \text{(deoarece~~\(\theta^{\ell}\) nu este funcție de \(\vZ^{\ell}\) deci \(\odif{\theta}^{\ell} = 0\) de această dată)} \\ 
+    &= \ip*{\bp{\odv{f^{\ell}}{\vZ^{\ell}}}^{*}\nabla_{\vZ^{\ell + 1}}\cL}{\odif{\vZ}^{\ell}} \qquad \text{(aceeași logică)} \\ 
+    &= \ip{\nabla_{\vZ^{\ell}}\cL}{\odif{\vZ}^{\ell}}.
+\end{align}
+Așadar, pentru a calcula \(\nabla_{\vZ^{\ell}}\cL\) calculăm \(\nabla_{\vZ^{\ell + 1}}\cL\) apoi aplicăm derivata adjunctă \(\bp{\odv{f^{\ell}}{\vZ^{\ell}}}^{*}\) la aceasta. Deci avem o recursiță pentru a calcula \(\nabla_{\vZ^{\ell}}\cL\) pentru toți \(\ell\), cu cazul de bază \(\nabla_{\vZ^{L + 1}}\cL\), care este dat de 
+\begin{align}
+    \odif{\cL}
+    &= \odif{\sfL} \\
+    &= \odv{\sfL}{\hat{\vy}}\cdot\odif{\hat{\vy}} \\
+    &= \odv{\sfL}{\hat{\vy}}\cdot\odif{{h(\vZ^{L + 1}, \theta^{\head})}} \\ 
+    &= \odv{\sfL}{\hat{\vy}}\bs{\odv{h}{\vZ^{L + 1}}\cdot\odif{\vZ}^{L + 1} + \odv{h}{\theta^{\head}}\cdot\odif{\theta}^{\head}} \\ 
+    &= \odv{\sfL}{\hat{\vy}}\cdot \odv{h}{\vZ^{L + 1}}\cdot\odif{\vZ}^{L + 1} \\ 
+    &= \ip*{\bp{\odv{h}{\vZ^{L + 1}}}^{*}\nabla_{\hat{\vy}}\sfL}{\odif{\vZ}^{L + 1}} \\ 
+    &= \ip{\nabla_{\vZ^{L + 1}}\cL}{\odif{\vZ}^{L + 1}}.
+\end{align}
+Așadar avem recursia:
+\begin{align}
+    \nabla_{\vZ^{L + 1}}\cL 
+    &= \bp{\odv{h}{\vZ^{L + 1}}}^{*}\nabla_{\hat{\vy}}\sfL \\ 
+    \nabla_{\vZ^{L}}\cL 
+    &= \bp{\odv{f^{L}}{\vZ^{L}}}^{*}\nabla_{\vZ^{L + 1}}\cL \\ 
+    \nabla_{\theta^{L}}\cL
+    &= \bp{\odv{f^{L}}{\theta^{L}}}^{*}\nabla_{\vZ^{L + 1}}\cL \\
+    \vdots &  \\ 
+    \nabla_{\vZ^{1}}\cL 
+    &= \bp{\odv{f^{1}}{\vZ^{1}}}^{*}\nabla_{\vZ^{2}}\cL \\ 
+    \nabla_{\theta^{1}}\cL 
+    &= \bp{\odv{f^{1}}{\theta^{1}}}^{*}\nabla_{\vZ^{2}}\cL \\ 
+    \nabla_{\theta^{\emb}}\cL 
+    &= \bp{\odv{f^{\emb}}{\theta^{\emb}}}^{*}\nabla_{\vZ^{1}}\cL.
+\end{align}
+
+Aceasta ne dă un algoritm eficient din punct de vedere computațional pentru a găsi toți gradienții din întreaga rețea.
+
+Vom încheia această secțiune calculând derivata adjunctă pentru un strat simplu.
+\begin{example}
+    Considerăm stratul ``liniar'' (afin) \(f^{\ell}\)
+    \begin{equation}
+        f^{\ell}(\vZ, \vW^{\ell}, \vb^{\ell}) \doteq \vW^{\ell}\vZ + \vb^{\ell}\vone^{\top} = \mat{\vW^{\ell} & \vb^{\ell}}.
+    \end{equation}
+    Putem calcula diferențialul în raport cu ambii parametri ca
+    \begin{align}
+        \odif{f}^{\ell}
+        &= [(\vW^{\ell} + \odif{\vW}^{\ell})\vZ + (\vb^{\ell} + \odif{\vb}^{\ell})\vone^{\top}] - [\vW^{\ell}\vZ + \vb^{\ell}] \\ 
+        &= (\odif{\vW}^{\ell})\vZ + (\odif{\vb}^{\ell})\vone^{\top}.
+    \end{align}
+    Așadar derivata acestei transformări este 
+    \begin{equation}
+        \odv{f^{\ell}}{(\vW^{\ell}, \vb^{\ell})}[\odif{\vW}^{\ell}, \odif{\vb}^{\ell}] = (\odif{\vW}^{\ell})\vZ + (\odif{\vb}^{\ell})\vone^{\top},
+    \end{equation}
+    anume, reprezentând următoarea transformare liniară de la \(\R^{m \times d} \times \R^{m}\) la \(\R^{m \times n}\):
+    \begin{equation}
+        T[\vA, \vu] = \vA\vZ + \vu\vone^{\top}.
+    \end{equation}
+    Calculăm adjuncta \(T^{*} \colon \R^{m \times n} \to \R^{m \times d} \times \R^{m}\) în raport cu produsul scalar sumă-peste-coordonate (Frobenius) prin următoarea procedură:
+    \begin{align}
+        \ip{T[\vA, \vu]}{\vB}_{\R^{m \times n}} 
+        &= \tr((\vA\vZ + \vu\vone^{\top})\vB^{\top}) \\
+        &= \tr(\vA\vZ\vB^{\top} + \vu\vone^{\top}\vB^{\top}) \\
+        &= \tr(\vA\vZ\vB^{\top}) + \tr(\vu\vone^{\top}\vB^{\top}) \\
+        &= \tr(\vB\vZ^{\top}\vA^{\top}) + \tr(\vone^{\top}\vB^{\top}\vu) \\
+        &= \ip{\vB\vZ^{\top}}{\vA}_{\R^{m \times d}} + \ip{\vB\vone}{\vu}_{\R^{m}} \\
+        &= \ip{\vB(\vZ^{\top}, \vone)}{(\vA, \vu)}_{\R^{m \times d} \times \R^{m}}
+    \end{align}
+    Deci \(T^{*}\vB = \vB(\vZ^{\top}, \vone)\).
+\end{example}
+
+Notăm că, ca o aplicare simplă a regulii lanțului, atât backpropagarea cât și diferențierea automată funcționează peste ``grafuri de calcul'' generale, adică compoziții de funcții (simple). Dăm toate exemplele ca straturi de rețele neuronale deoarece acesta este exemplul cel mai comun în practică.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+        
+        
+        
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+\section{Teoria Jocurilor și Optimizare Minimax} \label{sec:minimax}\label{sec:game_theory}
+
+În anumite cazuri, cum ar fi în \Cref{ch:closed-loop}, o problemă de învățare nu poate fi redusă la o singură problemă de optimizare, ci mai degrabă reprezintă multiple componente potențial opuse ale sistemului care încearcă fiecare să-și minimizeze propriul obiectiv. Exemple ale acestei paradigme includ învățarea distribuțiilor prin rețele generative adversariale (GAN) și transcripția în buclă închisă (CTRL). Vom nota un astfel de sistem ca un \textit{joc cu doi jucători}, unde avem doi ``jucători'' (adică componente) numiți Jucătorul 1 și Jucătorul 2 care încearcă fiecare să-și minimizeze obiectivele \(\cL^{1}\) și respectiv \(\cL^{2}\). Jucătorul 1 alege parametrii \(\theta \in \Theta\) și Jucătorul 2 alege parametrii \(\eta \in \Eta\). În această carte considerăm cazul special al \textit{jocurilor cu sumă zero}, adică definând un obiectiv comun \(\cL\) astfel încât \(\cL = -\cL^{1} = \cL^{2}\).
+
+Primul nostru exemplu, foarte preliminar, este următorul. Să presupunem că există funcțiile \(u(\theta)\) și \(v(\eta)\) astfel încât 
+\begin{equation}
+    \cL(\theta, \eta) = -u(\theta) + v(\eta).
+\end{equation}
+Atunci obiectivele ambilor jucători sunt independente de celălalt jucător, și jucătorii ar trebui să încerce să-și atingă optimele respective:
+\begin{equation}
+    \theta^{\star} \in \argmin_{\theta \in \Theta}u(\theta), \qquad \eta^{\star} \in \argmin_{\eta \in \Eta}v(\eta).
+\end{equation}
+Perechea \((\theta^{\star}, \eta^{\star})\) este un caz special simplu de \textit{echilibru}: o situație în care niciunul dintre jucători nu va vrea să se miște, dacă ar avea ocazia, deoarece mutarea va înrăutăți propria situație. Totuși, nu toate jocurile sunt atât de triviale; multe au obiective și structuri de informații mai complicate.
+
+În această carte, formalismul teorie-jocurilor relevant este un joc Stackelberg (numit și joc secvențial). În acest formalism, un jucător (fără pierdere de generalitate Jucătorul 1, descris și ca \textit{lider}) își alege parametrii înaintea celuilalt (adică Jucătorul 2, descris ca \textit{urmăritor}), iar urmăritorul poate folosi cunoștința completă a alegerii liderului pentru a-și face propria alegere. Noțiunea corectă de echilibru pentru un joc Stackelberg este un \textit{echilibru Stackelberg}. Pentru a explica acest echilibru, notăm că deoarece Jucătorul 2 (adică urmăritorul) poate alege \(\eta\) reactiv la alegerea \(\theta_{1}\) făcută de Jucătorul 1 (adică liderul), Jucătorul 2 ar alege desigur \(\eta\) care minimizează \(\cL(\theta_{1}, \cdot)\). Dar desigur un Jucător 1 rațional și-ar da seama de acest lucru, și așa ar alege un \(\theta_{1}\) astfel încât cel mai rău caz \(\eta\) ales de Jucătorul 2 conform acestei reguli să nu fie prea rău. Mai formal, fie \(\cS(\theta) \doteq \argmin_{\eta \in \Eta}\cL(\theta, \eta)\) mulțimea de \(\eta\) care minimizează \(\cL(\theta, \eta)\), adică mulțimea tuturor \(\eta\) pe care Jucătorul 2 este probabil să le joace dat fiind că Jucătorul 1 a jucat \(\theta\). Atunci \((\theta^{\star}, \eta^{\star})\) este un echilibru Stackelberg dacă 
+\begin{equation}
+    \theta^{\star} \in \argmax_{\theta \in \Theta}\min_{\eta \in \cS(\theta)}\cL(\theta, \eta), \qquad \eta^{\star} \in \argmin_{\eta  \in \Eta}\cL(\theta^{\star}, \eta).
+\end{equation}
+De fapt (demonstrație ca exercițiu), se poate arăta că în contextul jocurilor Stackelberg cu doi jucători și sumă zero, \((\theta^{\star}, \eta^{\star})\) este un echilibru Stackelberg dacă și numai dacă
+\begin{equation}
+    \theta^{\star} \in \argmax_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta), \qquad \eta^{\star} \in \argmin_{\eta  \in \Eta}\cL(\theta^{\star}, \eta),
+\end{equation}
+(notăm că notația \(\cS(\theta)\) nu este folosită nici necesară). 
+\begin{proof} %
+    Notăm că 
+    \begin{equation}
+        \cS(\theta) = \argmin_{\eta \in \Eta}\cL(\theta, \eta),
+    \end{equation}
+    deci avem 
+    \begin{equation}
+        \min_{\eta \in \cS(\theta)}\cL(\theta, \eta) = \min_{\eta \in \argmin_{\eta^{\prime} \in \Eta}\cL(\theta, \eta^{\prime})}\cL(\theta, \eta) = \min_{\eta \in \Eta}\cL(\theta, \eta).
+    \end{equation}
+\end{proof}
+
+În restul secțiunii, vom discuta pe scurt câteva abordări algoritmice pentru a învăța echilibre Stackelberg. Intuiția pe care ar trebui să o aveți este că învățarea unui echilibru este ca și cum lăsați diferitele părți ale sistemului să descopere automat compromisurile dintre diferitele obiective pe care vor să le optimizeze. 
+
+Încheiem această secțiune cu o precizare: în jocurile cu doi jucători și sumă zero, dacă avem
+\begin{equation}
+    \max_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta) = \min_{\eta \in \Eta}\max_{\theta \in \Theta}\cL(\theta, \eta)
+\end{equation}
+atunci fiecare echilibru Stackelberg este un punct de șa,\footnote{Numit celebru \textit{echilibru Nash}.} adică 
+\begin{equation}
+    \theta^{\star} \in \argmax_{\theta \in \Theta}\cL(\theta, \eta^{\star}), \qquad \eta^{\star} \in \argmin_{\eta \in \Eta}\cL(\theta^{\star}, \eta),
+\end{equation}
+\textit{și viceversa}, și mai mult, fiecare echilibru Stackelberg are (aceeași) valoare obiectiv \[\max_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta).\]
+\begin{proof} %
+    Să presupunem că într-adevăr 
+    \begin{equation}
+        \max_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta) = \min_{\eta \in \Eta}\max_{\theta  \in \Theta}\cL(\theta, \eta).
+    \end{equation}
+
+    Mai întâi să presupunem că \((\theta^{\star}, \eta^{\star})\) este un punct de șa. Vom arăta că este un echilibru Stackelberg. Prin definiție avem 
+    \begin{equation}
+        \min_{\eta \in \Eta}\cL(\theta^{\star}, \eta) = \cL(\theta^{\star}, \eta^{\star}) = \max_{\theta \in \Theta}\cL(\theta, \eta^{\star}).
+    \end{equation}
+    Atunci pentru orice \(\theta\) și \(\eta\) avem 
+    \begin{equation}
+        \min_{\eta \in \Eta}\cL(\theta, \eta) \leq \cL(\theta, \eta^{\star}) \leq \cL(\theta^{\star}, \eta^{\star}).
+    \end{equation}
+    Prin urmare
+    \begin{equation}
+        \max_{\theta \in \Theta}\cL(\theta, \eta) \leq \cL(\theta^{\star}, \eta^{\star}).
+    \end{equation}
+    Complet simetric, 
+    \begin{equation}
+        \cL(\theta^{\star}, \eta^{\star}) \leq \cL(\theta^{\star}, \eta) \leq \max_{\theta \in \Theta}\cL(\theta^{\star}, \eta) \implies \cL(\theta^{\star}, \eta^{\star}) \leq \min_{\eta \in \Eta}\max_{\theta \in \Theta}\cL(\theta, \eta).
+    \end{equation}
+    Prin urmare, deoarece \(\max\min = \min\max\) avem 
+    \begin{equation}\label{eq:nash_equilibrium_minmax_maxmin}
+        \max_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta) = \cL(\theta^{\star}, \eta^{\star}) = \min_{\eta \in \Eta}\max_{\theta \in \Theta}\cL(\theta, \eta).
+    \end{equation}
+    În particular, avem
+    \begin{equation}
+        \theta^{\star} \in \argmax_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta).
+    \end{equation}
+    Din condiția punctului de șa avem \(\eta^{\star} \in \argmin_{\eta \in \Eta}\cL(\theta^{\star}, \eta)\). Deci \((\theta^{\star}, \eta^{\star})\) este un echilibru Stackelberg. Mai mult, am demonstrat de asemenea că toate punctele de șa respectă \eqref{eq:nash_equilibrium_minmax_maxmin}.
+
+    Acum fie \((\theta^{\star}, \eta^{\star})\) un echilibru Stackelberg. Afirmăm că este un punct de șa, ceea ce completează demonstrația. Prin definiția echilibrului minimax,
+    \begin{equation}
+        \max_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta) = \cL(\theta^{\star}, \eta^{\star}).
+    \end{equation}
+    Atunci prin ipoteza \(\min\max = \max\min\) avem
+    \begin{equation}
+        \max_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta) = \cL(\theta^{\star}, \eta^{\star}) = \min_{\eta \in \Eta}\max_{\theta \in \Theta}\cL(\theta, \eta).
+    \end{equation}
+    Aceasta demonstrează că toate echilibrele minimax au valoarea obiectiv dorită \(\cL(\theta^{\star}, \eta^{\star})\). Acum vrem să arătăm că
+    \begin{equation}
+        \theta^{\star} \in \argmax_{\theta \in \Theta}\cL(\theta, \eta^{\star}), \qquad \eta^{\star} \in \argmin_{\eta \in \Eta}\cL(\theta^{\star}, \eta).
+    \end{equation}
+    Într-adevăr, ultima aserțiune este valabilă prin definiția echilibrului minimax, deci doar prima trebuie demonstrată. Anume, vom arăta că
+    \begin{equation}
+        \max_{\theta \in \Theta}\cL(\theta, \eta^{\star}) = \cL(\theta^{\star}, \eta^{\star}).
+    \end{equation}
+    Pentru a arăta aceasta notăm că prin definiția lui \(\max\)
+    \begin{equation}
+        \cL(\theta^{\star}, \eta^{\star}) \leq \max_{\theta \in \Theta}\cL(\theta, \eta^{\star}),
+    \end{equation}
+    între timp avem \(\min_{\eta \in \Eta}\cL(\theta, \eta) \leq \cL(\theta, \eta^{\star})\) deci
+    \begin{equation}
+        \cL(\theta^{\star}, \eta^{\star}) = \max_{\theta \in \Theta}\min_{\eta \in \Eta}\cL(\theta, \eta) \leq \max_{\theta \in \Theta}\cL(\theta, \eta^{\star}).
+    \end{equation}
+    Prin urmare avem 
+    \begin{equation}
+        \cL(\theta^{\star}, \eta^{\star}) = \max_{\theta \in \Theta}\cL(\theta, \eta^{\star}),
+    \end{equation}
+    și demonstrația este completă.
+\end{proof}
+Condițiile în care egalitatea \(\min\max = \max\min\) este valabilă sunt date de așa-numitele \textit{teoreme minimax}; cea mai celebră dintre acestea este o teoremă a lui von Neumann. Totuși, în cazurile la care ne gândim, această proprietate de obicei nu este valabilă.
+
+\subsection{Învățarea Echilibrelor Stackelberg}
+
+Cum putem învăța echilibre Stackelberg prin GDA? În general acest lucru este clar imposibil, deoarece învățarea echilibrelor Stackelberg prin GDA este evident cel puțin la fel de dificilă ca și calcularea unui minimizator global al unei funcții de pierdere (să zicem prin setarea obiectivului comun \(\cL(\theta, \eta)\) să fie doar o funcție de \(\eta\)). Ca atare, putem obține două tipuri de garanții de convergență:
+\begin{itemize}
+    \item Când \(\cL\) este (puternic) concavă în primul argument \(\theta\) și (puternic) convexă în al doilea argument \(\eta\) (precum și având gradienți Lipschitz în ambele argumente), putem obține convergență exponențial rapidă către un echilibru Stackelberg.
+    \item Când \(\cL\) nu este concavă sau convexă în niciunul dintre argumente, putem obține \textit{garanții de convergență locală}: anume, dacă inițializăm valorile parametrilor aproape de un echilibru (local) Stackelberg și geometria de optimizare este bună atunci putem învăța acel echilibru eficient. 
+\end{itemize}
+
+Prima situație este exact analogă cu cazul optimizării cu un singur jucător, unde am demonstrat că coborarea gradientului converge exponențial rapid pentru obiective puternic convexe care au gradient Lipschitz. A doua situație este de asemenea analogă cu cazul optimizării cu un singur jucător, deși nu am abordat-o în profunzime din cauza dificultății tehnice; într-adevăr există garanții de convergență locală pentru obiective neconvexe care au geometrie local bună.
+
+Algoritmul în aceste două cazuri este același algoritm, numit Coborare-Urcare prin Gradient (GDA). Pentru a motiva GDA, să presupunem că încercăm să învățăm \(\theta^{\star}\). Am putea face urcare prin gradient pe funcția \(\theta \mapsto \min_{\eta \in \Eta}\cL(\theta, \eta)\). Dar atunci ar trebui să luăm derivata în \(\theta\) a acestei funcții. Pentru a vedea cum să facem aceasta, să presupunem că \(\cL\) este puternic convexă în \(\eta\) astfel încât există un singur minimizator \(\eta^{\star}(\theta)\) al lui \(\cL(\theta, \cdot)\). Atunci, \textit{teorema lui Danskin} spune că
+\begin{equation}
+    \nabla_{\theta}\bs{\min_{\eta \in \Eta}\cL(\theta, \eta)} = \nabla_{\theta}\cL(\theta, \texttt{stop\_grad}(\eta^{\star}(\theta))),
+\end{equation}
+unde gradientul este \textit{doar în raport cu primul argument} (adică nu o derivată totală care ar necesita calcularea jacobianului lui \(\eta^{\star}(\theta)\) în raport cu \(\theta\)), indicat de operatorul stop-gradient.\footnote{În cazul în care \(\cL\) nu este puternic convexă în \(\eta\) ci doar convexă, teorema lui Danskin poate fi enunțată în termeni de subdiferențiale. Dacă \(\cL\) nu este deloc convexă în \(\eta\), atunci această derivată ar putea să nu fie bine definită, dar se pot obține (local) garanții de convergență pentru algoritmul rezultat oricum. Prin urmare folosim teorema lui Danskin ca motivație și nu ca justificare pentru algoritmii noștri. Teoremele lui Danskin pot fi generalizate în circumstanțe mai relaxate prin așa-numitele \textit{teoreme de anvelopă}.}
+Pentru a lua derivata în \(\theta\), trebuie să configurăm un \textit{proces secundar} pentru a optimiza de asemenea \(\eta\) pentru a obține o aproximare pentru \(\eta^{\star}(\theta)\). Putem face aceasta prin următorul șablon algoritmic:
+\begin{align}
+    &\eta_{k + 1} = \eta_{k + 1}^{T + 1}; \qquad \eta_{k + 1}^{t + 1} = \eta_{k + 1}^{t} - h \nabla_{\eta} \cL(\theta_{k}, \eta_{k + 1}^{t}), \quad \forall t \in [T]; \qquad \eta_{k + 1}^{1} = \eta_{k} \\
+    &\theta_{k + 1} = \theta_{k} + h \nabla_{\theta}\cL(\theta_{k}, \eta_{k + 1}).
+\end{align}
+Aceasta înseamnă că luăm \(T\) pași de coborare prin gradient pentru a actualiza \(\eta_{k}\) (sperăm către minimizatorul lui \(\cL(\theta_{k}, \cdot)\)), și apoi luăm un pas de urcare prin gradient pentru a actualiza \(\theta_{k}\). Ca bonus, pe lângă estimarea \(\theta_{K} \approx \argmax_{\theta}\min_{\eta}\cL(\theta, \eta)\), învățăm de asemenea un \(\eta_{K} \approx \argmin_{\eta}\cL(\theta_{K}, \eta)\) --- acesta este un echilibru Stackelberg aproximativ.
+
+Această metodă adesea nu este folosită în practică, deoarece necesită \(T + 1\) iterații totale de coborare prin gradient pentru a actualiza \(\theta\) o dată. În schimb, folosim așa-numita \textit{Coborare-Urcare prin Gradient (simultană)} (GDA)
+\begin{align}
+    \theta_{k + 1}
+    &= \theta_{k} + h\nabla_{\theta}\cL(\theta_{k}, \eta_{k}) \\ 
+    \eta_{k + 1}
+    &= \eta_{k} - Th\nabla_{\eta}\cL(\theta_{k}, \eta_{k}),
+\end{align}
+care poate fi implementată eficient prin intermediul unui singur pas de gradient pe \((\theta, \eta)\). Ideea crucială aici este, pentru a face metoda noastră apropiată de iterația ineficientă de mai sus, folosim o actualizare \(\eta\) care este de \(T\) ori mai rapidă decât actualizarea \(\theta\) (acestea pot fi văzute ca aproape aceleași prin luarea unei linearizări a dinamicii).
+
+Este crucial să alegem \(T\) în mod sensibil. Cum putem face asta? În continuare, discutăm două configurații ale lui \(T\) care conduc la convergența GDA către un echilibru Stackelberg sub diferite ipoteze.
+
+\subsubsection{Convergența GDA cu O Singură Scară de Timp către Echilibrul Stackelberg}
+
+Dacă \(T = 1\) (adică numită \textit{o singură scară de timp} deoarece ambele actualizări \(\theta\) și \(\eta\) sunt de aceeași scară), atunci algoritmul GDA devine 
+\begin{equation}
+    \theta_{k + 1} = \theta_{k} + h\nabla_{\theta}\cL(\theta_{k}, \eta_{k}), \qquad \eta_{k + 1} = \eta_{k} - h\nabla_{\eta}\cL(\theta_{k}, \eta_{k}).
+\end{equation}
+Dacă \(\cL\) are gradienți Lipschitz în \(\theta\) și \(\eta\), și este puternic concavă în \(\theta\) și puternic convexă în \(\eta\), și este coercivă (adică,\(\lim_{\norm{\theta}_{2}, \norm{\eta}_{2} \to \infty}\cL(\theta, \eta) = \infty\)), atunci toate punctele de șa sunt echilibre Stackelberg și viceversa. Lucrarea \cite{zamani2024convergence} arată că GDA (din nou, cu \(T = 1\)) cu o dimensiune a pasului \(h\) suficient de mică converge către un punct de șa (deci echilibru Stackelberg) exponențial rapid dacă există unul, analog cu coborarea gradientului pentru funcții puternic convexe cu gradient Lipschitz.\footnote{Nu furnizăm dimensiunea pasului sau baza exponențială deoarece sunt funcții complicate ale convexitatii/concavității puternice/constantei Lipschitz a gradientului. Desigur, lucrarea \cite{zamani2024convergence} furnizează valorile parametrilor preciși.} Din cunoștințele noastre, acest tip de rezultate constituie singura justificare riguroasă cunoscută pentru GDA cu o singură scară de timp.
+
+\subsubsection{Convergența Locală a GDA cu Două Scari de Timp către Echilibrul Stackelberg}
+
+Convexitatea/concavitatea puternică este o proprietate \textit{globală}, și niciunul dintre jocurile pe care le analizăm în această carte nu are obiective care sunt global puternic concave/puternic convexe. În acest caz, cel mai bun lucru pe care îl putem spera este convergența \textit{locală} către echilibre Stackelberg: dacă parametrii sunt inițializați aproape de un echilibru Stackelberg, atunci GDA poate converge către el, dată fiind o dimensiune a pasului \(h\) și o scară de timp \(T\) corespunzătoare. 
+
+De fapt, rezultatele noastre sunt valabile și pentru o versiune a echilibrului Stackelberg \textit{local} numit \textit{echilibru Stackelberg diferențial}, care a fost introdus în \cite{fiez2019convergence} (deși folosim definiția precisă din \cite{li2022convergence}), și pe care îl definim după cum urmează. Un punct \((\theta^{\star}, \eta^{\star})\) este un echilibru Stackelberg diferențial dacă:
+\begin{itemize}
+    \item \(\nabla_{\eta}\cL(\theta^{\star}, \eta^{\star}) = \vzero\);
+    \item \(\nabla_{\eta}^{2}\cL(\theta^{\star}, \eta^{\star})\) este simetric pozitiv definit;
+    \item \(\nabla_{\theta}\cL(\theta^{\star}, \eta^{\star}) = \vzero\);
+    \item \((\nabla_{\theta}^{2}\cL + [\odv*{\nabla_{\eta}\cL}{\theta}][\nabla_{\eta}^{2}\cL]^{-1}[\odv*{\nabla_{\theta}\cL}{\eta}])(\theta^{\star}, \eta^{\star})\) este simetric negativ definit.
+\end{itemize}
+Notăm că ultima condiție cere ca hessiana (totală)
+\begin{equation}
+    \nabla^{2} \cL(\theta, \eta) = \mat{\nabla_{\theta}^{2}\cL(\theta, \eta) & \odv*{\nabla_{\theta}^{2}\cL(\theta, \eta)}{\eta} \\ \odv*{\nabla_{\eta\theta}^{2}\cL(\theta, \eta)}{\theta} & \nabla_{\eta}^{2}\cL(\theta)}
+\end{equation}
+sau, echivalent, complementul său Schur să fie negativ definit. Dacă ne uităm la calculul lui \(\nabla_{\theta}[\min_{\eta \in \Eta}\cL(\theta, \eta)]\) furnizat de teorema lui Danskin, ultimele două criterii sunt de fapt constrângeri asupra gradientului și hessianei funcției \(\theta \mapsto \min_{\eta \in \Eta}\cL(\theta, \eta)\), asigurând că gradientul este \(0\) și hessiana este negativ semidefinită. Această intuiție ne spune că putem aștepta ca fiecare echilibru Stackelberg să fie un echilibru Stackelberg diferențial; \cite{fiez2020implicit} confirmă acest lucru riguros (până la unele condiții tehnice).
+
+Analog cu noțiunea de optim local strict în optimizarea cu un singur jucător (unde cerem ca \(\nabla^{2}\cL(\theta^{\star})\) să fie pozitiv semidefinită), definiția echilibrului Stackelberg diferențial \textit{implică că \(\cL(\theta, \cdot)\) este local (strict) convexă într-o vecinătate a echilibrului, și că \(\min_{\eta \in \Eta}\cL(\cdot, \eta)\) este local (strict) concavă în aceeași regiune}.
+
+În acest context, prezentăm rezultatul din \cite{li2022convergence}. Fie \((\theta^{\star}, \eta^{\star})\) un echilibru Stackelberg diferențial. Să presupunem că \(\cL\) are gradienți Lipschitz, adică,
+\begin{equation}
+    \max\rc{\norm{\nabla_{\theta}^{2}\cL(\theta^{\star}, \eta^{\star})}_{2}, \norm*{\nabla_{\eta}^{2}\cL(\theta^{\star}, \eta^{\star})}_{2},  \norm*{\odv*{\nabla_{\theta}\cL(\theta^{\star}, \eta^{\star})}{\eta}}_{2}} \leq \beta.
+\end{equation}
+Mai departe definiți parametrii de convexitate/concavitate puternică locală ai lui \(\cL(\theta, \cdot)\) și respectiv \(\min_{\eta}\cL(\cdot, \eta)\) ca
+\begin{equation}
+    \mu_{\eta} = \lambda_{\min}(\nabla_{\eta}^{2}\cL(\theta^{\star}, \eta^{\star})), \qquad \mu_{\theta} = \min\rc{\beta, -\bp{\nabla_{\theta}^{2}\cL + \rs{\odv*{\nabla_{\eta}\cL}{\theta}}\rs{\nabla_{\eta}^{2}\cL}^{-1}\rs{\odv*{\nabla_{\theta}\cL}{\eta}}}(\theta^{\star}, \eta^{\star})}.
+\end{equation}
+Atunci definiți numerele de condiție locale ca 
+\begin{equation}
+    \kappa_{\eta} = L/\mu_{\eta}, \qquad \kappa_{\theta} = L/\mu_{\theta}.
+\end{equation}
+Lucrarea \cite{li2022convergence} spune că dacă luăm dimensiunea pasului \(h = \frac{1}{4\beta T}\) și luăm \(T \geq 2\kappa\), astfel încât algoritmul este 
+\begin{align}
+    \theta_{k + 1}
+    &= \theta_{k} + \frac{1}{4\beta T}\nabla_{\theta} \cL(\theta_{k}, \eta_{k}), \\
+    \eta_{k + 1}
+    &= \eta_{k} - \frac{1}{4\beta}\nabla_{\eta} \cL(\theta_{k}, \eta_{k}),
+\end{align}
+hessiana totală \(\nabla^{2}\cL(\theta^{\star}, \eta^{\star})\) este diagonalizabilă, și inițializăm \((\theta_{0}, \eta_{0})\) suficient de aproape de \((\theta^{\star}, \eta^{\star})\), atunci există constante pozitive \(c_{0}, c_{1} > 0\) astfel încât 
+\begin{equation}
+    \norm{(\theta_{k}, \eta_{k}) - (\theta^{\star}, \eta^{\star})}_{2} \leq c_{0}\bp{1 - \frac{c_{1}}{T\kappa_{\theta}}}^{k}\norm{(\theta_{0}, \eta_{0}) - (\theta^{\star}, \eta^{\star})}_{2},
+\end{equation}
+implicând convergență exponențială către echilibrul Stackelberg diferențial.
+
+\subsection{Considerații Practice la Învățarea Echilibrelor Stackelberg}
+
+În practică, nu știm cum să inițializăm parametrii aproape de un echilibru Stackelberg (diferențial). Din cauza simetriilor din cadrul obiectivului, inclusiv cele induse de supraparametrizarea rețelelor neuronale care sunt antrenate, se poate aștepta (euristic) ca majoritatea inițializărilor să fie aproape de un echilibru Stackelberg. De asemenea, nu știm cum să calculăm dimensiunea pasului \(h\) sau scara de timp \(T\), deoarece depind de proprietățile pierderii \(\cL\) la echilibru. În practică, există câteva abordări comune:
+\begin{itemize}
+    \item Luăm \(T = 1\) (dimensiuni egale ale pașilor), și folosim actualizări pentru \(\theta\) și \(\eta\) care sunt derivate dintr-un optimizator adaptiv la rata de învățare precum Adam (spre deosebire de GD vanila). Aici, \textit{sperăm} (dar nu \textit{știm}) că optimizatorul poate ajusta ratele de învățare pentru a învăța un echilibru bun.
+    \item Luăm \(T\) să fie o constantă precum \(T = 10^{6}\) ceea ce implică că \(\eta\) se echilibrează de \(10^{6}\) ori mai repede decât \(\theta\). Aici puteți folosi de asemenea actualizări de tip Adam, și sperați că rezolvă scara de timp.
+    \item Lăsăm \(T\) să depindă de iterația \(k\), și lăsăm \(T_{k} \to \infty\) pe măsură ce \(k \to \infty\). Acest program a fost studiat (de asemenea în cazul zgomotului) de Borkar în \cite{borkar1997stochastic}.
+\end{itemize}
+De exemplu, puteți folosi aceasta în timp ce antrenați modele de tip CTRL (vezi \Cref{ch:closed-loop}), unde codificatorul este Jucătorul \(1\) și decodificatorul este Jucătorul \(2\). O anumită teorie despre CTRL este dată în \Cref{thm:ctrl_theory}.
+
+\section{Exerciții}
+
+\begin{exercise}
+    Am arătat că pentru o funcție netedă $f$, coborarea gradientului converge liniar către optimul global dacă este puternic convexă. Totuși, în optimizarea neconvexă generală, nu avem convexitate, cu atât mai puțin convexitate puternică. Din fericire, în unele cazuri, $f$ satisface așa-numita inegalitate $\mu$-Polyak-Lojasiewicz (PL), adică există o constantă $\mu > 0$ astfel încât pentru orice $\theta$, 
+    \begin{align*}
+        \frac{1}{2}\|\nabla f(\theta)\|_2^2 \ge \mu\left( f(\theta) - f(\theta^\star) \right),
+    \end{align*}
+    unde $\theta^*$ este un minimizator al lui $f$. 
+    
+    Vă rugăm să arătați că sub inegalitatea PL și presupunerea că $f$ este $\beta$-netedă, coborarea gradientului \eqref{eq:GD} converge liniar către $\theta^*$. 
+\end{exercise}
+
+\begin{exercise}
+    Calculați diferențialul și derivata adjunctă a funcției softmax, definită după cum urmează.
+    \begin{equation}
+        \softmax\rp{\mat{x_{1} \\ \vdots \\ x_{n}}} = \frac{1}{\sum_{i = 1}^{n}e^{x_{i}}}\mat{x_{1} \\ \vdots \\ x_{n}}.
+    \end{equation}
+\end{exercise}
+
+\begin{exercise}
+    Efectuați calculul backpropagării pentru un MLP cu \(L\) straturi, așa cum este definit în \Cref{sub:contrastive_learning_architecture}.
+\end{exercise}
+
+\begin{exercise}
+    Efectuați calculul backpropagării pentru un transformer cu \(L\) straturi, așa cum este definit în \Cref{sub:contrastive_learning_architecture}.
+\end{exercise}
+
+\begin{exercise}
+    Efectuați calculul backpropagării pentru un autocodificator cu \(L\) straturi de codificator și \(L\) straturi de decodificator (fără a specifica neapărat o arhitectură).
+\end{exercise}
+
+
+
+
+
+
+
+
+
+
+
+
+
+\end{document}

--- a/chapters/appendixB/entropy_ro.tex
+++ b/chapters/appendixB/entropy_ro.tex
@@ -1,0 +1,1274 @@
+\providecommand{\toplevelprefix}{../..}
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Entropie, Difuzie, Denoising și Codare cu Pierderi}\label{app:entropy}\label{app:diffusion-denoising}
+
+\begin{quote}
+``{\em Creșterea dezordinii sau entropiei cu timpul este un exemplu a ceea ce se numește o săgeată a timpului, ceva care distinge trecutul de viitor, dând o direcție timpului.}''
+
+$~$\hfill -- O scurtă istorie a timpului, Stephen Hawking
+ \end{quote}
+\vspace{5mm}
+
+În această anexă oferim demonstrații pentru mai multe fapte, menționate în
+\Cref{ch:general-distribution}, care sunt legate de entropia diferențială, cum
+evoluează aceasta sub procese de difuzie și conexiunile sale cu codarea cu pierderi. Vom
+face următoarea presupunere blândă despre variabila aleatoare care reprezintă
+sursa de date, notată \(\vx\).
+
+\begin{assumption}\label{assumption:entropy_x_compact_support}
+    \(\vx\) este suportată pe o mulțime compactă \(\cS \subseteq \R^{D}\) de rază cel mult \(R\), adică \(R \doteq \sup_{\vxi \in \cS}\norm{\vxi}_{2}\).
+\end{assumption}
+
+În particular, deoarece mulțimile compacte în spațiul euclidian sunt mărginite, avem \(R < \infty\). Vom folosi consistent notația \(B_{r}(\vxi) \doteq \{\vu \in \R^{D} \colon \norm{\vxi - \vu}_{2} \leq r\}\) pentru a denota bila euclidiană de rază \(r\) centrată în \(\vxi\). În acest sens, \Cref{assumption:entropy_x_compact_support} are \(\cS \subseteq B_{R}(\vzero)\).
+
+Observați că această presupunere este valabilă pentru (aproape) toate variabilele care ne interesează în practică, deoarece este (adesea) impusă de un pas de normalizare în timpul pre-procesării datelor. 
+
+\section{Entropia Diferențială a Distribuțiilor de Dimensiune Mică}\label{sec:low_dim_entropy}
+
+În această scurtă anexă discutăm entropia diferențială a distribuțiilor de dimensiune mică. Prin definiție, entropia diferențială a unei variabile aleatoare \(\vx\) care nu are o densitate este \(-\infty\); aceasta include toate variabilele aleatoare suportate pe mulțimi de dimensiune mică. Obiectivul acestei secțiuni este să discutăm de ce aceasta este o valoare ``moral corectă''.
+
+În fapt, fie \(\vx\) orice variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support} este valabilă, suportul \(\cS\) al lui \(\vx\) are volum \(0\).\footnote{Formal acest lucru înseamnă că \(\cS\) este măsurabil Borel cu măsură Borel \(0\).} Vom considera cazul în care \(\vx\) este uniform pe \(\cS\).\footnote{Să zicem, în raport cu măsura Hausdorff pe \(\cS\).} Scopul nostru este să calculăm \(h(\vx)\).
+
+În acest caz, \(\vx\) nu ar avea o densitate; în lumea contrafactuală unde nu am ști că \(h(\vx) = -\infty\), nu am putea-o defini direct folosind definiția standard a entropiei diferențiale. În schimb, ca în restul analizei și teoriei informației ar fi rezonabil să considerăm limita entropiilor aproximărilor succesiv mai bune \(\vx_{\eps}\) ale lui \(\vx\) care au densități, adică,
+\begin{equation}
+    h(\vx)\ \text{``=''}\ \lim_{\eps \searrow 0}h(\vx_{\eps}).
+\end{equation}
+
+
+Pentru aceasta, ideea de bază este să luăm o \(\eps\)-îngroșare a lui \(\cS\), să zicem \(\cS_{\eps}\) definită ca 
+\begin{equation}
+    S_{\eps} = \bigcup_{\vxi \in \cS}B_{\eps}(\vxi)
+\end{equation}
+și vizualizată în \Cref{fig:entropy_eps_thickening}.
+\begin{figure}[th]
+    \centering
+    \begin{tikzpicture}
+        \def\radius{0.2cm} %
+        \def\curve{(0,0) .. controls (1,1.5) and (3,-0.5) .. (4,1)} %
+
+        \path[decoration={markings, mark=between positions 0 and 1 step 0.02 with {
+                \fill[red!30, opacity=0.5, draw=none] (0,0) circle (\radius);
+            }}, postaction={decorate}] \curve;
+
+        \draw[blue, thick] \curve node[right, blue] {$\cS$};
+
+        \coordinate (p_on_curve) at (2, 0.5); %
+        \fill[red!50, opacity=0.7] (p_on_curve) circle (\radius);
+        \fill[black] (p_on_curve) circle (1pt) node[below left] {$x$};
+
+            \node[red, below right] at (3.5, -0.2) {$\cS_{\eps} = \bigcup_{\vxi \in S} B_{\eps}(\vxi)$};
+
+    \end{tikzpicture}
+    \caption{Ilustrarea \(\eps\)-îngroșării \(\cS_\eps\) a unei curbe \(\cS \subseteq \R^{2}\).}
+    \label{fig:entropy_eps_thickening}
+\end{figure}
+Vom lucra cu variabile aleatoare al căror suport este \(\cS_{\eps}\), care este complet dimensional, și vom lua limita când \(\eps \to 0\). Într-adevăr, definiți \(\vx_{\eps} \sim \dUnif(\cS_{\eps})\). Deoarece \(\cS_{\eps}\) are volum pozitiv, \(\vx_{\eps}\) are o densitate \(p_{\eps}\) egală cu
+\begin{equation}
+    p_{\eps}(\vxi) = \indvar(\vxi \in \cS_{\eps}) \cdot \frac{1}{\volume(\cS_{\eps})}.
+\end{equation}
+Calculând entropia lui \(\vx_{\eps}\) folosind convenția că \(0 \log 0 = 0\), avem
+\begin{align}
+    h(\vx_{\eps}) 
+    &= -\int_{\R^{D}}p_{\eps}(x)\log p_{\eps}(x)\odif{x} \\ 
+    &= -\int_{\cS_{\eps}}\frac{1}{\volume(\cS_{\eps})} \log\rp{\frac{1}{\volume(\cS_{\eps})}}\odif{\vxi} \\ 
+    &= \frac{\log(\volume(\cS_{\eps}))}{\volume(\cS_{\eps})}\int_{\cS_{\eps}}\odif{\vxi} \\ 
+    &= \log(\volume(\cS_{\eps})).
+\end{align}
+Deoarece \(\cS\) este compact \(\volume(\cS_{\eps})\) este finit și tinde către \(0\) când \(\eps \searrow 0\). Așadar
+\begin{equation}
+    h(\vx) = \lim_{\eps \searrow 0}h(\vx_{\eps}) = \lim_{\eps \searrow 0}\log(\volume(\cS_{\eps})) = -\infty,
+\end{equation}
+așa cum se dorea.
+
+Calculul de mai sus este de fapt un corolar al unui set mult mai celebru și celebrat de rezultate despre entropia maximă posibilă a lui \(\vx\) supusă anumitor constrângeri asupra distribuției lui \(\vx\). Ar fi o omisiune să nu oferim rezultatele aici; demonstrațiile sunt furnizate în Capitolul 2 din \cite{poliyanski2024information}, de exemplu.
+\begin{theorem}\label{thm:max_entropy}
+    Fie \(\vx\) o variabilă aleatoare pe \(\R^{D}\).
+    \begin{enumerate}
+        \item Dacă \(\vx\) este suportată pe o mulțime compactă \(\cS \subseteq \R^{D}\) (adică \Cref{assumption:entropy_x_compact_support}) atunci
+        \begin{equation}
+            h(\vx) \leq h(\dUnif(\cS)) = \log \volume(\cS).
+        \end{equation}
+        \item Dacă \(\vx\) are covarianță finită astfel încât, pentru o matrice PSD \(\vSigma \in \PSD(D)\), avem \(\Cov(\vx) \preceq \vSigma\) (în raport cu ordinea PSD, adică \(\vSigma - \Cov(\vx)\) este PSD), atunci
+        \begin{equation}
+            h(\vx) \leq h(\dNorm(\vzero, \vSigma)) = \frac{1}{2}\log((2\pi e)^{D}\det\vSigma).
+        \end{equation}
+        \item Dacă \(\vx\) are moment de ordinul doi finit astfel încât, pentru o constantă \(a \geq 0\), avem \(\Ex\norm{\vx}_{2}^{2} \leq a\), atunci
+        \begin{equation}
+            h(\vx) \leq h\rp{\dNorm\rp{\vzero, \frac{a}{D}\vI}} = \frac{D}{2}\log\frac{2\pi e a}{D}.
+        \end{equation}
+    \end{enumerate}
+\end{theorem}
+
+
+\section{Procese de Difuzie și Denoising}\label{sec:entropy_diffusion}
+
+În corpul principal (\Cref{ch:general-distribution}), am considerat o variabilă aleatoare \(\vx\), și un proces stocastic definit de \eqref{eq:additive_gaussian_noise_model}, adică,
+\begin{equation}\label{eq:app_additive_gaussian_noise_model}
+    \vx_{t} = \vx + t\vg, \qquad  \forall t \in [0, T]
+\end{equation}
+unde \(\vg \sim \dNorm(\vzero, \vI)\) independent de \(\vx\). 
+
+Structura acestei secțiuni este următoarea. În \Cref{sub:diffusion_entropy_increases} oferim o teoremă formală și o demonstrație clară care arată că sub \Cref{eq:app_additive_gaussian_noise_model} entropia crește, adică \(\odv*{h(\vx_{t})}{t} > 0\). În \Cref{sub:denoising_entropy_decreases} oferim o teoremă formală și o demonstrație clară care arată că sub \Cref{eq:app_additive_gaussian_noise_model}, entropia scade în timpul denoising-ului, adică \(h(\Ex[\vx_{s} \given \vx_{t}]) < h(\vx_{t})\) pentru toți \(s < t\). În \Cref{sub:app_diffusion_intermediate_results} oferim demonstrații pentru lemele tehnice care sunt necesare pentru a stabili afirmațiile din subsecțiunile anterioare.
+
+Înainte de a începe, introducem câteva notații cheie. Mai întâi, fie \(\phi_{t}\) densitatea lui \(\dNorm(\vzero, t^{2}\vI)\), adică,
+\begin{equation}\label{eq:gaussian_noise_time_t}
+    \phi_{t}(\vxi) \doteq \frac{1}{(2\pi)^{D/2}t^{D}}\exp\rp{-\frac{\norm{\vxi}_{2}^{2}}{2t^{2}}}.
+\end{equation}
+În continuare, \(\vx_{t}\) este suportat pe tot \(\R^{D}\), deci are o \textit{densitate}, pe care o notăm \(p_{t}\) (ca în corpul principal). Un calcul rapid arată că
+\begin{equation}\label{eq:p_t_representation}
+    p_{t}(\vxi) = \Ex[\phi_{t}(\vxi - \vx)],
+\end{equation}
+și din această reprezentare este posibil să deducem (adică din \Cref{prop:diff_convolution}) că \(p_{t}\) este netedă (adică infinit diferențiabilă) în \(\vxi\), de asemenea netedă în \(t\), și pozitivă peste tot. Acest fapt este oarecum remarcabil la prima vedere: chiar pentru o variabilă aleatoare complet neregulată \(\vx\) (să zicem, o variabilă aleatoare Bernoulli, care nu are o densitate), netezirea sa gaussiană admite o densitate pentru fiecare (arbitrar mic) \(t > 0\). Demonstrația este lăsată ca exercițiu pentru cititorii versați în analiza matematică.
+
+Totuși, trebuie să adăugăm și o presupunere despre \textit{netezimea} distribuției lui \(\vx\), care va elimina unele probleme tehnice care apar în jurul lui \(t = 0\) cu distribuții de dimensiune mică.\footnote{Deoarece atunci diverse cantități devin foarte neregulate și tratarea lor ar necesita analiză suplimentară semnificativă.} Cu toate acestea, ne așteptăm ca rezultatele noastre să fie valabile sub presupuneri mai blânde cu muncă suplimentară. Pentru moment, să presupunem:
+\begin{assumption}\label{assumption:entropy_x_density}
+    \(\vx\) are o densitate de două ori continuu diferențiabilă, notată \(p\).
+\end{assumption}
+
+
+\subsection{Procesul de Difuzie Crește Entropia în Timp}\label{sub:diffusion_entropy_increases}
+
+În această secțiune anexă oferim o demonstrație a \Cref{thm:diffusion_entropy_increases}. Pentru convenieță, o reiterăm după cum urmează. 
+
+\begin{theorem}[Difuzia Crește Entropia]\label{thm:diffusion_entropy_increases}
+    Fie \(\vx\) orice variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support,assumption:entropy_x_density} sunt valabile, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. Atunci 
+    \begin{equation}\label{eq:diffusion_entropy_increases}
+        h(\vx_{s}) < h(\vx_{t}), \qquad \forall s, t \colon 0 \leq s < t \leq T.
+    \end{equation}
+\end{theorem}
+\begin{proof}
+    Înainte de a începe, trebuie să ne întrebăm: când are sens inegalitatea din \eqref{eq:diffusion_entropy_increases}? Vom arăta în \Cref{lem:diffusion_entropy_exists} că sub presupunerile noastre, entropia diferențială este bine definită, nu este niciodată \(+\infty\), și pentru \(t > 0\) este finită, deci inegalitatea (strictă) din \eqref{eq:diffusion_entropy_increases} are sens.
+
+    Punând la o parte chestiunea bună-definiției, esența acestei demonstrații este să arătăm că densitatea \(p_{t}\) a lui \(\vx_{t}\) satisface o ecuație cu derivate parțiale particulară, care este foarte similară cu \textit{ecuația căldurii}. Ecuația căldurii este o EDP celebră care descrie difuzia căldurii prin spațiu. Acest lucru ar trebui să aibă sens intuitiv și pictează o imagine mentală: pe măsură ce timpul \(t\) crește, probabilitatea din originalul (poate strâns concentrat) \(\vx\) se dispersează în tot \(\R^{D}\) ca căldura care radiază dintr-o sursă în vid.
+    
+    Astfel de EDP-uri pentru \(p_{t}\), cunoscute ca \textit{ecuații Fokker-Planck} pentru procese stocastice mai generale, sunt unelte foarte puternice, deoarece ne permit să descriem derivatele temporale instantanee ale lui \(p_{t}\) în termenii derivatelor spațiale instantanee ale lui \(p_{t}\), și viceversa, oferind o descriere concisă a regularității și dinamicii lui \(p_{t}\). Odată ce obținem dinamica pentru \(p_{t}\), putem apoi folosi sistemul pentru a obține altul care descrie dinamica lui \(h(\vx_{t})\), care până la urmă este doar o funcțională a lui \(p_{t}\).  
+
+    Descrierea EDP implică un obiect matematic numit Laplacianul \(\Delta\). Amintiți-vă din cursul de calcul multivariabil că Laplacianul care operează pe o funcție diferențiabilă-în-timp și de două ori-diferențiabilă-în-spațiu \(f \colon (0, T) \times \R^{D} \to \R\) este dat de
+    \begin{equation}
+        \Delta f_{t}(\vxi) = \tr(\nabla^{2}f_{t}(\vxi)) = \sum_{i = 1}^{D}\pddv{f_{t}}{\xi_{i}}(\vxi).
+    \end{equation}
+    
+    Anume, folosind reprezentarea integrală a lui \(p_{t}\) și diferențiind sub integrală, putem calcula derivatele lui \(p_{t}\) (ceea ce facem în \Cref{prop:p_t_derivatives}) și observăm că \(p_{t}\) satisface EDP asemănătoare cu ecuația căldurii
+    \begin{equation}
+        \pdv{p_{t}}{t}(\vxi) = t\Delta p_{t}(\vxi).
+    \end{equation}
+    Apoi pentru a găsi dinamica lui \(h(\vx_{t})\), putem folosi \Cref{prop:dutis} din nou precum și EDP asemănătoare cu ecuația căldurii pentru a obține
+    \begin{align}
+        \odv*{h(\vx_{t})}{t}
+        &= -\odv*{\int_{\R^{D}}p_{t}(\vxi)\log p_{t}(\vxi)\odif{\vxi}}{t} \\
+        &= -\int_{\R^{D}}\pdv*{\bs{p_{t}(\vxi)\log p_{t}(\vxi)}}{t}\odif{\vxi} \\
+        &= -\int_{\R^{D}}\pdv{p_{t}}{t}(\vxi)[1 + \log p_{t}(\vxi)]\odif{\vxi} \\
+        &= -t\int_{\R^{D}}\Delta p_{t}(\vxi)[1 + \log p_{t}(\vxi)]\odif{\vxi}.
+    \end{align}
+    Folosind un argument de integrare prin părți puțin implicat (\Cref{lem:diffusion_ibp}), obținem 
+    \begin{align}
+        \odv*{h(\vx_{t})}{t}
+        &= t\int_{\R^{D}}\ip{\nabla \log p_{t}(\vxi)}{\nabla p_{t}(\vxi)}\odif{\vxi} \\
+        &= t\int_{\R^{D}}\frac{\norm{\nabla p_{t}(\vxi)}_{2}^{2}}{p_{t}(\vxi)}\odif{\vxi} \\
+        &> 0
+    \end{align}
+    unde inegalitatea strictă este valabilă în ultima linie deoarece, pentru ca ea să nu fie valabilă, \(\nabla p_{t}(\vxi)\) ar trebui să se anuleze aproape peste tot (adică peste tot cu excepția posibil pe o mulțime de volum zero), dar aceasta ar implica că \(p_{t}\) ar fi constantă aproape peste tot, o contradicție cu faptul că \(p_{t}\) este o densitate.
+
+    Pentru a completa demonstrația folosim doar teorema fundamentală a calculului
+    \begin{equation}
+        h(\vx_{t}) = h(\vx_{s}) + \int_{s}^{t}\odv*{h(\vx_{u})}{u}\odif{u} > h(\vx_{s}),
+    \end{equation}
+    care demonstrează afirmația. (Notăm că aceasta nu are sens când \(h(\vx_{s}) = -\infty\), ceea ce se poate întâmpla doar când \(s = 0\) și \(h(\vx) = -\infty\), dar în acest caz \(h(\vx_{t}) > -\infty\) deci afirmația este oricum adevărată în mod vacuu.)
+\end{proof}
+
+\subsection{Procesul de Denoising Reduce Entropia în Timp}\label{sub:denoising_entropy_decreases}
+
+Amintiți-vă că în \Cref{sub:intro_diffusion_denoising} pornim cu variabila aleatoare \(\vx_{T}\) și o denoisăm iterativ folosind iterații de forma
+\begin{equation}\label{eq:app_denoising_iteration}
+    \hat{\vx}_{s} \doteq \Ex[\vx_{s} \mid \vx_{t} = \hat{\vx}_{t}] = \frac{s}{t}\hat{\vx}_{t} + \bp{1 - \frac{s}{t}}\bar{\vx}^{\ast}(t, \hat{\vx}_{t}).
+\end{equation}
+pentru \(s, t \in \{t_{0}, t_{1}, \dots, t_{L}\}\) cu \(s < t\) și \(\vx_{T} = \hat{\vx}_{T}\). Dorim să demonstrăm că \(h(\hat{\vx}_{s}) < h(\hat{\vx}_{t})\), arătând că procesul de denoising reduce de fapt entropia.
+
+Înainte de a face aceasta, facem câteva remarci despre enunțul problemei. Întâi, formula lui Tweedie \eqref{eq:tweedie} spune că 
+\begin{equation}
+    \bar{\vx}^{\ast}(t, \vx_{t}) = \vx_{t} + t^{2}\nabla p_{t}(\vx_{t}),
+\end{equation}
+care face ca un pas complet de denoising de la timpul \(t\) la timpul \(0\) să semene cu un pas de gradient pe log-densitatea lui \(\vx_{t}\). Putem obține un rezultat similar pentru pasul complet de denoising de la timpul \(t\) la timpul \(s\) în \eqref{eq:app_denoising_iteration}? Se pare că într-adevăr putem, și este destul de simplu. Folosind \eqref{eq:app_denoising_iteration} și formula lui Tweedie \eqref{eq:tweedie}, obținem
+\begin{equation}\label{eq:app_denoising_iteration_score}
+    \Ex[\vx_{s} \mid \vx_{t}] = \frac{s}{t}\vx_{t} + \bp{1 - \frac{s}{t}}\bp{\vx_{t} + t^{2}\nabla_{\vx_{t}}\log p_{t}(\vx_{t})} = \vx_{t} + \bp{1 - \frac{s}{t}}t^{2}\nabla_{\vx_{t}}\log p_{t}(\vx_{t}).
+\end{equation}
+Deci acest pas iterativ de denoising este din nou un pas de gradient pe log-densitatea perturbată \(\log p_{t}\) cu o dimensiune a pasului micsorată. În particular, acest pas poate fi văzut ca o perturbare a distribuției variabilei aleatoare \(\vx_{t}\) prin \textit{câmpul vectorial al funcției scor}, sugerând o conexiune cu ecuațiile diferențiale stocastice (SDE) și teoria modelelor de difuzie \cite{song2020score}. Într-adevăr, o demonstrație a următorului rezultat \Cref{thm:conditioning_reduces_entropy} poate fi dezvoltată folosind acest mecanism puternic și un argument de limită (de exemplu, urmând abordarea tehnică din expunerea \cite{DBLP:conf/iclr/ChenC0LSZ23}). Vom da o demonstrație mai simplă aici, care va folosi doar unelte elementare și prin aceasta va ilumina unele dintre cantitățile cheie din spatele procesului de reducere a entropiei prin denoising. Pe de altă parte, va trebui să tratăm unele calcule ușor tehnice din cauza faptului că procesul de denoising din \Cref{thm:conditioning_reduces_entropy} \textit{nu} corespunde exact procesului \textit{invers} asociat procesului de adăugare de zgomot care generează observația \(\vx_{t}\).\footnote{Pentru cei familiarizați cu modelele de difuzie, ne referim aici la faptul că procesul înainte inversat în timp nu coincide cu secvența de iterații generate de procesul definit de \Cref{thm:conditioning_reduces_entropy}. Aceste procese coincid într-o anumită limită unde se iau infinit de mulți pași ai \Cref{thm:conditioning_reduces_entropy} cu niveluri infinit mici de zgomot adăugate la fiecare pas; pentru pași generali, finiți, trebuie să introducem unele aproximări indiferent de nivelul de sofisticare al uneltelor noastre.}
+
+Vrem să demonstrăm că \(h(\Ex[\vx_{s} \mid \vx_{t}]) < h(\vx_{t})\), adică formal:
+\begin{theorem}\label{thm:conditioning_reduces_entropy}
+    Fie \(\vx\) orice variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support,assumption:entropy_x_density} sunt valabile, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. Atunci 
+    \begin{equation}
+        h(\Ex[\vx_{s} \mid \vx_{t}]) < h(\vx_{t}), \qquad \forall s, t \in [0, T] \colon \quad 0 < t \leq \frac{R}{\sqrt{2D}}, \quad 0 \leq s  < t\cdot\min\bc{1, \frac{R^{2}/D - 2t^{2}}{R^{2}/D - t^{2}}}.
+    \end{equation}
+\end{theorem}
+\begin{proof}
+    Această demonstrație folosește două idei principale:
+    \begin{enumerate}
+        \item Mai întâi, scriem o densitate pentru \(\Ex[\vx_{s} \mid \vx_{t}]\) folosind o formulă de schimbare de variabile.
+        \item În al doilea rând, mărginim această densitate pentru a controla entropia.
+    \end{enumerate}
+    Schimbarea de variabile este justificată de \Cref{cor:gribonval_A2}, care a fost derivată inițial în \cite{Gribonval2011-pf}.
+
+    Executăm aceste idei acum. Din \Cref{cor:gribonval_A2}, obținem că funcția \(\bar{\vx}\) definită ca \(\bar{\vx}(\vxi) \doteq \Ex[\vx_{s} \given \vx_{t} = \vxi]\) este diferențiabilă, injectivă, și astfel inversabilă pe domeniul său, pe care îl notăm de acum \(\cX \subseteq \R^{D}\). Notăm inversa sa ca \(\bar{\vx}^{-1}\). Folosind o formulă de schimbare de variabile, densitatea \(\bar{p}\) a lui \(\bar{\vx}(\vx_{t})\) este dată de 
+    \begin{equation}
+        \bar{p}(\vxi) \doteq \frac{(p_{t} \circ \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))},
+    \end{equation}
+    unde (amintiți-vă, din \Cref{sec:autodiff}) \(\bar{\vx}^{\prime}\) este jacobianul lui \(\bar{\vx}\). Deoarece din \Cref{lem:gribonval_A1} știm că \(\bar{\vx}^{\prime}\) este o matrice pozitiv definită, determinantul este pozitiv și deci întreaga densitate este pozitivă. Atunci urmează că 
+    \begin{align}
+        h(\bar{\vx}(\vx_{t}))
+        &= -\int_{\cX}\frac{(p_{t} \circ \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))} \log \frac{(p_{t} \circ \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))} \odif{\vxi} \\ 
+        &= -\int_{\cX}\frac{(p_{t} \circ \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))} \log((p_{t} \circ \bar{\vx}^{-1})(\vxi))\odif{\vxi} \\ 
+        &\qquad + \int_{\cX}\frac{(p_{t} \circ
+        \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}\log\det\rp{\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi))}\odif{\vxi} \\ 
+        &= -\int_{\R^{D}}p_{t}(\vxi)\log p_{t}(\vxi)\odif{\vxi}
+        + \int_{\cX}\frac{(p_{t} \circ
+        \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}\log\det\rp{\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi))}\odif{\vxi} \\ 
+        &= h(\vx_{t}) - \int_{\cX}\frac{(p_{t} \circ \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}\log\rp{\frac{1}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}}\odif{\vxi}.
+    \end{align}
+    Vom studia ultimul termen (incluzând \(-\)), și vom arăta că este negativ.
+
+    Prin concavitate, avem \(-x\log x \leq 1 - x\) pentru orice \(x \geq 0\). Prin urmare 
+    \begin{align}
+        h(\bar{\vx}(\vx_{t})) - h(\vx_{t})
+        &= - \int_{\cX}\frac{(p_{t} \circ \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}\log\rp{\frac{1}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}}\odif{\vxi} \\ 
+        &\leq  \int_{\cX}(p_{t} \circ \bar{\vx}^{-1})(\vxi)\cdot \bp{1 - \frac{1}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}}\odif{\vxi} \\ 
+        &= \int_{\cX}(p_{t} \circ \bar{\vx}^{-1})(\vxi)\odif{\vxi} - \int_{\cX}\frac{(p_{t} \circ \bar{\vx}^{-1})(\vxi)}{\det(\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi)))}\odif{\vxi} \\
+        &= \int_{\R^{D}}p_{t}(\vxi)\det\rp{\bar{\vx}^{\prime}(\bar{\vx}^{-1}(\vxi))}\odif{\vxi} - \int_{\cX}\bar{p}(\vxi)\odif{\vxi} \\
+        &= \int_{\R^{D}}p_{t}(\vxi)\det\rp{\vI + \bp{1 - \frac{s}{t}}t^{2}\nabla^{2}\log p_{t}(\vxi)}\odif{\vxi} - 1.
+    \end{align}
+    Acum, prin inegalitatea AM-GM pe valori proprii, avem pentru orice matrice simetrică pozitiv definită \(\vM \in \PSD(D)\) marginea 
+    \begin{equation}
+        \det(\vM)^{1/D} = \prod_{i = 1}^{D}\lambda_{i}(\vM)^{1/D} \leq \frac{\sum_{i = 1}^{D}\lambda_{i}(\vM)}{D} = \frac{\tr(\vM)}{D},
+    \end{equation}
+    pe care o putem aplica expresiei de mai sus și obținem 
+    \begin{align}
+        &\int_{\R^{D}}p_{t}(\vxi)\det\rp{\vI + \bp{1 - \frac{s}{t}}t^{2}\nabla^{2}\log p_{t}(\vxi)}\odif{\vxi} \\
+        &\leq \int_{\R^{D}} p_{t}(\vxi) \tr\rp{\frac{1}{D}\bs{\vI + \bp{1 - \frac{s}{t}}t^{2}\nabla^{2}\log p_{t}(\vxi)}}^{D}\odif{\vxi} \\
+        &= \int_{\R^{D}} p_{t}(\vxi)\bp{1 + \frac{\bp{1 - \frac{s}{t}}t^{2}}{D}\tr(\nabla^{2}\log p_{t}(\vxi))}^{D}\odif{\vxi} \\
+        &= \int_{\R^{D}} p_{t}(\vxi)\bp{1 + \frac{\bp{1 - \frac{s}{t}}t^{2}}{D}\Delta \log p_{t}(\vxi)}^{D}\odif{\vxi}.
+    \end{align}
+    Din \Cref{lem:app_diffusion_laplacian_control}, avem (unde, amintiți-vă, \(R\) este raza suportului lui \(\vx\) ca în \Cref{assumption:entropy_x_compact_support})
+    \begin{equation}
+        \abs{\Delta \log p_{t}(\vxi)} \leq \max\rp{\frac{D}{t^{2}}, \abs*{\frac{R^{2}}{t^{4}} - \frac{D}{t^{2}}}} =: U_{t}.
+    \end{equation}
+    Atunci avem
+    \begin{equation}
+        -\frac{\bp{1 - \frac{s}{t}}t^{2}}{D}U_{t} \leq \frac{\bp{1 - \frac{s}{t}}t^{2}}{D}\Delta \log p_{t}(\vxi) \leq \frac{\bp{1 - \frac{s}{t}}t^{2}}{D}U_{t}.
+    \end{equation}
+    În același timp, funcția \(x \mapsto (1 + x)^{D}\) este convexă pe \([-1, \infty)\), deci pentru
+    \(-(1-s/t)t^{2}U_{t}/D \leq x \leq (1-s/t)t^{2}U_{t}/D\) avem 
+    \begin{align}
+        (1 + x)^{d} 
+        &\leq \bp{1 - \frac{\bp{1 - \frac{s}{t}}t^{2}U_{t}}{D}}^{D} + \underbrace{\bs{\bp{1 + \frac{\bp{1 - \frac{s}{t}}t^{2}U_{t}}{D}}^{D} - \bp{1 - \frac{\bp{1 - \frac{s}{t}}t^{2}U_{t}}{D}}^{D}}}_{M(s, t, D)}x \\ 
+        &\leq 1 + M(s, t, D)x.
+    \end{align}
+    Aici \(M(s, t, D) > 0\) deoarece \(U_{t} > 0\). În marginea de mai sus, trebuie să verificăm că marginea inferioară pentru \(x\) este \(\geq -1\). Într-adevăr,
+    \begin{align}
+        -\frac{\bp{1 - \frac{s}{t}}t^{2}}{D}U_{t}
+        &= -\frac{\bp{1 - \frac{s}{t}}t^{2}}{D}\max\rp{\frac{D}{t^{2}}, \abs*{\frac{R^{2}}{t^{4}} - \frac{D}{t^{2}}}} \\ 
+        &= -\bp{1 - \frac{s}{t}}\max\rp{1, \abs*{\frac{R^{2}}{Dt^{2}} - 1}}
+    \end{align}
+    Observăm că aceasta este \(\geq -1\) dacă și numai dacă \(\bp{1 - \frac{s}{t}}\cdot\bp{\frac{R^{2}}{Dt^{2}} - 1} \geq 1\), adică \(0 < t < R/\sqrt{2D}\) și \(0 \leq s \leq t\cdot\frac{R^{2}/D - 2t^{2}}{R^{2}/D - t^{2}}\), așa cum este acordat de presupuneri.
+    
+    Aplicând această margine, obținem
+    \begin{align}
+        &\int_{\R^{D}} p_{t}(\vxi)\bp{1 + \frac{\bp{1 - \frac{s}{t}}t^{2}}{D}\Delta \log p_{t}(\vxi)}^{D}\odif{\vxi} \\ 
+        &\leq \int_{\R^{D}}p_{t}(\vxi)\bp{1 + M(s, t, D)\Delta \log p_{t}(\vxi)}\odif{\vxi} \\
+        &= 1 + M(s, t, D)\int_{\R^{D}}p_{t}(\vxi)\Delta \log p_{t}(\vxi)\odif{\vxi} \\
+        &= 1 - M(s, t, D)\int_{\R^{D}}\ip{\nabla p_{t}(\vxi)}{\nabla\log p_{t}(\vxi)}\odif{\vxi} \\
+        &= 1 - M(s, t, D)\int_{\R^{D}}\frac{\norm{\nabla p_{t}(\vxi)}_{2}^{2}}{p_{t}(\vxi)}\odif{\vxi},
+    \end{align}
+    unde ultimele câteva linii sunt aceleași ca în demonstrația \Cref{thm:diffusion_entropy_increases}. Combinând acest rezultat cu estimarea noastră anterioară,
+    \begin{equation}
+        h(\bar{\vx}(\vx_{t})) - h(\vx_{t}) \leq - M(s, t, D)\int_{\R^{D}}\frac{\norm{\nabla p_{t}(\vxi)}_{2}^{2}}{p_{t}(\vxi)}\odif{\vxi} < 0
+    \end{equation}
+    unde inegalitatea este strictă prin același argument ca în \Cref{thm:diffusion_entropy_increases}.
+\end{proof}
+
+Observați că marginile pentru \(s\) și \(t\) depind de raza \(R\) a distribuției datelor, și nu sunt atât de generale ca marginile din \Cref{thm:diffusion_entropy_increases}. Rezultatul este de fapt ``atât de general cât este necesar'' în următorul sens. Notăm că dacă \(\vx\) are o densitate de două ori continuu diferențiabilă suportată pe bila de rază \(R\) centrată în \(\vzero\), atunci o are pentru \(2R\), și \(3R\), și așa mai departe, adică pentru orice bilă de rază \(R^{\prime} > R\). Așadar o strategie pentru a obține garanția de denoising corespunzătoare este: fixați o dimensiune a datelor \(D\) și un program de discretizare, și apoi setați (în analiză) raza datelor \(R\) să fie foarte mare astfel încât fiecare pas de denoising să satisfacă cerințele pentru scăderea entropiei date în \Cref{thm:conditioning_reduces_entropy}. Atunci fiecare pas al procesului de denoising va reduce într-adevăr entropia, așa cum se dorea.
+
+ 
+\subsection{Leme Tehnice și Rezultate Intermediare}\label{sub:app_diffusion_intermediate_results}
+
+În această subsecțiune prezentăm rezultate tehnice care susțin cele două teoreme conceptuale principale ale noastre. Prezentarea noastră va fi mai mult sau mai puțin standard pentru matematică; vom începe cu rezultatele de nivel mai înalt mai întâi, și vom merge treptat înapoi la rezultatele mai incrementale. Rezultatele de nivel mai înalt vor folosi rezultatele incrementale, și în acest fel avem o ordonare ușor de citit a dependențelor rezultatelor: niciun rezultat nu depinde de cele dinaintea sa. Rezultatele care nu depind unele de altele sunt în general ordonate după locul în care apar în perechea de demonstrații de mai sus. 
+
+
+\subsubsection{Finitudinea Entropiei Diferențiale}
+
+Mai întâi arătăm că entropia există de-a lungul procesului stocastic și este finită.
+
+\begin{lemma}\label{lem:diffusion_entropy_exists}
+    Fie \(\vx\) orice variabilă aleatoare, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. 
+    \begin{enumerate}
+        \item Pentru \(t > 0\), entropia diferențială \(h(\vx_{t})\) există și este \(> -\infty\).
+        \item Dacă în plus \Cref{assumption:entropy_x_compact_support} este valabilă pentru \(\vx\), atunci \(h(\vx) < \infty\) și \(h(\vx_{t})\ < \infty\).
+    \end{enumerate}
+\end{lemma}
+\begin{proof}
+    Pentru a demonstra \Cref{lem:diffusion_entropy_exists}.1, folosim un argument de analiză clasic dar obositor. Deoarece \(\vx_{t}\) are o densitate, putem scrie 
+    \begin{equation}
+        h(\vx_{t}) = -\int_{\R^{D}}p_{t}(\vxi)\log p_{t}(\vxi) \odif{\vxi}.
+    \end{equation}
+    În consecință, fie \(g \colon \R^{D} \to \R\) definită ca 
+    \begin{equation}
+        g(\vxi) \doteq -p_{t}(\vxi)\log p_{t}(\vxi) \implies h(\vx_{t}) = \int_{\R^{D}}g(\vxi)\odif{\vxi}.
+    \end{equation}
+    Ca de obicei pentru a mărgini valoarea unei integrale în analiză, definim 
+    \begin{equation}
+        g_{+}(\vxi) \doteq \max(g(\vxi), 0), \quad g_{-}(\vxi) \doteq \max(-g(\vxi), 0) \quad \implies \quad g = g_{+} - g_{-}\quad \text{și} \quad g_{+}, g_{-} \geq 0.
+    \end{equation}
+    Atunci 
+    \begin{equation}
+        h(\vx_{t}) = \int_{\R^{D}}g_{+}(\vxi)\odif{\vxi} - \int_{\R^{D}}g_{-}(\vxi)\odif{\vxi},
+    \end{equation}
+    și ambele integrale sunt garantate să fie ne-negative deoarece integranții lor sunt. 
+    
+    Pentru a arăta că \(h(\vx_{t})\) este bine definită, trebuie să arătăm că \(\int_{\R^{D}}g_{+}(\vxi)\odif{\vxi} < \infty\) sau \(\int_{\R^{D}}g_{-}(\vxi) \odif{\vxi} < \infty\). Pentru a arăta că \(h(\vx_{t}) > -\infty\), este suficient doar să arătăm că \(\int_{\R^{D}}g_{-}(\vxi)\odif{\vxi} < \infty\). Pentru a mărgini integrala lui \(g_{-}\) trebuie să înțelegem cantitatea \(g_{-}\), anume, vrem să caracterizăm când \(g\) este negativă.
+    \begin{equation}
+        g(\vxi) \leq 0 \iff p_{t}(\vxi)\log p_{t}(\vxi) \geq 0 \iff \log p_{t}(\vxi) \geq 0 \iff p_{t}(\vxi) \geq 1.
+    \end{equation}
+    Așadar, avem că 
+    \begin{equation}
+        g_{-}(\vxi) = \indvar(p_{t}(\vxi) \geq 1)\cdot (-g(\vxi)) = \indvar(p_{t}(\vxi) \geq 1)p_{t}(\vxi)\log p_{t}(\vxi).
+    \end{equation}
+    Pentru a mărgini integrala lui \(g_{-}(\vxi)\), trebuie să arătăm că \(p_{t}\) ``nu este prea concentrată,'' anume că \(p_{t}\) nu este prea mare. Pentru a demonstra aceasta, în acest caz suntem norocoși să putem mărgini funcția \(g_{-}(\vxi)\) însăși. Anume, observăm că 
+    \begin{equation}
+        \max_{\vxi \in \R^{D}}\phi_{t}(\vxi - \vx) = \phi_{t}(\vzero) = \frac{1}{(2\pi)^{D/2}t^{D}} =: C_{t}.
+    \end{equation}
+    care explodează când \(t \to 0\) dar este finită pentru toți \(t\) finiți. Prin urmare 
+    \begin{equation}
+        p_{t}(\vxi) = \Ex \phi_{t}(\vxi - \vx) \leq \Ex C_{t} = C_{t}.
+    \end{equation}
+    Acum există două cazuri.
+    \begin{itemize}
+        \item Dacă \(C_{t} < 1\), atunci \(p_{t}(\vxi) < 1\), deci indicatorul nu este niciodată \(1\), prin urmare \(g_{-} = 0\) identic și integrala sa este de asemenea \(0\).
+        \item Dacă \(C_{t} \geq 1\), atunci \(\log C_{t} \geq 0\), deci deoarece logaritmul este monoton crescător,
+        \begin{align}
+            \int_{\R^{D}}g_{-}(\vxi)\odif{\vxi}
+            &= \int_{\R^{D}}\indvar(p_{t}(\vxi) \geq 1)p_{t}(\vxi)\log p_{t}(\vxi)\odif{\vxi}  \\ 
+            &= \Ex[\indvar(p_{t}(\vx_{t}) \geq 1)\log p_{t}(\vx_{t})]  \\ 
+            &\leq \Ex[\indvar(p_{t}(\vx_{t}) \geq 1) \log C_{t}] \\ 
+            &= \Pr[p_{t}(\vx_{t}) \geq 1]\log C_{t}.
+        \end{align}
+    \end{itemize}
+    Prin urmare avem \(\int_{\R^{D}}g_{-}(\vxi)\odif{\vxi} < \infty\), deci entropia diferențială \(h(\vx_{t})\) există și este \(> -\infty\).
+
+    Pentru a demonstra \Cref{lem:diffusion_entropy_exists}.2, să presupunem că \Cref{assumption:entropy_x_compact_support} este valabilă. Vrem să arătăm că \(h(\vx) < \infty\) și \(h(\vx_{t}) < \infty\). Mecanismul pentru a face aceasta este același, și implică rezultatul de entropie maximă \Cref{thm:max_entropy}. Anume, deoarece \(\vx\) este absolut mărginită, are o covarianță finită pe care o vom nota \(\vSigma\). Atunci covarianța lui \(\vx_{t}\) este \(\vSigma + t^{2}\vI\). Așadar entropia lui \(\vx\) și \(\vx_{t}\) poate fi mărginită superior de entropia distribuțiilor normale cu covarianțele respective, adică \(\log[(2\pi e)^{D}\det(\vSigma)]\) sau \(\log[(2\pi e)^{D}\det(\vSigma + t^{2}\vI)]\), și ambele sunt \(< \infty\).
+\end{proof}
+
+\subsubsection{Integrare prin Părți în Identitatea De Brujin}
+
+În final, completăm argumentul de integrare prin părți la care s-a făcut aluzie în demonstrațiile \Cref{thm:diffusion_entropy_increases,thm:conditioning_reduces_entropy}. Argumentul este conceptual destul de simplu dar necesită unele estimări tehnice pentru a arăta că termenul de frontieră în integrarea prin părți dispare.
+
+\begin{lemma}\label{lem:diffusion_ibp}
+    Fie \(\vx\) orice variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support,assumption:entropy_x_density} sunt valabile, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. Pentru \(t \geq 0\), fie \(p_{t}\) densitatea lui \(\vx_{t}\). Atunci pentru o constantă \(c \in \R\) avem 
+    \begin{equation}
+        \int_{\R^{D}}\Delta p_{t}(\vxi)[c + \log p_{t}(\vxi)]\odif{\vxi} = -\int_{\R^{D}}\ip{\nabla \log p_{t}(\vxi)}{\nabla p_{t}(\vxi)}\odif{\vxi}.
+    \end{equation}
+\end{lemma}
+\begin{proof}
+    Ideea de bază a acestei demonstrații este în doi pași:
+    \begin{itemize}
+        \item Mai întâi, aplicăm teorema lui Green pentru a face integrare prin părți peste o mulțime compactă;
+        \item În al doilea rând, trimitem raza acestei mulțimi compacte la \(+\infty\), pentru a obține integrale peste tot \(\R^{D}\).
+    \end{itemize}
+    Teorema lui Green spune că pentru orice mulțime compactă \(\cK \subseteq \R^{D}\), \(\plainphi \colon \R^{D} \to \R\) de două ori continuu diferențiabilă, și \(\psi \colon \R^{D} \to \R\) continuu diferențiabilă,
+    \begin{equation}
+        \int_{\cK}\bc{\psi(\vxi) \Delta \plainphi(\vxi) + \ip{\nabla \psi(\vxi)}{\nabla \plainphi(\vxi)}}\odif{\vxi} = \int_{\partial \cK}\psi(\vxi)\ip{\nabla \plainphi(\vxi)}{\vn(\vxi)}\odif{\sigma(\vxi)}
+    \end{equation}
+    unde \(\odif{\sigma(\vxi)}\) denotă o integrală peste ``măsura de suprafață'', adică măsura moștenită pe \(\partial \cK\), anume frontiera lui \(\cK\), și în consecință \(\vxi\) ia valori pe această suprafață și \(\vn(\vxi)\) este vectorul normal unitar la \(\cK\) în punctul de pe suprafață \(\vxi\). Acum, luând \(\plainphi(\vxi) \doteq p_{t}(\vxi)\) și \(\psi(\vxi) \doteq c + \log p_{t}(\vxi)\), peste o bilă \(B_{r}(\vzero)\) de rază \(r > 0\) centrată în \(\vzero\) (astfel încât \(\partial B_{r}(\vzero)\) este sfera de rază \(r\) centrată în \(\vzero\) și \(\vn(\vxi) = \vxi/\norm{\vxi}_{2} = \vxi/r\)):
+    \begin{align}
+        &\int_{B_{r}(\vzero)}\bc{\Delta p_{t}(\vxi)[c + \log p_{t}(\vxi)] + \ip{\nabla \log p_{t}(\vxi)}{\nabla p_{t}(\vxi)}}\odif{\vxi} \\
+        &= \int_{\partial B_{r}(\vzero)}[c + \log p_{t}(\vxi)]\ip*{\nabla p_{t}(\vxi)}{\frac{\vxi}{r}}\odif{\sigma(\vxi)} \\
+        &= \frac{1}{r}\int_{\partial B_{r}(\vzero)}[c + \log p_{t}(\vxi)]\ip*{\nabla p_{t}(\vxi)}{\vxi}\odif{\sigma(\vxi)}.
+    \end{align}
+    Trimițând \(r \to \infty\), avem că 
+    \begin{align}
+        &\int_{\R^{D}}\bc{\Delta p_{t}(\vxi)[c + \log p_{t}(\vxi)] + \ip{\nabla \log p_{t}(\vxi)}{\nabla p_{t}(\vxi)}}\odif{\vxi} \label{eq:app_diffusion_r_infinity_limit} \\
+        &= \lim_{r \to \infty}\int_{B_{r}(\vzero)}\bc{\Delta p_{t}(\vxi)[c + \log p_{t}(\vxi)] + \ip{\nabla \log p_{t}(\vxi)}{\nabla p_{t}(\vxi)}}\odif{\vxi} \\
+        &= \lim_{r \to \infty}\frac{1}{r}\int_{\partial B_{r}(\vzero)}[c + \log p_{t}(\vxi)]\ip*{\nabla p_{t}(\vxi)}{\vxi}\odif{\sigma(\vxi)},
+    \end{align}
+    unde prima inegalitate urmează prin convergență dominată pe integrand. Rămâne să calculăm ultima limită. Pentru aceasta, luăm expansiuni asimptotice ale fiecărui termen. Dispozitivul principal este următorul: pentru \(\vxi \in \partial B_{r}(\vzero)\), avem \(\norm{\vxi}_{2} = r\). Prin inegalitatea Cauchy-Schwarz, pentru orice \(\vx\) cu \(\norm{\vx}_{2} \leq R\), avem
+    \begin{equation}
+        -2r\norm{\vx}_{2} - \norm{\vx}_{2}^{2} \leq 2\ip{\vxi}{\vx} - \norm{\vx}_{2}^{2} \leq 2r\norm{\vx}_{2} - \norm{\vx}_{2}^{2}.
+    \end{equation}
+    Reamintim că prin \Cref{assumption:entropy_x_compact_support}, \(\vx\) este suportat pe o mulțime compactă \(\cS\) de rază \(R\). Astfel
+    \begin{equation}
+        -2R(r + R) \leq 2\ip{\vxi}{\vx} - \norm{\vx}_{2}^{2} \leq 2Rr.
+    \end{equation}
+    Cu alte cuvinte, avem
+    \begin{equation}
+        C_{t}e^{-[r^{2} + 2R(r + R)]/(2t^{2})} \leq p_{t}(\vxi) \leq C_{t}e^{[-r^{2} + 2Rr]/(2t^{2})}.
+    \end{equation}
+    Acum pentru a calcula gradientul, putem folosi \Cref{prop:p_t_derivatives} și liniaritatea așteptării pentru a calcula
+    \begin{align}
+        \ip{\nabla p_{t}(\vxi)}{\vxi}
+        &= \ip*{-\frac{1}{t^{2}}\Ex\rs{\bp{\vxi - \vx}\phi_{t}(\vxi - \vx)}}{\vxi} \\
+        &= -\frac{1}{t^{2}}\Ex\rs{\ip{\vxi - \vx}{\vxi}\phi_{t}(\vxi - \vx)} \\
+        &= -\frac{1}{t^{2}}\Ex\rs{\bp{\norm{\vxi}_{2}^{2} - \ip{\vxi}{\vx}}\phi_{t}(\vxi - \vx)} \\
+        &= -\frac{1}{t^{2}}\Ex\rs{\bp{r^{2} - \ip{\vxi}{\vx}}\phi_{t}(\vxi - \vx)} \\
+        &= \frac{1}{t^{2}}\Ex\rs{\bp{\ip{\vxi}{\vx} - r^{2}}\phi_{t}(\vxi - \vx)}.
+    \end{align}
+    Folosind Cauchy-Schwarz și reprezentarea \(p_{t}(\vxi) \doteq \Ex[\phi_{t}(\vxi - \vx)]\) din nou, avem
+    \begin{align}
+        &\frac{1}{t^{2}}\Ex\rs{\bp{-Rr - r^{2}}\phi_{t}(\vxi - \vx)} \leq \ip{\nabla p_{t}(\vxi)}{\vxi} \leq \frac{1}{t^{2}}\Ex\rs{\bp{Rr - r^{2}}\phi_{t}(\vxi - \vx)} \\
+        &\frac{1}{t^{2}}\bp{-Rr - r^{2}}\Ex\rs{\phi_{t}(\vxi - \vx)} \leq \ip{\nabla p_{t}(\vxi)}{\vxi} \leq \frac{1}{t^{2}}\bp{Rr - r^{2}}\Ex\rs{\phi_{t}(\vxi - \vx)} \\
+        &-\frac{r(R + r)}{t^{2}}p_{t}(\vxi) \leq \ip{\nabla p_{t}(\vxi)}{\vxi} \leq -\frac{r(r - R)}{t^{2}}p_{t}(\vxi).
+    \end{align}
+    Pentru \(r > R > 0\) (cum este potrivit, deoarece vom lua limita \(r \to \infty\) în timp ce \(R\) este fix), ambele părți sunt negative. Acest lucru are sens: cea mai mare parte a masei de probabilitate este conținută în bila de rază \(R\) și astfel scorul indică spre interior, având un produs scalar negativ cu vectorul care indică spre exterior \(\vxi\). Astfel, folosind limitele corespunzătoare pentru \(p_{t}(\vxi)\),
+    \begin{equation}
+        -\frac{r(R + r)}{t^{2}}\cdot C_{t}e^{[-r^{2} + 2Rr]/(2t^{2})} \leq \ip{\nabla p_{t}(\vxi)}{\vxi} \leq -\frac{r(r - R)}{t^{2}}\cdot C_{t}e^{-[r^{2} + 2R(r + R)]/(2t^{2})}.
+    \end{equation}
+    Apoi, notând că \(C_{t} = \mathrm{poly}(t^{-1})\), putem calcula
+    \begin{equation}
+        [c + \log p_{t}(\vxi)]\ip{\nabla p_{t}(\vxi)}{\vxi} = \mathrm{poly}(r, R, t^{-1}, c)e^{-\Theta_{r}(r^{2})}
+    \end{equation}
+    Deci se poate vedea că, notând aria suprafeței \(\partial B_{r}(\vzero)\) ca \(\omega_{D} r^{D - 1}\) unde \(\omega_{D}\) este o funcție de \(D\), avem
+    \begin{equation}
+        \frac{1}{r}\int_{\partial B_{r}(\vzero)}[c + \log p_{t}(\vxi)]\ip{\nabla p_{t}(\vxi)}{\vxi}\odif{\vxi} = \mathrm{poly}(r, R, t^{-1}, c)e^{-\Theta_{r}(r^{2})}
+    \end{equation}
+    și prin urmare cozile exponențial descăzătoare înseamnă
+    \begin{equation}
+        \lim_{r \to \infty}\frac{1}{r}\int_{\partial B_{r}(\vzero)}[c + \log p_{t}(\vxi)]\ip{\nabla p_{t}(\vxi)}{\vxi}\odif{\vxi} = 0.
+    \end{equation}
+    În final, înlocuind în \eqref{eq:app_diffusion_r_infinity_limit}, avem
+    \begin{align}
+        &\int_{\R^{D}}\bc{\Delta p_{t}(\vxi)[c + \log p_{t}(\vxi)] + \ip{\nabla \log p_{t}(\vxi)}{\nabla p_{t}(\vxi)}}\odif{\vxi} = 0 \\
+        \implies 
+        &\int_{\R^{D}}\Delta p_{t}(\vxi)[c + \log p_{t}(\vxi)]\odif{\vxi} = -\int_{\R^{D}}\ip{\nabla \log p_{t}(\vxi)}{\nabla p_{t}(\vxi)}\odif{\vxi}
+    \end{align}
+    așa cum s-a afirmat.
+\end{proof}
+
+\subsubsection{Invertibilitatea Locală a Denoiser-ului \(\bar{\vx}\)}
+
+Aici oferim câteva rezultate folosite în demonstrația \Cref{thm:conditioning_reduces_entropy} care sunt generalizări corespunzătoare ale rezultatelor corespondente din \cite{Gribonval2011-pf}.
+
+\begin{lemma}[Generalizare a \cite{Gribonval2011-pf}, Lema A.1]\label{lem:gribonval_A1}
+    Fie \(\vx\) orice variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support,assumption:entropy_x_density} sunt valabile, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. Fie \(s, t \in [0, T]\) astfel încât \(0 \leq s < t \leq T\), și fie \(\bar{\vx}(\vxi) \doteq \Ex[\vx_{s} \mid \vx_{t} = \vxi]\). Jacobianul \(\bar{\vx}^{\prime}(\vxi)\) este simetric pozitiv definit.
+\end{lemma}
+\begin{proof}
+    Avem 
+    \begin{equation}
+        \bar{\vx}^{\prime}(\vxi) = \vI + \bp{1 - \frac{s}{t}}t^{2}\nabla^{2}\log p_{t}(\vxi).
+    \end{equation}
+    Aici expandăm 
+    \begin{equation}
+        \nabla^{2}\log p_{t}(\vxi) = \frac{p_{t}(\vxi)\nabla^{2}p_{t}(\vxi) - (\nabla p_{t}(\vxi))(\nabla p_{t}(\vxi))^{\top}}{p_{t}(\vxi)^{2}}.
+    \end{equation}
+    Deci trebuie să asigurăm că 
+    \begin{align}
+        \bar{\vx}^{\prime}(\vxi)
+        &= \vI + \bp{1 - \frac{s}{t}}t^{2}\frac{p_{t}(\vxi)\nabla^{2}p_{t}(\vxi) - (\nabla p_{t}(\vxi))(\nabla p_{t}(\vxi))^{\top}}{p_{t}(\vxi)^{2}} \\
+        &= \frac{p_{t}(\vxi)^{2}\vI + \bp{1 - \frac{s}{t}}t^{2}\bs{p_{t}(\vxi)\nabla^{2}p_{t}(\vxi) - (\nabla p_{t}(\vxi))(\nabla p_{t}(\vxi))^{\top}}}{p_{t}(\vxi)^{2}}
+    \end{align}
+    este simetric pozitiv semidefinit. Într-adevăr este evident simetric (prin teorema lui Clairaut). Pentru a arăta pozitiv semidefinirea sa, înlocuim reprezentarea de așteptare a lui \(p_{t}\) dată de \eqref{eq:p_t_representation} (și \(\nabla p_{t}\), \(\Delta p_{t}\) prin \Cref{prop:p_t_derivatives}) pentru a obține (unde \(\vx\) este așa cum este definit și \(\vy\) este i.i.d.~ca \(\vx\)),
+    \begin{align}
+        &\vv^{\top}[\bar{\vx}^{\prime}(\vxi)]\vv \\
+        &= p_{t}(\vxi)^{-2}\vv^{\top}\Bigg\{p_{t}(\vxi)^{2}\vI + \bp{1 - \frac{s}{t}}t^{2}\Ex[\phi_{t}(\vxi - \vx)]\Ex\rs{\phi_{t}(\vxi - \vx)\cdot\frac{(\vxi - \vx)(\vxi - \vx)^{\top} - t^{2}\vI}{t^{4}}} \\
+        & \qquad \qquad \qquad -\bp{1 - \frac{s}{t}}t^{2}\Ex\rs{-\phi_{t}(\vxi - \vx)\cdot\frac{\vxi - \vx}{t^{2}}}\Ex\rs{-\phi_{t}(\vxi - \vx)\cdot\frac{\vxi - \vx}{t^{2}}}^{\top}\Bigg\}\vv \\
+        &= p_{t}(\vxi)^{-2}\vv^{\top}\Bigg\{\Ex[\phi_{t}(\vxi - \vx)\phi_{t}(\vxi - \vy)\vI] \\
+        & \qquad \qquad \qquad + \bp{1 - \frac{s}{t}}t^{2}\Ex\rs{\phi_{t}(\vxi - \vx)\phi_{t}(\vxi - \vy)\cdot\frac{(\vxi - \vy)(\vxi - \vy)^{\top} - t^{2}\vI}{t^{4}}} \\
+        & \qquad \qquad \qquad -\bp{1 - \frac{s}{t}}t^{2}\Ex\rs{\phi_{t}(\vxi - \vx)\phi_{t}(\vxi - \vy)\cdot\frac{(\vxi - \vx)(\vxi - \vy)^{\top}}{t^{4}}}\Bigg\} \\ 
+        &= \frac{1 - s/t}{p_{t}(\vxi)^{2}}\vv^{\top}\Ex\mathopen{}\Bigg[\phi_{t}(\vxi - \vx)\phi_{t}(\vxi - \vy)\bc{\frac{1}{1 - s/t}\vI + \frac{(\vxi - \vy)(\vxi - \vy)^{\top}}{t^{2}} - \vI - \frac{(\vxi - \vx)(\vxi - \vy)^{\top}}{t^{2}}}\Bigg]\vv \\
+        &= \frac{t - s}{tp_{t}(\vxi)^{2}}\vv^{\top}\Ex\rs{\frac{s}{t - s}\vI +\frac{(\vxi - \vx)(\vxi - \vx)^{\top}}{2t^{2}} + \frac{(\vxi - \vy)(\vxi - \vy)^{\top}}{2t^{2}} - \frac{(\vxi - \vx)(\vxi - \vy)^{\top}}{t^{2}}}\vv \\
+        &= \frac{t - s}{tp_{t}(\vxi)^{2}}\vv^{\top}\Ex\rs{\frac{s}{t - s}\vI +\frac{1}{2t^{2}}\bp{(\vxi - \vx)(\vxi - \vx)^{\top} + (\vxi - \vy)(\vxi - \vy)^{\top} - 2(\vxi - \vx)(\vxi - \vy)^{\top}}}\vv \\
+        &= \frac{t - s}{tp_{t}(\vxi)^{2}}\Ex\rs{\frac{s}{t - s}\norm{\vv}_{2}^{2} +\frac{1}{2t^{2}}\bp{[(\vxi - \vx)^{\top}\vv]^{2} + [(\vxi - \vy)^{\top}\vv]^{2} - 2[(\vxi - \vx)^{\top}\vv][(\vxi - \vy)^{\top}\vv]}} \\
+        &= \frac{t - s}{tp_{t}(\vxi)^{2}}\Ex\rs{\frac{s}{t - s}\norm{\vv}_{2}^{2} +\frac{1}{2t^{2}}\bp{[(\vxi - \vx)^{\top}\vv] - [(\vxi - \vy)^{\top}\vv]}^{2}} \\
+        &= \frac{t - s}{tp_{t}(\vxi)^{2}}\Ex\rs{\frac{s}{t - s}\norm{\vv}_{2}^{2} +\frac{1}{2t^{2}}[(\vy - \vx)^{\top}\vv]^{2}} \\
+        &= \frac{s}{tp_{t}(\vxi)^{2}}\norm{\vv}_{2}^{2} + \frac{t - s}{2t^{3}p_{t}(\vxi)}\Ex[\{(\vy - \vx)^{\top}\vv\}^{2}]
+    \end{align}
+    Deoarece \(\vx\) și \(\vy\) sunt i.i.d., întreaga integrală (adică forma pătratică originală) este \(0\) dacă și numai dacă \(s = 0\) și \(\vx\) are suport conținut în întregime într-un subspațiu afin care este ortogonal pe \(\vv\). Dar aceasta este exclusă prin presupunere (adică că \(\vx\) are o densitate pe \(\R^{D}\)), deci jacobianul \(\bar{\vx}^{\prime}(\vxi)\) este simetric pozitiv definit.
+\end{proof}
+
+\begin{lemma}[Generalizare a \cite{Gribonval2011-pf} Corolar A.2, Partea 1]\label{lem:gribonval_A2}
+    Fie \(f \colon \R^{D} \to \R^{D}\) orice funcție diferențiabilă al cărei jacobian \(f^{\prime}(\vx)\) este simetric pozitiv definit. Atunci \(f\) este injectivă, și prin urmare inversabilă ca funcție \(\R^{D} \to \Range(f)\) unde \(\Range(f)\) este imaginea lui \(f\).
+\end{lemma}
+\begin{proof}
+    Să presupunem că \(f\) nu ar fi injectivă, adică există \(\vx, \vx^{\prime}\) astfel încât \(f(\vx) = f(\vx^{\prime})\) în timp ce \(\vx \neq \vx^{\prime}\). Definim \(\vv \doteq (\vx^{\prime} - \vx)/\norm{\vx^{\prime} - \vx}_{2}\). Definim funcția \(g \colon \R \to \R\) ca \(g(t) \doteq \vv^{\top}f(\vx + t\vv)\). Atunci \(g(0) = \vv^{\top}f(\vx) = \vv^{\top}f(\vx^{\prime}) = g(\norm{\vx^{\prime} - \vx}_{2})\). Deoarece \(f\) este diferențiabilă, \(g\) este diferențiabilă, deci derivata \(g^{\prime}\) trebuie să se anuleze pentru un \(t^{\ast} \in (0, \norm{\vx^{\prime} - \vx}_{2})\) prin teorema valorii medii. Totuși,
+    \begin{equation}
+        g^{\prime}(t^{\ast}) \doteq \vv^{\top}\bs{f^{\prime}(\vx + t^{\ast}\vv)}\vv > 0
+    \end{equation}
+    deoarece jacobianul este pozitiv definit. Așadar ajungem la o contradicție, așa cum s-a afirmat.
+\end{proof}
+
+Combinând cele două rezultate de mai sus, obținem următorul rezultat crucial.
+
+\begin{corollary}[Generalizare a \cite{Gribonval2011-pf} Corolar A.2, Partea 2]\label{cor:gribonval_A2}
+    Fie \(\vx\) orice variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support,assumption:entropy_x_density} sunt valabile, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. Fie \(s, t \in [0, T]\) astfel încât \(0 \leq s < t \leq T\), și fie \(\bar{\vx}(\vxi) \doteq \Ex[\vx_{s} \mid \vx_{t} = \vxi]\). Atunci \(\bar{\vx}\) este injectivă, și prin urmare inversabilă pe imaginea sa.
+\end{corollary}
+\begin{proof}
+    Singurul lucru rămas de arătat este că \(\bar{\vx}\) este diferențiabilă, dar aceasta este imediat din formula lui Tweedie (\Cref{thm:tweedie}) care arată că \(\bar{\vx}\) este diferențiabilă dacă și numai dacă \(\nabla \log p_{t}\) este diferențiabilă, și aceasta este furnizată de \Cref{eq:p_t_representation}.
+\end{proof}
+
+\subsubsection{Controlul Laplacianului \(\Delta \log p_{t}\)}
+
+În final, dezvoltăm o estimare tehnică care este necesară pentru demonstrația \Cref{thm:conditioning_reduces_entropy} și motivează de fapt presupunerea pentru \(t\) viabil.
+
+\begin{lemma}\label{lem:app_diffusion_laplacian_control}
+    Fie \(\vx\) orice variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support,assumption:entropy_x_density} sunt valabile, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. Fie \(p_{t}\) densitatea lui \(\vx_{t}\). Atunci, pentru \(t > 0\) avem 
+    \begin{equation}
+        \sup_{\vxi \in \R^{D}}\abs{\Delta \log p_{t}(\vxi)} \leq \max\rp{\frac{D}{t^{2}}, \abs*{\frac{R^{2}}{t^{4}} - \frac{D}{t^{2}}}}.
+    \end{equation}
+\end{lemma}
+\begin{proof}
+    Prin regula lanțului, un exercițiu simplu calculează 
+    \begin{equation}
+        \Delta \log p_{t}(\vxi) = \frac{\Delta p_{t}(\vxi)}{p_{t}(\vxi)} - \frac{\norm{\nabla p_{t}(\vxi)}_{2}^{2}}{p_{t}(\vxi)^{2}}.
+    \end{equation}
+    Folosind \Cref{prop:p_t_derivatives} pentru a scrie termenii din \(\Delta p_{t}(\vxi)\), obținem
+    \begin{align}
+        \frac{\Delta p_{t}(\vxi)}{p_{t}(\vxi)}
+        &= \frac{\Ex\rs{\frac{\norm{\vxi - \vx}_{2}^{2} - Dt^{2}}{t^{4}} \cdot \phi_{t}(\vxi - \vx)}}{\Ex[\phi_{t}(\vxi - \vx)]} \\
+        &= \frac{\int_{\R^{D}}\bc{\frac{\norm{\vxi - \vu}_{2}^{2} - Dt^{2}}{t^{4}}}\phi_{t}(\vxi - \vu)p(\vu)\odif{\vu}}{\int_{\R^{D}}\phi_{t}(\vxi - \vu)p(\vu)\odif{\vu}}.
+    \end{align}
+    Aceasta arată ca o marginalizare bayesiană, deci să definim densitatea normalizată corespunzătoare
+    \begin{equation}
+        q_{\vxi}(\vu) = \frac{\phi_{t}(\vxi - \vu)p(\vu)}{\int_{\R^{D}}\phi_{t}(\vxi - \vv)p(\vv)\odif{\vv}} = \frac{\phi_{t}(\vxi - \vu)p(\vu)}{\Ex[\phi_{t}(\vxi - \vx)]} = \frac{\phi_{t}(\vxi - \vu)p(\vu)}{p_{t}(\vxi)}
+    \end{equation}
+    Apoi, definând \(\vy_{\vxi} \sim q_{\vxi}\), putem scrie 
+    \begin{equation}
+        \frac{\Delta p_{t}(\vxi)}{p_{t}(\vxi)} = \int_{\R^{D}}\bc{\frac{\norm{\vxi - \vu}_{2}^{2} - Dt^{2}}{t^{4}}}q_{\vxi}(\vu)\odif{\vu} = \frac{1}{t^{4}}\Ex[\norm{\vxi - \vy_{\vxi}}_{2}^{2}] - \frac{D}{t^{2}}.
+    \end{equation}
+    Similar, scriind al doilea termen (nepătrat) obținem
+    \begin{equation}
+        \frac{\nabla p_{t}(\vxi)}{p_{t}(\vxi)} = -\frac{\vxi - \Ex[\vy_{\vxi}]}{t^{2}}.
+    \end{equation}
+    Notând \(\vz_{\vxi} \doteq \vy_{\vxi} - \vxi\), avem
+    \begin{equation}
+        \frac{\Delta p_{t}(\vxi)}{p_{t}(\vxi)} = \frac{\Ex[\norm{\vz_{\vxi}}_{2}^{2}]}{t^{4}} - \frac{D}{t^{2}}, \qquad \frac{\nabla p_{t}(\vxi)}{p_{t}(\vxi)} = \frac{\Ex[\vz_{\vxi}]}{t^{2}}.
+    \end{equation}
+    Astfel scriind \(\Delta \log p_{t}\) complet, avem
+    \begin{align}
+        \Delta \log p_{t}(\vxi)
+        &= \frac{\Ex[\norm{\vz_{\vxi}}_{2}^{2}]}{t^{4}} - \frac{D}{t^{2}} - \frac{\norm{\Ex[\vz_{\vxi}]}_{2}^{2}}{t^{4}} \\
+        &= \frac{\Ex[\norm{\vz_{\vxi}}_{2}^{2}] - \norm{\Ex[\vz_{\vxi}]}_{2}^{2}}{t^{4}} - \frac{D}{t^{2}} \\
+        &= \frac{\tr(\Cov(\vz_{\vxi}))}{t^{4}} - \frac{D}{t^{2}} \\
+        &= \frac{\tr(\Cov(\vy_{\vxi}))}{t^{4}} - \frac{D}{t^{2}}.
+    \end{align}
+    O limită inferioară trivială pentru această urmă este \(0\), deoarece matricele de covarianță sunt pozitiv semidefinite. Pentru a găsi o limită superioară, observăm că \(\vy_{\vxi}\) ia valori doar în suportul lui \(\vx\) (deoarece \(p\) este un factor al densității \(q_{\vxi}\) a lui \(\vy_{\vxi}\)), care prin \Cref{assumption:entropy_x_compact_support} este o mulțime compactă \(\cS\) cu raza \(R \doteq \sup_{\vxi \in \R^{D}}\norm{\vxi}_{2}\). Deci
+    \begin{equation}
+        \tr(\Cov(\vy_{\vxi})) = \Ex[\norm{\vy_{\vxi}}_{2}^{2}] - \norm{\Ex[\vy_{\vxi}]}_{2}^{2} \leq \Ex[\norm{\vy_{\vxi}}_{2}^{2}] \leq R^{2}.
+    \end{equation}
+    Prin urmare
+    \begin{equation}
+        -\frac{D}{t^{2}} \leq \Delta \log p_{t}(\vxi) \leq \frac{R^{2}}{t^{4}} - \frac{D}{t^{2}},
+    \end{equation}
+    ceea ce demonstrează afirmația.
+\end{proof}
+
+\subsubsection{Calcule de Derivate}
+
+Aici calculăm unele derivate utile care vor fi reutilizate în întregul apendice.
+
+\begin{proposition}\label{prop:p_t_derivatives}
+    Fie \(\vx\) o variabilă aleatoare astfel încât \Cref{assumption:entropy_x_compact_support,assumption:entropy_x_density} sunt îndeplinite, și fie \((\vx_{t})_{t \in [0, T]}\) procesul stocastic \eqref{eq:app_additive_gaussian_noise_model}. Pentru \(t \geq 0\), fie \(p_{t}\) densitatea lui \(\vx_{t}\). Atunci
+    \begin{align}
+        \pdv{p_{t}}{t}(\vxi)
+        &= \Ex\rs{\phi_{t}(\vxi - \vx)\cdot\frac{\norm{\vxi - \vx}_{2}^{2} - Dt^{2}}{t^{3}}} \\
+        \nabla p_{t}(\vxi)
+        &= -\Ex\rs{\phi_{t}(\vxi - \vx)\cdot\frac{\vxi - \vx}{t^{2}}} \\
+        \nabla^{2}p_{t}(\vxi)
+        &= \Ex\rs{\phi_{t}(\vxi - \vx)\cdot\frac{(\vxi - \vx)(\vxi - \vx)^{\top} - t^{2}\vI}{t^{4}}} \\ 
+        \Delta p_{t}(\vxi)
+        &= \Ex\rs{\phi_{t}(\vxi - \vx)\cdot\frac{\norm{\vxi - \vx}_{2}^{2} - Dt^{2}}{t^{4}}}.
+    \end{align}
+\end{proposition}
+\begin{proof} 
+    Folosim reprezentarea prin convoluție a lui \(p_{t}\), anume \eqref{eq:p_t_representation}. Luând mai întâi derivata în timp, un calcul arată că \Cref{prop:dutis} se aplică,\footnote{Folosim \(f_{t}(\vxi) = p(\vxi) \phi_{t}(\vxi - \vx)\), observând că este de două ori continuu diferențiabilă în \(\vxi\) și (mai mult de) două ori continuu diferențiabilă în \(t\). Apoi pentru a verifica integrabilitatea locală a lui \(f_{t}\) calculăm \(\pdv{f_{t}}{t}(\vxi) = f_{t}(\vxi)\cdot \frac{1}{t^{3}}(\norm{\vxi - \vx}_{2}^{2} - Dt^{2})\), care este ușor de verificat integrabilă peste \(\vxi\) și \(t \in [t_{\min}, t_{\max}]\) unde \(t_{\min} > 0\). (Într-adevăr, \(f_{t}\) are cozi care scad exponențial, deci termenul pătratic din produs nu este o problemă.)} deci putem aduce derivata înăuntrul integralei/așteptării ca:
+    \begin{equation}
+        \pdv{p_{t}}{t}(\vxi) = \pdv*{\Ex[\phi_{t}(\vxi - \vx)]}{t} = \Ex\rs{\pdv*{\phi_{t}(\vxi - \vx)}{t}} = \pdv{\phi_{t}}{t} * p.
+    \end{equation}
+    Între timp, prin proprietățile convoluțiilor (\Cref{prop:diff_convolution}) și folosind faptul că \(p\) are suport compact (\Cref{assumption:entropy_x_compact_support}),
+    \begin{equation}
+        p_{t} = \phi_{t} * p \implies \nabla p_{t} = \nabla \phi_{t} * p \implies \nabla^{2}p_{t} = \nabla^{2}\phi_{t} * p \implies \Delta p_{t} = \Delta \phi_{t} * p.
+    \end{equation}
+    Restul calculului urmează din \Cref{prop:normal_derivatives}.
+\end{proof}
+
+
+\begin{proposition}\label{prop:normal_derivatives}
+    Pentru \(t > 0\) și \(\vxi \in \R^{D}\) avem
+    \begin{align}
+        \pdv*{\phi_{t}}{t}(\vxi)
+        &= \phi_{t}(\vxi) \cdot \frac{\norm{\vxi}_{2}^{2} - Dt^{2}}{t^{3}} \\
+        \nabla \phi_{t}(\vxi)
+        &= -\phi_{t}(\vxi)\cdot\frac{\vxi}{t^{2}} \\ 
+        \nabla^{2} \phi_{t}(\vxi)
+        &= \phi_{t}(\vxi)\cdot\frac{\vxi\vxi^{\top} - t^{2}\vI}{t^{4}} \\
+        \Delta \phi_{t}(\vxi)
+        &= \phi_{t}(\vxi) \cdot \frac{\norm{\vxi}_{2}^{2} - Dt^{2}}{t^{4}}.
+    \end{align}
+\end{proposition}
+\begin{proof}
+    Calcul direct.
+\end{proof}
+
+
+
+\subsubsection{Diferențierea Sub Semnul Integralei}
+
+În acest apendice, diferențiem sub semnul integralei de multe ori, și este important să știm când putem face acest lucru. Există două tipuri de diferențiere sub semnul integralei:
+\begin{enumerate}
+    \item Diferențierea unei integrale \(\int f_{t}(\vxi)\odif{\vxi}\) în raport cu parametrul auxiliar \(t\).
+    \item Diferențierea unei convoluții \((f * g)(\vxi) = \int f(\vxi)g(\vxi - \vu)\odif{u}\) în raport cu variabila \(\vxi\).
+\end{enumerate}
+
+Pentru prima categorie, oferim un rezultat concret, enunțat fără demonstrație dar atribuibil \href{https://planetmath.org/differentiationundertheintegralsign}{sursei link-uite}, care derivează următorul rezultat ca un caz special al unei teoreme mai generale despre interacțiunea operatorilor diferențiali și distribuțiilor temperate, mult dincolo de scopul cărții. O referință formală completă poate fi găsită în \cite{jones1982theory}.
+\begin{proposition}[\cite{jones1982theory}, Secțiunea 11.12]\label{prop:dutis}
+    Fie \(f \colon (0, T) \times \R^{D} \to \R\) astfel încât:
+    \begin{itemize}
+        \item \(f\) este o funcție măsurabilă în comun de \((t, \vxi)\);
+        \item Pentru aproape fiecare \(\vxi \in \R^{D}\) în sensul Lebesgue, funcția \(t \mapsto f_{t}(\vxi)\) este absolut continuă;
+        \item \(\pdv{f_{t}}{t}\) este local integrabilă, adică pentru fiecare \([t_{\min}, t_{\max}] \subseteq (0, T)\) avem
+        \begin{equation}
+            \int_{t_{\min}}^{t_{\max}}\int_{\R^{D}}\abs*{\pdv{f_{t}}{t}(\vxi)}\odif{\vxi} < \infty.
+        \end{equation}
+    \end{itemize}
+    Atunci \(t \mapsto \int_{\R^{D}}f_{t}(\vxi)\odif{\vxi}\) este o funcție absolut continuă pe \((0, T)\), și derivata sa este
+    \begin{equation}
+        \odv*{\int_{\R^{D}}f_{t}(\vxi)\odif{\vxi}}{t} = \int_{\R^{D}}\pdv*{f_{t}}{t}(\vxi)\odif{\vxi},
+    \end{equation}
+    definită pentru aproape fiecare \(t \in (0, T)\).
+\end{proposition}
+
+Pentru a doua categorie, oferim un alt rezultat concret, enunțat fără demonstrație dar complet formalizat în \cite{brezis2011functional}.
+\begin{proposition}[\cite{brezis2011functional}, Propoziția 4.20]\label{prop:diff_convolution}
+    Fie \(f\) de \(k\) ori continuu diferențiabilă cu suport compact, și fie \(g\) local integrabilă. Atunci convoluția \(f * g\) definită prin
+    \begin{equation}
+        (f * g)(\vxi) \doteq \int_{\R^{D}}f(\vu)g(\vxi - \vu)\odif{\vu}
+    \end{equation}
+    este de \(k\) ori continuu diferențiabilă, și derivata sa de ordinul \(k\) este
+    \begin{equation}
+        \nabla^{k}(f * g) =(\nabla^{k}f) * g. 
+    \end{equation}
+\end{proposition}
+Deși nu este în carte, un argument simplu de integrare prin părți arată că dacă \(g\) este și ea de \(k\) ori diferențiabilă, atunci putem "face schimb" de regularitate:
+\begin{equation}
+    \nabla^{k}(f * g) = f * (\nabla^{k} g).
+\end{equation}
+
+
+\section{Codare cu Pierderi și Împachetarea Sferelor}\label{app:rate-distortion-covering}
+
+În această secțiune, demonstrăm \Cref{thm:covering-number-rate-distortion}.
+Urmând convențiile noastre din acest apendice, scriem $\cS = \Supp(\vx)$
+pentru suportul compact al variabilei aleatoare $\vx$.
+
+După cum am anticipat, vom face o presupunere de regularitate asupra mulțimii suport $\cS$
+pentru a demonstra \Cref{thm:covering-number-rate-distortion}. O posibilitate pentru
+a proceda sub presupuneri minime ar fi să instanțiem rezultatele din
+\cite{Riegler2018-jh,Riegler2023-rr} în contextul nostru, deoarece aceste rezultate se aplică
+mulțimilor $\cS$ cu regularitate foarte scăzută (de exemplu, mulțimi de tip Cantor cu structură
+fractală). Cu toate acestea, am constatat că calcularea precisă a constantelor în aceste
+rezultate, o încercare necesară pentru a afirma o concluzie precum
+\Cref{thm:covering-number-rate-distortion}, este oarecum dificilă în contextul
+nostru.
+Abordarea noastră este, prin urmare, să adăugăm o presupunere de regularitate geometrică asupra
+mulțimii $\cS$ care sacrifică ceva generalitate, dar permite dezvoltarea
+unui argument mai transparent. Pentru a evita sacrificarea prea multă generalitate, trebuie
+să ne asigurăm că dimensionalitatea scăzută în mulțimea $\cS$ nu este interzisă.
+Prin urmare, considerăm exemplul curent pe care l-am folosit pe parcursul cărții,
+amestecul de distribuții gaussiene de rang mic. În acest cadru geometric, vom
+impune acest lucru presupunând că $\cS$ este o reuniune de hipersfere, ceea ce este
+echivalent cu presupunerea gaussiană în dimensiuni înalte cu probabilitate
+copleșitoare.
+
+\begin{assumption}\label{assumption:union-of-spheres}
+    Suportul $\cS \subset \R^D$ al variabilei aleatoare $\vx$ este o reuniune
+    finită de $K$ sfere, fiecare cu dimensiunea $d_k$, $k \in [K]$.
+    Probabilitatea ca $\vx$ să fie extrasă din a $k$-a sferă este dată de
+    $\pi_k \in [0, 1]$, și condiționat de a fi extrasă din a $k$-a sferă,
+    $\vx$ este distribuită uniform pe acea sferă.
+    Suporturile satisfac că fiecare sferă este mutual ortogonală cu toate
+    celelalte.
+\end{assumption}
+
+Procedăm sub \Cref{assumption:union-of-spheres} simplificatoare pentru a
+simplifica tehnicitatea excesivă și pentru a ne conecta la un exemplu important
+folosit pe parcursul monografiei. Credem că rezultatele noastre pot fi generalizate la
+suportul $\cS$ din clasa \textit{mulțimilor cu atingere pozitivă} cu
+efort tehnic suplimentar, dar lăsăm acest lucru pentru viitor.
+
+
+
+
+\subsection{Demonstrația Relației Dintre Distorsiunea Ratei și Acoperire}
+
+Schițăm pe scurt demonstrația, apoi procedăm la stabilirea a trei leme
+fundamentale, apoi dăm demonstrația. Demonstrația va depinde de noțiunile introduse în
+schița de mai jos.
+
+Obținerea unei limite superioare pentru funcția de distorsiune a ratei
+\eqref{eqn:rate-distortion-general} este simplă: prin caracterizarea ratei
+(adică, funcția de distorsiune a ratei este rata minimă a
+unui cod pentru $\vx$ cu distorsiune $\ell^2$ pătrată așteptată $\epsilon$), limitarea
+superioară a $\cR_{\epsilon}(\x)$ necesită doar demonstrarea unui cod pentru $\x$ care
+atinge această distorsiune țintă, și orice $\epsilon$-acoperire a $\Supp(\x)$
+realizează acest lucru, cu rata egală cu logaritmul în baza 2 al cardinalității
+acoperirii.
+Limita inferioară este mai subtilă. Facem uz de limita inferioară Shannon,
+discutată în \Cref{rem:slb}: calcularea constantelor în \cite[\S III,
+(22)]{Linder1994-ej} oferă o versiune mai precisă a rezultatului citat în
+\Cref{eq:slb} (în biți, desigur): pentru orice variabilă aleatoare $\vx$ cu suport
+compact și o densitate, avem
+\begin{equation}\label{eq:slb-appendix-1}
+    \cR_{\epsilon}(\x)
+    \geq
+    h(\x)
+    - \log \volume(B_{\epsilon})
+    +
+    \log
+    \left(
+    \frac{
+    	2
+    }
+    {
+    	D \Gamma(D/2)
+    }
+    \left(
+    \frac{
+    	D
+    }
+    {
+    	2e
+    }
+    \right)^{D/2}
+    \right),
+\end{equation}
+cu entropia (etc.) în nats în această expresie.
+Constanta poate fi estimată ușor folosind aproximația lui Stirling.
+O formă cantitativă a aproximației lui Stirling care este adesea utilă dă
+pentru orice $x > 0$ \cite{Jameson2015-hy}
+\begin{equation}
+    \Gamma(x) \leq \sqrt{2\pi} x^{x - 1/2} e^{-x} e^{1/(12x)}.
+\end{equation}
+Vom aplica această limită la $\Gamma(D/2)$ în \Cref{eq:slb-appendix-1}.
+Obținem
+\begin{align}
+    \log
+    \left(
+    \frac{
+        2
+    }
+    {
+        D \Gamma(D/2)
+    }
+    \left(
+    \frac{
+        D
+    }
+    {
+        2e
+    }
+    \right)^{D/2}
+    \right)
+    &\geq
+    -\frac{1}{6D}
+    +
+    \log\left(
+        \frac{2}{D} 
+        \left(
+        \frac{
+            D
+        }
+        {
+            2e
+        }
+        \right)^{D/2}
+        \cdot
+        \sqrt{\frac{D}{4\pi}}
+        \left(
+        \frac{D}{2e}
+        \right)^{-D/2}
+    \right)
+    \\
+    &=
+    -\frac{1}{6D}
+    - \frac{1}{2}\log D\pi,\label{eq:slb-constant-est}
+\end{align}
+pe care o putem lua pentru valoarea explicită a constantei $C_D$ în \Cref{eq:slb}.
+Rezumând limita inferioară Shannon complet cuantificată (în biți):
+\begin{equation}\label{eq:slb-appendix}
+    \cR_{\epsilon}(\x)
+    \geq
+    h(\x)
+    - \log_2 \volume(B_{\epsilon})
+    - O(\log D).
+\end{equation}
+
+Acum, constrângerea importantă pentru scopurile noastre actuale este că limita inferioară
+Shannon necesită ca variabila aleatoare $\vx$ să aibă o densitate, ceea ce exclude multe
+distribuții de interes cu dimensionalitate scăzută.
+Dar să luăm în considerare momentan situația când $\vx$ admite o densitate.
+Presupunerea că $\vx$ este distribuită uniform pe suportul său este ușor
+formalizată în acest cadru: pentru orice mulțime Borel $A \subset \cS$, avem
+\begin{equation}
+    \Pr[\vx \in A] = \int_{A} \frac{1}{\volume(\cS)} \odif \vx.
+\end{equation}
+Atunci entropia $h(\vx)$ este doar
+\begin{equation}
+    h(\vx) = \log_2 \volume(\cS).
+\end{equation}
+Demonstrația se încheie apoi cu o lemă care leagă raportul $\volume(\cS)
+/ \volume(B_{\epsilon})$ de numărul de $\epsilon$-acoperire a $\cS$ cu
+bile de rază $\epsilon$.
+
+
+Pentru a extinde programul de mai sus la distribuții degenerate care satisfac
+\Cref{assumption:union-of-spheres},
+demonstrația noastră a limitei inferioare în \Cref{thm:covering-number-rate-distortion} va
+folosi un argument de aproximare a distribuției actuale cu dimensionalitate
+scăzută $\vx$ prin distribuții "apropiate" care au
+densități, similar dar nu exact la fel ca schița demonstrației care precede \Cref{thm:max_entropy}.
+Vom lega apoi parametrul introdus în
+secvența de aproximare de parametrul de distorsiune $\epsilon$ pentru a
+obține concluzia dorită în \Cref{thm:covering-number-rate-distortion}.
+
+
+\begin{definition}\label{def:thickening-set}
+    Fie $\cS$ o mulțime compactă.
+    Pentru orice $\delta > 0$, definim $\delta$-îngroșarea lui $\cS$, notată
+    $\cS_{\delta}$, prin
+    \begin{equation}
+        \cS_{\delta} = \set*{\vxi \in \R^D \given \mathrm{dist}(\vxi, \cS) \leq
+        \delta}.
+    \end{equation}
+\end{definition}
+Funcția de distanță referită în \Cref{def:thickening-set} este definită prin
+\begin{equation}\label{eq:dist-func}
+    \dist(\vxi, \cS) = \inf_{\vxi' \in \cS} \norm*{\vxi - \vxi'}_2.
+\end{equation}
+Pentru o mulțime compactă $\cS$, teorema lui Weierstrass implică că pentru orice $\vxi \in
+\R^D$, există întotdeauna un $\vxi' \in \cS$ care atinge infimumul în funcția de
+distanță.
+Compactitatea lui $\cS_{\delta}$ rezultă imediat din compactitatea lui $\cS$, deci
+$\volume(\cS_{\delta})$ este finit pentru orice $\delta > 0$. Este atunci posibil să
+facem următoarea definiție a unei variabile aleatoare îngroșate, specializată la
+\Cref{assumption:union-of-spheres}.
+
+
+\begin{definition}\label{def:thickening-rv-uos}
+    Fie $\vx$ o variabilă aleatoare astfel încât $\Supp(\vx) = \cS$ este o reuniune de
+    $K$ hipersfere, distribuită ca în \Cref{assumption:union-of-spheres}.
+    Notăm suportul fiecărei componente a amestecului cu $\cS_k$.
+    Definim variabila aleatoare îngroșată $\vx_{\delta}$ ca amestecul de
+    măsuri unde fiecare măsură componentă este uniformă pe mulțimea îngroșată
+    $\cS_{k, \delta}$ (\Cref{def:thickening-set}), pentru $k \in [K]$, cu ponderi de
+    amestecare $\pi_k$.
+\end{definition}
+
+
+\begin{lemma}\label{lem:rate-distortion-lb-uos}
+    Presupunem că variabila aleatoare $\vx$ satisface
+    \Cref{assumption:union-of-spheres}. Atunci dacă $0 < \delta < \tfrac{1}{2}$,
+    variabila aleatoare îngroșată $\vx_{\delta}$ (\Cref{def:thickening-rv-uos})
+    satisface pentru orice $\epsilon > 0$
+    \begin{equation}
+        R_{\delta + \epsilon}(\vx_{\delta})
+        \leq
+        R_{\epsilon}(\vx).
+    \end{equation}
+\end{lemma}
+
+Demonstrația \Cref{lem:rate-distortion-lb-uos} este amânată la
+\Cref{sec:app-rate-dist-deferred-proofs}.
+Folosind \Cref{lem:rate-distortion-lb-uos}, programul de mai sus poate fi realizat,
+deoarece variabila aleatoare $\vx_{\delta}$ are o densitate care este uniformă în
+raport cu măsura Lebesgue.
+
+\begin{proof}[(Demonstrația \Cref{thm:covering-number-rate-distortion})]
+    Limita superioară este ușor de arătat. Dacă $S$ este orice $\epsilon$-acoperire a
+    suportului lui $\vx$ cu cardinalitate $\cN_{\epsilon}(\Supp(\vx))$, atunci considerăm
+    schema de codare care atribuie fiecărui $\vxi \in \Supp(\vx)$ reconstrucția
+    $\hat{\vxi} = \argmin_{\vxi' \in S}\, \norm{\vxi - \vxi'}_2$, cu egalitățile
+    rezolvate arbitrar. Atunci egalitățile apar cu probabilitate zero, și faptul că
+    $S$ acoperă $\Supp(\vx)$ la scara $\epsilon$ garantează distorsiune nu mai mare
+    decât $\epsilon$; rata acestei scheme este $\log_2 \cN_{\epsilon}(\Supp(\vx))$.
+
+    Pentru limita inferioară, fie $0 < \delta < \tfrac{1}{2}$, și considerăm
+    variabila aleatoare îngroșată $\vx_{\delta}$. Prin
+    \Cref{lem:rate-distortion-lb-uos}, avem
+    \begin{equation}
+        R_{\delta + \epsilon}(\vx_{\delta})
+        \leq
+        R_{\epsilon}(\vx).
+    \end{equation}
+    Deoarece $\vx_{\delta}$ are o densitate Lebesgue care este uniformă, putem apoi
+    aplica limita inferioară Shannon, în forma \eqref{eq:slb-appendix}, pentru a obține
+    \begin{equation}\label{eq:slb-proof}
+        \log_2 \volume(\Supp(\vx_{\delta}))
+        - \log_2 \volume(B_{\delta + \epsilon})
+        - O(\log D)
+        \leq
+        R_{\epsilon}(\vx).
+    \end{equation}
+    În final, trebuie să limităm inferior raportul
+    \begin{equation}
+        \frac{
+            \volume(\Supp(\vx_{\delta}))
+        }
+        {
+            \volume(B_{\delta + \epsilon})
+        }
+    \end{equation}
+    în termeni de numărul de acoperire.
+    Deoarece $\Supp(\vx_{\delta}) = \Supp(\vx) + B_{\delta}$, unde $+$ aici
+    denotă suma Minkowski, o aplicație standard a argumentelor de limită de volum
+    (vezi de exemplu \cite[Propoziția 4.2.12]{Vershynin2018-br}) dă
+    \begin{equation}
+        \volume(\Supp(\vx_{\delta}))
+        \geq
+        \cN_{2\delta}(\Supp(\vx))
+        \volume(B_{\delta}).
+    \end{equation}
+    Prin urmare
+    \begin{align}
+        \frac{
+            \volume(\Supp(\vx_{\delta}))
+        }
+        {
+            \volume(B_{\delta + \epsilon})
+        }
+        &\geq
+        \cN_{2\delta}(\Supp(\vx))
+        \frac{
+            \volume(B_{\delta})
+        }
+        {
+            \volume(B_{\delta + \epsilon})
+        }
+        \\
+        &=
+        \cN_{2\delta}(\Supp(\vx))
+        \left(
+            \frac{
+                \delta
+            } 
+            {
+                \delta + \epsilon
+            }
+        \right)^D.
+    \end{align}
+    Alegând $\delta = \epsilon / 2$ obținem din limita inferioară Shannon
+    \eqref{eq:slb-proof} și estimările de mai sus
+    \begin{equation}
+        \log_2 \cN_{\epsilon}(\Supp(\vx))
+        - O(D)
+        \leq
+        R_{\epsilon}(\vx),
+    \end{equation}
+    ceea ce trebuia demonstrat.
+
+\end{proof}
+
+
+
+\subsection{Demonstrația Lemei \ref{lem:rate-distortion-lb-uos}}\label{sec:app-rate-dist-deferred-proofs}
+
+\begin{proof}[(Demonstrația \Cref{lem:rate-distortion-lb-uos})]
+    Este suficient să arătăm că orice cod pentru $\vx$ cu distorsiune pătrată așteptată
+    $\epsilon^2$ produce un cod pentru $\vx_{\delta}$ cu aceeași rată și
+    distorsiune nu mult mai mare, pentru o alegere potrivită a lui $\delta$.
+    Deci fixăm un astfel de cod pentru $\vx$, obținând rata $R$ și distorsiune pătrată
+    așteptată $\epsilon^2$. Scriem $\hat{\vx}$ pentru variabila aleatoare
+    reconstruită folosind acest cod, și $\mathrm{q} : \Supp(\vx) \to \Supp(\vx)$
+    pentru maparea asociată de codare-decodare (adică, $\hat{\vx}
+    = \mathrm{q}(\vx)$).
+
+    Acum fie $\cS_k$ a $k$-a hipersferă în suportul lui $\vx$.
+    Există o bază ortonormală $\vU_{k} \in \R^{D \times d_k}$ astfel încât
+    $\Span(\cS_k) = \Span(\vU_k)$.
+    Următoarea descompunere ortogonală a mulțimii suport $\cS$
+    va fi folosită repetat pe parcursul demonstrației.
+    Avem
+    \begin{align}
+        \cS_{\delta} 
+        &= \set{\vxi \in \R^D \given \exists k \in [K] \::\: \dist(\vxi,
+        \cS_k) \leq \delta}
+        \\
+        &= \bigcup_{k \in [K]} \set{\vxi \in \R^D \given \dist(\vxi,
+        \cS_k) \leq \delta}.
+    \end{align}
+    Prin proiecție ortogonală, pentru orice $k \in [K]$ orice $\vxi \in \R^D$ poate fi
+    scris ca $\vxi = \vxi^{\|} + \vxi^{\perp}$, cu $\vxi^{\|} \in \Span(\cS_k)$
+    și $\ip{\vxi^{\|}}{\vxi^\perp} = 0$.
+    Atunci pentru orice $\vxi' \in \cS_k$, avem
+    \begin{align}
+        \norm*{\vxi - \vxi'}_2^2 
+        = 
+        \norm*{\vxi^{\|} + \vxi^{\perp} - \vxi'}_2^2
+        &=
+        \norm*{\vxi^{\|}}_2^2 + \norm*{\vxi^{\perp}}_2^2 + \norm*{\vxi'}_2^2
+        - 2 \ip*{\vxi^{\|}}{\vxi'}
+        \\
+        &\geq
+        \norm*{\vxi^{\|}}_2^2 + \norm*{\vxi'}_2^2
+        - 2 \ip*{\vxi^{\|}}{\vxi'}
+        \\
+        &=
+        \norm*{\vxi^{\|} - \vxi'}_2^2.
+    \end{align}
+    Mai mult, se știe că pentru orice $\vxi^{\|} \in \Span(\cS_k)$ nenul,
+    \begin{equation}
+        \inf_{\vxi' \in \cS_k}\,
+        \norm*{\vxi^{\|} - \vxi'}_2^2
+        =
+        \norm*{\vxi^{\|} - \frac{\vxi^{\|}}{\norm{\vxi^{\|}}_2}}_2^2.
+    \end{equation}
+    Dacă $\vxi^{\|}$ este zero, este clar că distanța de mai sus este egală cu $1$
+    pentru fiecare $\vxi' \in \cS_k$.
+    Prin urmare, dacă definim o mapare de proiecție
+    $\pi_{\cS_k}(\vxi)$
+    prin
+    \begin{equation}
+        \pi_{S_k}(\vxi) = \frac{\vU_k\vU_k^\top \vxi}{\norm{\vU_k^\top \vxi}_2}
+    \end{equation}
+    pentru orice $\vxi \in \R^D$ cu $\vU_k^\top \vxi \neq \mathbf{0}$, atunci
+    $\pi_{\cS_k}(\vxi) = \argmin_{\vxi' \in \cS_k}\norm*{\vxi' - \vxi}_2$.
+    Alegem $0 < \delta < 1$, astfel încât mulțimea îngroșată $\cS_{\delta}$
+    să nu conțină puncte $\vxi \in \R^D$ la care oricare dintre mapările de proiecție
+    $\pi_{\cS_k}$ nu este bine definită.
+    Deci mulțimea îngroșată $\cS_{\delta}$ satisface
+    \begin{align}
+        \cS_{\delta} 
+        &= \bigcup_{k \in [K]} \set*{\vxi \in \R^D \given 
+        \norm*{\vxi - \frac{\vU_k\vU_k^\top \vxi}{\norm{\vU_k^\top \vxi}_2}}_2
+        \leq \delta}.
+    \end{align}
+    Aceste distanțe pot fi rescrise în termenii descompunerii ortogonale ca
+    \begin{align}
+        \norm*{\vxi - \frac{\vU_k\vU_k^\top \vxi}{\norm{\vU_k^\top \vxi}_2}}_2^2
+        &=
+        \norm*{\vxi}_2^2 - 2 \norm{\vU_k^\top \vxi}_2 + 1
+        \\
+        &=
+        \norm*{\vxi^{\|}}_2^2 
+        + \norm*{\vxi^{\perp}}_2^2
+        - 2 \norm{\vU_k^\top \vxi^{\|}}_2 + 1
+        \\
+        &=
+        \norm*{\vxi^{\perp}}_2^2
+        + \left( \norm*{\vxi^{\|}}_2 - 1 \right)^2.
+        \label{eq:distance-to-hypersphere}
+    \end{align}
+    Vom arăta în continuare că fiecare astfel de $\vxi \in \cS_{\delta}$ poate fi
+    asociat unic cu o proiecție pe un singur subspațiu în amestec,
+    ceea ce ne va permite să definim o proiecție corespunzătoare pe $\cS$.
+    Dat un $\vxi \in \cS_{\delta}$, prin cele de mai sus, putem găsi un subspațiu
+    $\vU_k$ astfel încât descompunerea ortogonală $\vxi = \vxi^{\|}_k
+    + \vxi^{\perp}_k$ satisface
+    \begin{equation}
+        \norm*{\vxi^{\perp}_k}_2^2
+        + \left( \norm*{\vxi^{\|}_k}_2 - 1 \right)^2
+        \leq
+        \delta^2.
+    \end{equation}
+    Considerăm descompunerea $\vxi = \vxi_j^{\|} + \vxi_j^{\perp}$ pentru un $j
+    \neq k$. Avem
+    \begin{align}
+        \norm*{\vxi_j^{\|}}_2
+        =
+        \norm*{
+            \vU_j \vU_j^\top \vxi 
+        }_2
+        &=
+        \norm*{
+            \vU_j \vU_j^\top( \vU_k \vU_k^\top \vxi + (\vI - \vU_k \vU_k^\top)
+            \vxi )
+        }_2
+        \\
+        &=
+        \norm*{
+            \vU_j \vU_j^\top (\vI - \vU_k \vU_k^\top) \vxi
+        }_2
+        \\
+        &\leq
+        \norm*{
+            (\vI - \vU_k \vU_k^\top) \vxi
+        }_2
+        =
+        \norm*{
+            \vxi_k^{\perp}
+        }_2
+        \leq \delta,
+    \end{align}
+    unde a doua linie folosește presupunerea de ortogonalitate asupra subspațiilor
+    $\vU_k$, și a treia folosește faptul că proiecțiile ortogonale sunt
+    neexpansive.
+    Prin urmare, a $j$-a distanță satisface
+    \begin{equation}
+        \norm*{\vxi^{\perp}_j}_2^2
+        + \left( \norm*{\vxi^{\|}_j}_2 - 1 \right)^2
+        \geq
+        (1 - \delta)^2.
+    \end{equation}
+    Aceasta implică că dacă $0 < \delta < 1/2$, fiecare $\vxi \in \cS_{\delta}$ are
+    un subspațiu cel mai apropiat unic în amestec.
+    Prin urmare, sub această condiție, următoarea mapare $\pi_{\cS} : \cS_{\delta}
+    \to \cS$ este bine definită:
+    \begin{equation}
+        \pi_{\cS}(\vxi) 
+        =
+        \pi_{\cS_{k_\star}}(\vxi),
+        \enspace\text{unde}\enspace
+        k_{\star} = \argmin_{k \in [K]}\,
+        \dist(\vxi, \cS_{k}).
+    \end{equation}
+
+
+    Acum, definim un cod pentru $\vx_{\delta}$ prin
+    \begin{equation}
+        \hat{\vx}_{\delta} = \mathrm{q}( \pi_{\cS}(\vx_{\delta}) ).
+    \end{equation}
+    În mod clar aceasta este asociată cu un cod de rată $R$ pentru $\vx_{\delta}$, deoarece
+    folosește mapările de codare-decodare din codul de rată $R$ pentru $\vx$. Trebuie
+    să arătăm că atinge distorsiune mică.
+    Calculăm
+    \begin{align}
+        \bE\left[ \norm*{ \vx_{\delta} - \hat{\vx}_{\delta} }_2^2 \right]
+        &=
+        \bE\left[ \norm*{ \vx_{\delta} - \mathrm{q}(\pi_{\cS}(\vx_{\delta})) }_2^2 \right]
+        \\
+        &\leq
+        \left(
+        \bE\left[ \norm*{ \vx_{\delta} - \pi_{\cS}(\vx_{\delta}) }_2^2
+        \right]^{1/2}
+        + \bE\left[ \norm*{ \pi_{\cS}(\vx_{\delta})
+        - \mathrm{q}(\pi_{\cS}(\vx_{\delta})) }_2^2 \right]^{1/2}
+        \right)^2,\label{eq:distortion-decomposition}
+    \end{align}
+    unde inegalitatea folosește inegalitatea Minkowski.
+    Acum, prin \Cref{def:thickening-set,def:thickening-rv-uos}, avem
+    determinist
+    \begin{equation}
+        \norm*{ \vx_{\delta} - \pi_{\cS}(\vx_{\delta}) }_2^2
+        \leq \delta^2,
+    \end{equation}
+    deci așteptarea satisface și această estimare.
+    Pentru al doilea termen, va fi suficient să caracterizăm densitatea
+    variabilei aleatoare $\pi_{\cS}(\vx_{\delta})$ ca fiind suficient de aproape de
+    densitatea lui $\vx$---care, așa cum implică \Cref{assumption:union-of-spheres}, este
+    un amestec de distribuții uniforme pe fiecare sub-sferă $\cS_k$.
+    Prin argumentul de mai sus, fiecare punct $\vxi \in \cS_{\delta}$ poate fi asociat
+    cu unul și numai un subspațiu $\vU_k$, ceea ce înseamnă că componentele
+    amestecului în definiția lui $\cS_{\delta}$ (amintiți-vă
+    \Cref{def:thickening-rv-uos}) nu se suprapun. Prin urmare, densitatea
+    $\pi_{\cS}(\vx_{\delta})$ poate fi caracterizată studiind efectul lui
+    $\pi_{\cS_k}$ asupra variabilei aleatoare condiționate $\vx_{\delta}$, condiționată
+    să fie extrasă din $\cS_{k, \delta}$. Notăm această măsură cu $\mu_{k,
+    \delta}$.
+    Afirmăm că împingerea înainte a acestei măsuri sub $\pi_{\cS_k}$ este uniformă pe $\cS_k$.
+    Pentru a vedea că aceasta este valabilă, ne amintim
+    \Cref{eq:distance-to-hypersphere},
+    care dă caracterizarea
+    \begin{equation}
+        \cS_{k, \delta} = \set*{
+            \vxi^{\|} + \vxi^{\perp} 
+            \given 
+            \vxi^{\|} \in \Span(\vU_k),
+            \vxi^{\perp} \in \Span(\vU_k)^\perp,
+            \norm*{\vxi^{\perp}}_2^2
+            + \left( \norm*{\vxi^{\|}}_2 - 1 \right)^2
+            \leq
+            \delta
+        }.
+    \end{equation}
+    Distribuția condiționată în discuție este uniformă pe această mulțime; trebuie să
+    arătăm că proiecția $\pi_{\cS_k}$ aplicată acestei variabile aleatoare
+    condiționate produce o variabilă aleatoare care este uniformă pe $\cS_k$.
+    În raport cu aceste coordonate, am văzut că $\pi_{\cS_k}(\vxi^\|
+    + \vxi^\perp) = \vxi^\| / \norm{\vxi^{\|}}_2$.
+    Prin urmare, pentru orice $\vxi \in \cS_{k}$, avem că preimaginea lui $\vxi$ în
+    $\cS_{k, \delta}$ sub $\pi_{\cS_k}$ este
+    \begin{equation}
+        \pi_{\cS_k}^{-1}(\vxi) = \set*{
+            r\vxi + \vxi^\perp 
+            \given
+            r > 0,
+            \vxi^{\perp} \in \Span(\vU_k)^\perp,
+            \norm*{\vxi^{\perp}}_2^2
+            + \left( r - 1 \right)^2
+            \leq
+            \delta
+        }.
+        \label{eq:fiber-of-uos}
+    \end{equation}
+    Pentru a arăta că $(\pi_{\cS_k})_{\sharp} \mu_{k, \delta}$ este uniformă, trebuie să
+    descompunem integrala densității uniforme pe $\cS_{k, \delta}$ într-un mod
+    care face clar că fiecare dintre fibrele
+    $\pi_{\cS_k}^{-1}(\vxi)$ (pentru fiecare $\vxi \in \cS_k$) "contribuie" în mod egal
+    la integrală.\footnote{Mai riguros, aceasta corespunde descompunerii
+    densității uniforme pe $\cS_{k, \delta}$ într-o densitate condiționată regulată
+    corespunzătoare lui $\vxi \in \cS_{k}$, și arătând că densitatea
+    corespunzătoare pe $\vxi$ este uniformă. Demonstrația face clar că aceasta este adevărat.}
+    Avem prin \Cref{def:thickening-rv-uos}
+    \begin{equation}
+        \volume(\cS_{k, \delta})
+        = \iint_{\Span(\vU_k) \times \Span(\vU_k)^\perp} \mathbf{1}_{
+            \norm*{\vxi^{\perp}}_2^2
+            + \left( \norm*{\vxi^{\|}}_2 - 1 \right)^2
+            \leq
+            \delta
+        }
+        \odif \vxi^{\|} \odif \vxi^{\perp}.
+    \end{equation}
+    În particular, integrarea peste coordonatele ortogonale se factorizează.
+    Fie $\odif \vtheta^{d}$ măsura uniformă (Haar) pe sfera de
+    rază $1$ în $\R^d$. Convertind integrala $\vxi^{\|}$ în coordonate
+    polare, avem
+    \begin{equation}
+        \volume(\cS_{k, \delta})
+        = \int_{[0, \infty)} \int_{\bS^{d_k-1}} \int_{\Span(\vU_k)^\perp} 
+        r^{d_k-1}
+        \mathbf{1}_{
+            \norm*{\vxi^{\perp}}_2^2
+            + \left( r - 1 \right)^2
+            \leq
+            \delta
+        }
+        \odif r \odif \vtheta^{d_k} \odif \vxi^{\perp}.
+    \end{equation}
+    Comparând cu reprezentarea fibrei \eqref{eq:fiber-of-uos},
+    vedem că trebuie să "integrăm" peste componentele $r$ și $\vxi^\perp$
+    ale integralei precedente pentru a verifica că împingerea înainte
+    este uniformă.
+    Dar aceasta este evidentă, deoarece expresia anterioară arată că valoarea acestei
+    integrale este independentă de $\vxi^\|$---sau, echivalent în context,
+    valoarea componentei sferice $\vtheta^{d_k}$.
+
+    Astfel rezultă din argumentul de mai sus că $\pi_{\cS}(\vx_{\delta})$ este
+    uniformă.
+    Deoarece presupunerea asupra lui $\delta$ implică că componentele amestecului în
+    distribuția lui $\vx_{\delta}$ nu se suprapun, ponderile de amestecare
+    $\pi_k$ sunt de asemenea păstrate în imaginea $\pi_{\cS}(\vx_{\delta})$, și în
+    particular, distribuția lui $\pi_{\cS}(\vx_{\delta})$ este egală cu
+    distribuția lui $\vx$.
+    Prin urmare, al doilea termen în \Cref{eq:distortion-decomposition} satisface
+    \begin{equation}
+        \bE\left[ \norm*{ \pi_{\cS}(\vx_{\delta}) - \mathrm{q}(\pi_{\cS}(\vx_{\delta})) }_2^2 \right]
+        =
+        \bE\left[ \norm*{ \vx - \mathrm{q}(\vx) }_2^2 \right]
+        \leq
+        \epsilon^2,
+    \end{equation}
+    deoarece $\mathrm{q}$ este un cod cu distorsiune $\epsilon$ pentru $\vx$.
+
+    Am arătat astfel că codul ipotezat de rată $R$, distorsiune (pătrată așteptată)
+    $\epsilon^2$ pentru $\vx$ produce un cod de rată $R$, distorsiune (pătrată
+    așteptată) $\delta + \epsilon$ pentru $\vx_{\delta}$.
+    Aceasta stabilește că
+    \begin{equation}
+        R_{\delta + \epsilon}(\vx_{\delta})
+        \leq
+        R_{\epsilon}(\vx),
+    \end{equation}
+    ceea ce trebuia demonstrat.
+
+
+\end{proof}
+
+\end{document}

--- a/chapters/chapter1/introduction_ro.tex
+++ b/chapters/chapter1/introduction_ro.tex
@@ -1,0 +1,981 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{O Introducere Informală}
+\label{ch:intro}
+
+\begin{quote}
+``{\em Așa cum creșterea constantă a entropiei este legea de bază a universului, tot așa este legea de bază a vieții să fie din ce în ce mai structurată și să lupte împotriva entropiei.}''
+
+$~$\hfill -- V\'{a}clav Havel
+\end{quote}
+\vspace{5mm}
+
+
+
+\section{Inteligență, Cibernetică și Inteligență Artificială}
+Lumea în care trăim nu este nici complet aleatorie, nici complet imprevizibilă.\footnote{Notați că nu există nicio nevoie ca o ființă inteligentă să învețe sau să memoreze ceva dacă lumea este complet aleatorie.} În schimb, urmează anumite ordini, tipare și legi care o fac în mare parte previzibilă.\footnote{Unele deterministe și altele probabilistice.} Însăși apariția și existența vieții depind de un mediu de viață previzibil. Doar învățând și memorând ceea ce este previzibil în mediu poate viața să supraviețuiască și să prospere, deoarece deciziile și acțiunile bune depind de predicții fiabile. Deoarece pare să existe un număr nelimitat de lucruri care sunt previzibile despre lume, ființele inteligente, cum ar fi animalele și oamenii, au continuat să-și îmbunătățească prin evoluție capacitatea de a explora și exploata această predictibilitate pentru o viață din ce în ce mai bună. În acest scop, au dezvoltat simțuri din ce în ce mai acute, inclusiv vedere, auz, atingere, gust și miros, pentru a percepe ceea ce este previzibil în mediul extern din aceste date senzoriale cu randament ridicat. Prin urmare, o sarcină fundamentală pentru toate ființele inteligente este să poată:
+\begin{center}
+    {\em învăța și memoriza informații previzibile din date masive percepute.}
+\end{center}
+Înainte de a putea începe să înțelegem cum se face acest lucru, trebuie să luăm în considerare câteva întrebări conexe:
+\begin{itemize}
+    \item Cum să modelăm și să reprezentăm matematic astfel de informații previzibile în date?
+    \item Cum pot fi învățate astfel de informații eficient și eficace din date din punct de vedere computațional?
+    \item Cum ar trebui organizate cel mai bine astfel de informații pentru predicții și inferențe viitoare?
+\end{itemize}
+Această carte își propune să ofere câteva răspunsuri la aceste întrebări. Aceste răspunsuri ne vor ajuta să înțelegem mai bine inteligența, în special principiile și mecanismele computaționale care o fac posibilă. Există motive să credem că toate formele de inteligență, de la inteligența de nivel scăzut observată în viața primitivă timpurie până la cea mai înaltă formă de inteligență, practica științei moderne, urmează același set de principii și mecanisme. Vom elabora mai multe mai jos.
+
+\paragraph{Apariția și evoluția inteligenței.}
+
+O condiție necesară pentru apariția vieții pe Pământ acum aproximativ 4 miliarde de ani este că mediul Pământului este în mare parte previzibil. În mediu, viața a dezvoltat mecanisme care îi permit să învețe ceea ce este previzibil despre mediu, să codifice informația într-un anumit mod și să o folosească pentru supraviețuire. În general, numim această abilitate de a învăța {\em inteligență}. Într-o mare măsură, evoluția vieții este mecanismul inteligenței la lucru. În natură, inteligența este dezvoltată în principal prin două tipuri de mecanisme de învățare: {\em filogenetic} și {\em ontogenetic} \cite{Wiener-Cybernetics-1961}.
+
+{\em Inteligența filogenetică} se referă la învățarea prin evoluția speciilor. Speciile moștenesc și supraviețuiesc în principal pe baza cunoștințelor moștenite din ADN-ul sau genele părinților lor. Într-o mare măsură, putem numi ADN-ul modelele mari pre-antrenate ale naturii, deoarece joacă un rol foarte similar. Caracteristica principală a inteligenței filogenetice este că indivizii nu au multă capacitate de învățare. Învățarea se realizează cu un mecanism de „încercare și eroare" bazat pe mutația aleatorie a genelor, iar apoi speciile evoluează pe baza procesului de selecție naturală -- supraviețuirea celui mai apt, așa cum este prezentat în \Cref{fig:phylogenetic}.
+Aceasta poate fi văzută ca modul naturii de a implementa ceea ce este acum cunoscut sub numele de „învățare prin întărire". Cu toate acestea, un astfel de proces de învățare „încercare și eroare" poate fi extrem de lent, costisitor și imprevizibil: Se știe că de la apariția primelor forme de viață, de acum aproximativ 4,4 până la 3,8 miliarde de ani, viața s-a bazat pe această formă de evoluție.\footnote{Cititorii atenți ar fi putut observa o asemănare ciudată între modul în care evoluează viața timpurie și modul în care evoluează astăzi modelele lingvistice mari.}
+\begin{figure}
+    \centering
+\includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter1/figs/DNAs.png}
+\includegraphics[width=0.40\linewidth]{\toplevelprefix/chapters/chapter1/figs/Evolution.jpg}
+    \caption{Evoluția inteligenței filogenetice: Cunoașterea lumii externe este codată și transmisă prin ADN (stânga) și este decodată din ADN în ARN și în proteine etc. În stadiul timpuriu al evoluției vieții (dreapta), inteligența dezvoltă cunoștințe la nivel de specie prin mutația (aleatorie) a genelor și selecția naturală -- „fie ca cel mai apt să supraviețuiască", care poate fi văzută ca o formă primitivă de învățare prin întărire.}
+    \label{fig:phylogenetic}
+\end{figure}
+\begin{figure}
+    \centering
+\includegraphics[height=0.19\linewidth]{\toplevelprefix/chapters/chapter1/figs/Luca.jpeg}
+\includegraphics[height=0.19\linewidth]{\toplevelprefix/chapters/chapter1/figs/Worm.jpeg}
+\includegraphics[height=0.19\linewidth]{\toplevelprefix/chapters/chapter1/figs/Cambrian.jpg}
+    \caption{Evoluția vieții, de la strămoșul întregii vieți de astăzi (numit LUCA --- ultimul strămoș comun universal), un organism asemănător unei celule unice care a trăit acum 3,5-4,3 miliarde de ani, la apariția primului sistem nervos în specii asemănătoare viermilor (mijloc), acum aproximativ 550 de milioane de ani, la explozia formelor de viață în perioada cambriană (dreapta), acum aproximativ 530 de milioane de ani.}
+    \label{fig:evolution}
+\end{figure}
+
+{\em Inteligența ontogenetică} se referă la mecanismele de învățare care permit unui individ să învețe prin propriile simțuri, amintiri și predicții în cadrul mediului său specific de viață și să-și îmbunătățească și adapteze comportamentele. Învățarea ontogenetică a devenit posibilă după apariția sistemului nervos acum aproximativ 550-600 de milioane de ani (în organisme asemănătoare viermilor), prezentată în \Cref{fig:evolution} mijloc. Adică, cu un sistem senzorial și nervos, un individ este capabil să formeze și să-și îmbunătățească continuu propriile cunoștințe despre lume, cunoscute și sub numele de memorie, pe lângă ceea ce este moștenit din ADN-ul sau genele sale. Această capacitate a îmbunătățit semnificativ supraviețuirea individului și a contribuit la explozia formelor de viață în perioada cambriană de acum aproximativ 530 de milioane de ani. Comparativ cu învățarea filogenetică, învățarea ontogenetică este semnificativ mai eficientă și previzibilă, care poate fi realizată în limitele de resurse ale unui individ în durata sa de viață.
+
+Observați că ambele tipuri de mecanisme de învățare se bazează pe o formă de feedback (din mediul extern), în termeni de pedeapsă (moarte) sau recompensă (hrană), a acțiunilor unei specii sau ale indivizilor\footnote{Mutația genelor speciei sau acțiunile făcute de individ.} pentru a învăța. Ca rezultat, toate ființele inteligente, ca specii sau ca indivizi, se bazează pe un mecanism de feedback în buclă închisă pentru a învăța și a-și îmbunătăți cunoștințele despre lume. Observăm, de asemenea, că de la plante, la pești, la păsări și la mamifere, speciile mai avansate se bazează din ce în ce mai mult pe capacitățile lor de învățare ontogenetică. Ei stau cu părinții lor și învață de la ei din ce în ce mai mult după naștere, deoarece indivizii din aceeași specie trebuie să supraviețuiască în medii foarte diverse.
+
+\paragraph{Evoluția inteligenței umane.}
+De la apariția homo sapiens acum aproximativ 315 mii de ani, a apărut o formă nouă și superioară de inteligență care evoluează mai eficient și economic. Limbajele, mai întâi vorbite și apoi scrise\footnote{Limba sumeriană este considerată a fi una dintre cele mai vechi limbi scrise existente, atestată pentru prima dată în jurul anului 3100 î.Hr. în sudul Mesopotamiei.}, au fost dezvoltate acum câteva mii de ani. Vezi \Cref{fig:human-intelligence}. Aceasta permite indivizilor să comunice și să împărtășească informații utile cu alții. Prin urmare, o comunitate sau societate umană se poate comporta ca un singur organism inteligent care poate învăța mult mai repede și poate deține mai multe cunoștințe decât orice individ. Într-un fel, limbajele scrise, sau textele, joacă un rol similar cu ADN-ul și genele, deoarece permit societăților umane să acumuleze și să transmită cunoștințe despre lume generațiilor următoare. Ne putem referi la acest tip de inteligență ca {\em inteligență societală}, pentru a o distinge de inteligența filogenetică a speciilor și inteligența ontogenetică a indivizilor. Acest tip de acumulare de cunoștințe servește drept fundație a civilizațiilor antice.
+\begin{figure}
+    \centering
+    \includegraphics[height=0.25\linewidth]{\toplevelprefix/chapters/chapter1/figs/Spoken-language.jpg}
+   \hspace{5mm} \includegraphics[height=0.25\linewidth]{\toplevelprefix/chapters/chapter1/figs/Cuneiform.png}
+   \hspace{5mm} \includegraphics[height=0.25\linewidth]{\toplevelprefix/chapters/chapter1/figs/adopt-euclid1685-2.jpg}
+    \caption{Dezvoltarea comunicării verbale și a limbajelor vorbite (între 10000-5000 î.Hr.), a limbajelor scrise (aproximativ 3000 î.Hr.) și a matematicii (în jurul anilor 500-300 î.Hr.) marchează trei repere cheie în evoluția inteligenței umane.}
+    \label{fig:human-intelligence}
+\end{figure}
+
+Destul de miraculos, acum câteva mii de ani, a avut loc un alt salt cuantic în inteligența umană, care le-a permis filozofilor și matematicienilor să dezvolte cunoștințe care par să depășească cu mult dezvoltarea cunoștințelor empirice. Dezvoltarea conceptelor și simbolurilor matematice abstracte, cum ar fi numerele, spațiul și timpul, precum și logica matematică, servesc ca un nou limbaj precis pentru știința modernă. În plus, dezvoltarea abilității de a genera noi ipoteze și de a verifica corectitudinea acestora pe baza deducției logice sau a experimentării științifice. Aceasta, pentru prima dată, a permis oamenilor să dezvolte proactiv cunoștințe noi dincolo de mijloacele empirice pasive. Se crede că abilitatea de a desfășura aceste forme de dezvoltare a cunoștințelor de nivel înalt este unică pentru oameni. Această formă avansată de inteligență este denumită „inteligență artificială" (AI), termen inventat de John McCarthy la atelierul de vară de la Dartmouth din 1956.
+
+Prin urmare, din ceea ce putem învăța din natură, de acum înainte, ori de câte ori folosim cuvântul „inteligență", trebuie să fim foarte specifici despre ce nivel/formă de inteligență ne referim:
+\begin{equation}
+\mbox{\textbf{filogenetică}} \;
+   \Longrightarrow \; \mbox{\textbf{ontogenetică}} \; \Longrightarrow \;
+   \mbox{\textbf{societală}}
+   \; \Longrightarrow \;
+   \mbox{\textbf{inteligență artificială}}.
+\end{equation}
+O caracterizare și distincție clară sunt necesare și importante deoarece vrem să studiem inteligența ca subiect științific și matematic. Este foarte probabil că, chiar dacă toate pot împărtăși obiectivul comun de a învăța cunoștințe utile despre lume, mecanismele computaționale specifice și implementările fizice din spatele fiecărui nivel/formă de inteligență ar putea fi diferite. Credem că cititorul va înțelege și aprecia mai bine aceste diferențe după ce va termina de studiat această carte. Prin urmare, vom lăsa mai multe discuții despre inteligența generală pentru ultimul \Cref{ch:future}.
+
+
+
+
+\paragraph{Originea inteligenței mașinilor -- Cibernetica.}
+În anii 1940, parțial din cauza efortului de război, inteligența din natură a inspirat oamenii de știință să emuleze inteligența animalelor prin mașini, ceea ce a dus la mișcarea „Cibernetică" promovată de Norbert Wiener. Wiener a studiat zoologia la Harvard ca student, dar mai târziu a devenit matematician și teoretician al controlului. Wiener a avut o pasiune pe viață pentru înțelegerea și dezvoltarea sistemelor autonome care ar putea emula comportamentele inteligente ale animalelor. Astăzi, programul Cibernetică este adesea interpretat îngust de oameni ca fiind în principal despre sistemele de control cu feedback pentru care Wiener a făcut într-adevăr cele mai semnificative contribuții tehnice. Dar programul Cibernetică a fost mult mai larg și mai profund decât atât. Este mai mult despre înțelegerea inteligenței ca întreg\footnote{Cel puțin la nivelul animalelor.} și a influențat de fapt munca unei întregi generații de oameni de știință renumiți, inclusiv Warren McCulloch, Walter Pitts, Claude Shannon, John von Neumann și Alan Turing.
+
+\begin{figure}
+    \centering
+    \includegraphics[height=0.4\linewidth]{\toplevelprefix/chapters/chapter1/figs/Cybernetics1.jpg}
+    \hspace{10mm} \includegraphics[height=0.4\linewidth]{\toplevelprefix/chapters/chapter1/figs/Cybernetics2.jpg}
+    \caption{Cartea „Cibernetica" de Norbert Wiener publicată în 1948 \cite{Wiener-Cybernetics-1948} (stânga) și a doua ediție în 1961 \cite{Wiener-Cybernetics-1961} (dreapta).}
+    \label{fig:cybernetcis}
+\end{figure}
+
+
+Wiener a fost probabil prima persoană care a studiat inteligența ca {\em un sistem}, în loc să acorde atenție doar unei componente sau aspect al acesteia. Viziunile sale cuprinzătoare asupra inteligenței au fost elaborate în faimoasa sa carte din 1948 {\em „Cibernetica: sau Control și Comunicare în Animal și Mașină"} \cite{Wiener-Cybernetics-1948}. În această carte și în a doua ediție publicată în 1961 \cite{Wiener-Cybernetics-1961} (vezi \Cref{fig:cybernetcis}), el a încercat să identifice mai multe caracteristici și mecanisme necesare ale sistemelor inteligente, care includ (dar nu se limitează la):
+\begin{itemize}
+    \item Cum să {\em măsurăm și stocăm} informația (în creier) și cum să comunicăm cu alții.\footnote{Norbert Wiener a fost primul care a subliniat că „informația" nu este materie sau energie, ci o cantitate independentă pentru studiu.} Aceasta a dus la formularea teoriei informației și teoriei codării de către Claude Shannon în 1948.
+    \item Cum să {\em corectăm erorile} în predicție și estimare pe baza informațiilor existente. Norbert Wiener însuși a ajutat la formalizarea teoriei pentru sistemele de control bazate pe feedback în buclă închisă în anii 1940.
+    \item Cum să învățăm să {\em luăm decizii mai bune} din interacțiunea cu un oponent potențial necooperant sau un mediu adversarial. Aceasta a fost formalizată de John von Neumann ca teoria jocurilor în 1944.
+\end{itemize}
+În 1943, foarte motivat de programul Cibernetică al lui Wiener, psihiatrul Warren McCulloch și logicianul Walter Pitts au formalizat împreună primul model computațional pentru un neuron \cite{McCulloch-Pitts}, numit {\em un neuron artificial}, așa cum este ilustrat mai târziu în \Cref{fig:neuron}. Bazat pe acest model, în anii 1950, Frank Rosenblatt a construit o mașină fizică, numită {\em Mark I Perceptron}, cu o rețea de sute de astfel de neuroni artificiali. Perceptron a fost prima rețea neuronală artificială realizată fizic, vezi \Cref{fig:perceptron}. În mod notabil, arhitectura computerului universal a lui John von Neumann, propusă în 1945, a fost de asemenea concepută pentru a facilita obiectivul de a construi {\em mașini de calcul} care pot realiza fizic mecanismele sugerate de programul Cibernetică.
+
+Cititorii atenți probabil au observat că anii 1940 au fost cu adevărat o epocă magică: Atât de multe idei fundamentale au fost inventate și teorii influente formalizate în acea epocă, inclusiv modelul matematic al neuronilor, rețelele neuronale artificiale, teoria informației, teoria controlului, teoria jocurilor și mașinile de calcul. \Cref{fig:god-fathers} arată câțiva dintre pionierii acestor teorii. După cum știm acum, fiecare lucrare de mai sus a crescut pentru a deveni fundamentul unui domeniu științific sau ingineresc pentru următoarele decenii și are un impact extraordinar asupra noastră. Toate aceste teorii fundamentale au fost inspirate și motivate de obiectivul de a încerca să dezvolte mașini care pot emula inteligența din natură. Pe baza notelor istorice, mișcarea Cibernetică a lui Wiener a influențat aproape toți acești oameni și muncă. Într-o mare măsură, programul Cibernetică stabilit de Wiener poate fi văzut ca adevăratul predecesor al programului foarte popular în prezent de inteligență „încorporată". De fapt, Wiener a descris programul în termeni mult mai concreți \cite{Wiener-Cybernetics-1961}.
+\begin{figure}
+    \centering
+    \includegraphics[height=0.3\linewidth]{\toplevelprefix/chapters/chapter1/figs/Wiener.png}
+    \includegraphics[height=0.3\linewidth]{\toplevelprefix/chapters/chapter1/figs/Shannon.jpg}
+    \includegraphics[height=0.3\linewidth]{\toplevelprefix/chapters/chapter1/figs/neumann.jpg}
+    \includegraphics[height=0.3\linewidth]{\toplevelprefix/chapters/chapter1/figs/Turing.jpeg}
+    \caption{Pionierii fundamentelor teoretice și computaționale pentru inteligență: Norbert Wiener (cibernetică și teoria controlului), Claude Shannon (teoria informației), John von Neumann (teoria jocurilor) și Alan Turing (teoria calculului).}
+    \label{fig:god-fathers}
+\end{figure}
+
+Deși Wiener a identificat în munca sa multe caracteristici și mecanisme cheie ale inteligenței (încorporate), nu există nicio indicație că știa cum să integreze corespunzător toate aceste mecanisme împreună pentru a construi un sistem inteligent autonom complet. Judecând după cunoștințele de astăzi, unele dintre opiniile sale despre aceste mecanisme nu au fost în întregime corecte sau complete. În special, în ultimul capitol al celei de-a doua ediții a Ciberneticii \cite{Wiener-Cybernetics-1961}, el a subliniat că este crucial să {\em abordăm neliniaritatea} dacă un sistem de învățare automată este conceput pentru a emula mecanismele tipice de învățare din natură. Dar el nu a oferit soluții concrete și eficiente la această problemă dificilă. În apărarea sa însă, la acea vreme, puțini oameni știau cum, deoarece chiar și teoria pentru abordarea modelelor și sistemelor liniare era încă în stadiul incipient.
+
+Cu toate acestea, nu ne-am putut abține să nu ne minunăm de previziunea lui Wiener despre importanța neliniarității. După cum vom vedea în această carte, răspunsul a fost găsit doar recent: neliniaritatea poate fi abordată eficient prin linearizare progresivă și transformare realizată de rețele neuronale profunde (vezi \Cref{ch:representation}). În plus, vom încerca să arătăm în această carte cum toate aceste mecanisme enumerate mai sus pot fi integrate natural într-un sistem complet care ar prezenta caracteristicile unui sistem inteligent autonom (vezi \Cref{ch:autoencoding}).
+
+\paragraph{Originea Inteligenței Artificiale.}
+Din subtitlul cărții Cibernetica lui Wiener: {\em „Control și Comunicare în Animal și Mașină"}, se poate spune că studiile din anii 1940 au vizat în principal emularea inteligenței la nivelul animalelor. După cum am menționat înainte, agendele de cercetare despre inteligență din jurul anilor 1940 au fost foarte mult dominate de mișcarea Cibernetică a lui Norbert Wiener.
+
+Alan Turing a fost unul dintre primii care a observat această limitare. În celebra sa lucrare din 1950 „{\em Mașini de Calcul și Inteligență}" \cite{Turing-1950}, Turing a pus oficial întrebarea dacă mașinile pot imita inteligența chiar și la nivel uman, până la punctul de a fi indistinguibile de capacitățile inteligente ale oamenilor. Aceasta este acum cunoscută sub numele de {\em testul Turing}.
+
+În jurul anului 1955, un grup de oameni de știință tineri și ambițioși au încercat să se desprindă de mișcarea și agendele de cercetare dominante ale Ciberneticii, astfel încât să aibă șansa de a-și crea propria moștenire. Au decis să accepte provocarea lui Turing de a imita inteligența umană și au propus un atelier care să aibă loc la Dartmouth College în vara anului 1956. Și-au făcut intenția clară cu o declarație în propunerea lor:
+\begin{quote}
+    „{\em Studiul urmează să procedeze pe baza conjecturii că fiecare aspect al învățării sau orice altă caracteristică a inteligenței poate fi în principiu descris atât de precis încât o mașină poate fi făcută să-l simuleze. Se va încerca să se găsească cum să facem mașinile să folosească limbajul, să formeze abstracții și concepte, să rezolve tipuri de probleme acum rezervate oamenilor și să se îmbunătățească}."
+\end{quote}
+În esență, ei au vrut să formalizeze și să studieze inteligența de nivel superior care diferențiază oamenii de animale. Subiectele pe care le-au luat în considerare au variat de la abstracție, metode simbolice, limbaje naturale și metode deductive (inclusiv inferență cauzală, deducție logică etc.) Organizatorul atelierului, John McCarthy, pe atunci un tânăr profesor asistent de matematică la Dartmouth College, a inventat termenul acum faimos „Inteligență Artificială" (AI) pentru a încapsula setul de caracteristici sau mecanisme care se crede că sunt {\em unice pentru inteligența umană}.
+
+\paragraph{Renașterea „Inteligenței Artificiale" sau a „Ciberneticii"?}
+După cum cititorii ar putea ști, în ultimul deceniu sau cam așa ceva, inteligența mașinilor a suferit o dezvoltare explozivă, alimentată în principal de practica rețelelor neuronale artificiale profunde, declanșată de munca lui Geoffrey Hinton și studenții în 2012 \cite{krizhevsky2012imagenet}. Această eră este de asemenea salutată ca „Renașterea" Inteligenței Artificiale (AI). Cu toate acestea, în ceea ce privește sarcinile pe care oamenii au încercat de fapt să le abordeze (recunoaștere, generare și predicție) și tehnicile pe care oamenii le-au dezvoltat și implementat până acum (întărire, imitare, codare, decodare, îndepărtarea zgomotului și compresie), emulăm foarte mult doar mecanismele care sunt comune inteligenței vieții timpurii și animalelor. Chiar și în această privință, după cum vom încerca să clarificăm în această carte, modelele și sistemele „AI" actuale nu au implementat corect toate mecanismele necesare pentru inteligența la aceste niveluri, care erau deja cunoscute mișcării Cibernetice din anii 1940.
+
+Prin urmare, strict vorbind, avansul inteligenței mașinilor din ultimul deceniu nu se aliniază bine cu programul „Inteligență Artificială" stabilit în atelierul de la Dartmouth din 1956. În schimb, ceea ce a fost realizat predominant până acum este mai strâns legat de obiectivele programului clasic „Cibernetică" stabilit de Norbert Wiener în anii 1940. Probabil este mai potrivit să numim epoca actuală „Renașterea Ciberneticii".\footnote{Creșterea recentă a așa-numitei „AI Încorporate" pentru roboți inteligenți autonomi împărtășește și mai multă similitudine cu obiectivele programului Cibernetică.} Doar după ce am înțeles pe deplin ceea ce am făcut cu adevărat din perspectiva științifică și matematică, putem ști cu adevărat ce rămâne de făcut și în ce direcție să mergem pentru a urmări adevărata natură a inteligenței. Acesta este unul dintre scopurile principale ale acestei cărți.
+
+
+\section{Ce să Învățăm?}
+\label{sec:what-to-learn}
+
+
+
+\subsection{Predictibilitate}
+\label{sec:predictability}
+Datele care poartă informații utile se manifestă în multe forme diferite. În forma cea mai naturală, ele pot fi modelate ca secvențe care sunt previzibile și calculabile. Noțiunea și proprietățile unei secvențe previzibile și calculabile au fost în centrul teoriei calculului și au dus în mare parte la inventarea calculatoarelor \cite{Turing-1936}. Rolul secvențelor previzibile în inferența (inductivă) a fost studiat de Ray Solomonoff, Andrey Kolmogorov și mulți alții în anii 1960 \cite{Kolmogorov1998OnTO} ca o generalizare a Teoriei Informației clasice a lui Claude Shannon \cite{Shannon-1948}. Pentru a înțelege conceptul de secvențe previzibile, să începem mai întâi cu câteva exemple concrete simple.
+\paragraph{Cazul Scalar.} Cea mai simplă secvență discretă previzibilă este probabil secvența numerelor naturale:
+\begin{equation}
+   {S} =  1, 2, 3, 4, 5, 6, \ldots, n, n+1, \ldots
+\end{equation}
+în care următorul număr $x_{n+1}$ este definit ca numărul său anterior $x_n$ plus 1:
+\begin{equation}
+x_{n+1} = x_n + 1.
+\end{equation}
+Se poate generaliza noțiunea de predictibilitate la orice secvență $\{x_n\}_{n=1}^\infty$ cu $ x_n \in \mathbb{R}$ dacă următorul număr $x_{n+1}$ poate fi întotdeauna calculat din cel anterior $x_n$:
+\begin{equation}
+    x_{n+1} = f(x_{n}), \quad x_n \in \mathbb{R}, \; n =  1, 2, 3, \ldots
+\end{equation}
+unde $f(\cdot)$ este o funcție {\em calculabilă} (scalară).\footnote{Aici subliniem că funcția $f(\cdot)$ însăși este calculabilă, ceea ce înseamnă că poate fi implementată ca un program pe un computer.} Notați că aici subliniem că funcția $f(\cdot)$ trebuie să fie calculabilă. Există multe funcții care pot fi definite dar nu sunt calculabile. Lucrarea seminală a lui Alan Turing din 1936 \cite{Turing-1936} oferă o definiție riguroasă a calculabilității. În practică, adesea presupunem în plus că $f$ este calculabilă eficient și are proprietăți frumoase cum ar fi fiind continuă și diferențiabilă etc. Necesitatea acestor proprietăți va deveni clară mai târziu odată ce înțelegem mai multe despre noțiuni mai rafinate de calculabilitate și rolurile lor în învățarea automată și inteligență.
+
+\paragraph{Cazul Multi-Variabil.}
+Desigur, valoarea următorului număr poate depinde și de doi dintre predecesorii săi. De exemplu, faimoasa {\em secvență Fibonacci} este definită ca:
+\begin{equation}
+    {S} = 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, \ldots
+\end{equation}
+unde se poate vedea ușor:
+\begin{equation}
+    x_{n+2} = x_{n+1} + x_{n}, \quad  x_n \in \mathbb{R}, \;  n = 1, 2, 3, \ldots
+\end{equation}
+În mod similar, putem generaliza această recursiune la \begin{equation}
+    x_{n+2} = f(x_{n+1}, x_{n}), \quad x_n \in \mathbb{R}, \;  n =  1, 2, 3, \ldots
+\end{equation}
+unde $f(\cdot,\cdot)$ este orice funcție calculabilă care ia două variabile ca intrare. Putem generaliza în continuare noțiunea de predictibilitate la o secvență a cărei valoare următoare depinde de, să zicem, $d$ dintre predecesorii săi:
+\begin{equation}
+    x_{n+d} = f(x_{n+d-1}, \ldots,  x_{n}), \quad  x_n \in \mathbb{R}, \; n =  1, 2, 3, \ldots
+    \label{eqn:recursive-d}
+\end{equation}
+Numărul de predecesori $d$ necesari pentru predicție se numește {\em gradul} predicției recursive. Expresia de mai sus \eqref{eqn:recursive-d} se mai numește și {\em (auto) regresie}. O astfel de secvență se mai numește și secvență {\em auto-regresivă}. Dacă funcția $f$ este o funcție liniară, o numim regresie (auto) liniară.
+
+\paragraph{Cazul Vectorial.}
+Pentru a simplifica notația, putem defini un vector $\vx \in \mathbb{R}^d$ care colectează $d$ valori consecutive în secvență: \begin{equation}
+    \vx_n \doteq [x_{n+d-1}, \ldots,  x_{n}]^\top, \quad \vx_n \in \mathbb{R}^d, \; n = 1, 2, 3, \ldots
+\end{equation}
+Cu această notație, relația recursivă \eqref{eqn:recursive-d} poate fi scrisă convenabil ca
+\begin{equation}
+    \vx_{n+1} = g(\vx_{n}) \; \in \mathbb{R}^d, \quad n =  1, 2, 3, \ldots
+    \label{eqn:recursive-v}
+\end{equation}
+unde funcția $g(\cdot)$ este definită unic de funcția $f$ în \eqref{eqn:recursive-d} și ia un vector $d$-dimensional ca intrare. În contexte diferite, un astfel de vector este uneori denumit „stare" sau „token". Notați că ecuația din \eqref{eqn:recursive-d} denotă o mapare $\mathbb{R}^d \rightarrow \mathbb{R}$, dar ecuația de aici este $g: \mathbb{R}^d \rightarrow \mathbb{R}^d$.
+
+
+\paragraph{Predicție Controlată.}
+Putem defini, de asemenea, o secvență previzibilă care depinde de o altă secvență previzibilă ca intrare:
+\begin{equation}
+    \vx_{n+1} = f(\vx_{n}, \vu_n) \; \in \mathbb{R}^d, \quad n =  1, 2, 3, \ldots,
+\label{eqn:recursive-control}
+\end{equation}
+unde $\{\vu_n\}$ cu $\vu_n \in \mathbb{R}^k$ este o secvență previzibilă (calculabilă). Cu alte cuvinte, următorul vector $\vx_{n+1} \in \mathbb{R}^d$ depinde atât de $\vx_n \in \mathbb{R}^d$ cât și de $\vu_n \in \mathbb{R}^k$. În contextul teoriei controlului, secvența $\{\vu_n\}$ este adesea denumită „intrarea de control" și $\vx_n$ ca „starea" sau „ieșirea" sistemului \eqref{eqn:recursive-control}. Un exemplu clasic este un sistem dinamic liniar:
+\begin{equation}
+    \vx_{n+1} = \boldsymbol{A}\vx_n + \boldsymbol{B}\vu_n, \quad \boldsymbol{A} \in \mathbb{R}^{d\times d}, \boldsymbol{B} \in \mathbb{R}^{d\times k},
+    \label{eqn:lineary-system}
+\end{equation}
+care este studiat pe larg în teoria controlului \cite{Cal:Des}.
+
+Foarte des intrarea de control este dată de o funcție calculabilă a stării $\vx_n$ însăși:
+\begin{equation}
+    \vu_n = h(\vx_n), \quad n =  1, 2, 3, \ldots
+\end{equation}
+Ca rezultat, secvența $\{\vx_n\}$ este dată prin compunerea celor două funcții calculabile $f$ și $h$ ca:
+\begin{equation}
+    \vx_{n+1} = f\big(\vx_{n}, h(\vx_n)\big), \quad n =  1, 2, 3, \ldots
+    \label{eqn:recursive-closed-loop}
+\end{equation}
+În acest fel, secvența $\{\vx_n\}$ devine din nou o secvență previzibilă auto-regresivă. Când intrarea $\vu_n$ depinde de ieșirea $\vx_n$, spunem că secvența rezultată este produsă de un sistem „în buclă închisă" \eqref{eqn:recursive-closed-loop}. Deoarece sistemul în buclă închisă nu mai depinde de nicio intrare externă, spunem că un astfel de sistem a devenit {\em autonom}. Poate fi văzut ca un caz special de auto-regresie. De exemplu, dacă alegem în sistemul liniar de mai sus \eqref{eqn:lineary-system}, $\vu_n = \boldsymbol{F}\vx_n$, sistemul în buclă închisă devine
+\begin{equation}
+        \vx_{n+1} = \boldsymbol{A}\vx_n + \boldsymbol{B}\vu_n = \boldsymbol{A}\vx_n + \boldsymbol{B}\boldsymbol{F}\vx_n = (\boldsymbol{A}+ \boldsymbol{B}\boldsymbol{F})\vx_n,
+    \label{eqn:lineary-system-closed}
+\end{equation}
+care este o auto-regresie liniară.
+
+
+
+\paragraph{Procese Continue.}
+Secvențele previzibile au corespondente naturale în cazul continuu. Ne putem referi la ele ca procese previzibile. Similar cu secvența numerelor naturale, cel mai simplu proces continuu previzibil este timpul însuși $x=t$.
+
+Mai general, spunem că un proces, notat cu $\vx(t)$, este previzibil dacă în orice moment $t$, valoarea procesului la $t+\delta t$, unde $\delta t$ este un increment infinitezimal, este determinată de valoarea sa la $t$. De obicei, schimbarea în valoare $\delta \vx(t)$ este continuă și netedă. Deci $\delta \vx(t) = \vx(t + \delta t) - \vx(t)$ este infinitezimal de mică. Procesele previzibile sunt de obicei descrise de ecuații diferențiale (multivariabile):
+\begin{equation}
+    \dot{\vx}(t) = f(\vx(t)), \quad \vx \in \mathbb{R}^d.
+    \label{eqn:process}
+\end{equation}
+
+În contextul teoriei sistemelor \cite{Cal:Des,Sastry-Nonlinear}, ecuația de mai sus este cunoscută și ca model de spațiu de stare. Similar cu cazul discret, un proces controlat poate fi dat de:
+\begin{equation}
+    \dot{\vx}(t) = f(\vx(t), \vu(t) ), \quad \vx \in \mathbb{R}^d, \vu \in \mathbb{R}^k,
+    \label{eqn:process-controlled}
+\end{equation}
+unde $\vu(t)$ este un proces de intrare calculabil.
+
+\begin{example}
+    De exemplu în fizică, a doua lege a mișcării a lui Newton descrie cum să prezicem traiectoria $\boldsymbol{x}(t) \in \mathbb{R}^3$ a unui obiect în mișcare sub o intrare de forță $\boldsymbol{F}(t) \in \mathbb{R}^3$:
+\begin{equation}
+    m\ddot{\boldsymbol{x}}(t) = \boldsymbol{F}(t).
+\end{equation}
+Când nu există forță $\boldsymbol{F}(t) \equiv 0$, legea de mai sus se reduce la un caz special, cunoscut ca prima lege a lui Newton: obiectul menține o viteză constantă în linie dreaptă:
+\begin{equation}
+   \ddot{\boldsymbol{x}}(t) = \boldsymbol{0} \; \Leftrightarrow \; \dot{\boldsymbol{x}}(t) = \boldsymbol{v}
+\end{equation}
+pentru un anumit vector de viteză constantă $\boldsymbol{v} \in \mathbb{R}^3$.
+\end{example}
+
+
+
+
+\subsection{Dimensionalitate Redusă}\label{sec:intro-low-dimensionality}
+\paragraph{Învățarea Predicției.}
+Acum să presupunem că ați observat sau vi s-au dat multe segmente de secvență:
+\begin{equation}
+    \{S_1, S_2, \ldots, S_i, \ldots, S_N\}
+\end{equation}
+toate dintr-o secvență previzibilă $\{x_n\}_{n=1}^\infty$. Fără pierderea generalității, putem presupune că lungimea fiecărui segment este $D \gg d$. Deci fiecare segment este de forma:
+\begin{equation}
+    S_i = [x_{j(i)}, x_{j(i)+1}, \ldots, x_{j(i)+D-1}]^\top \in \mathbb{R}^D
+\end{equation}
+pentru un anumit $j \in \mathbb{N}$. Apoi vi se dă un nou segment $S_t$ și vi se cere să preziceți valorile sale viitoare.
+
+O dificultate aici este că în mod normal nu cunoașteți funcția $f$ și gradul $d$ din care este generată secvența:
+\begin{equation}
+    x_{n+d} = f(x_{n+d-1}, \ldots,  x_{n}).
+\label{eqn:sequence-order-d}
+\end{equation}
+Deci speranța este cumva „să învățați" $f$ și $d$ din segmentele de eșantion date $S_1, S_2, \ldots, S_N$. Prin urmare, sarcina centrală a învățării predicției este:
+\begin{center}
+{\em Fiind date multe segmente eșantionate dintr-o secvență previzibilă, cum să identificăm eficient și eficace funcția $f$.}
+\end{center}
+
+\paragraph{Predictibilitate și Dimensionalitate Redusă.}
+Pentru a identifica funcția predictivă $f$, putem observa o caracteristică comună a segmentelor oricărei secvențe previzibile date de \eqref{eqn:sequence-order-d}. Dacă luăm un segment lung, să zicem cu o lungime $D \gg d$, din secvență și îl privim ca un vector:
+\begin{equation}
+    \vx_i = [x_i, x_{i+1}, \ldots x_{i+D-1}]^\top \in \mathbb{R}^D.
+\end{equation}
+Atunci setul tuturor acestor vectori $\{\vx_i\}$ este departe de a fi aleatoriu și prin urmare nu poate ocupa întregul spațiu al $\R^D$. În schimb, ei au în esență cel mult $d$ grade de libertate -- date primele $d$ intrări ale oricărui $\vx_i$, valorile restului intrărilor sunt determinate unic. Cu alte cuvinte, toți $\{\vx_i\}$ se află pe o suprafață $d$-dimensională. În matematică, o astfel de suprafață este adesea numită o subvarietate, notată ca $\mathcal{S} \subset \R^D$.
+
+
+\begin{figure}[t]
+\centering
+\includegraphics[width=0.6\linewidth]{\toplevelprefix/chapters/chapter1/figs/two-dimensional plane in R10.pdf}
+    \caption{Un subspațiu bidimensional într-un spațiu ambiental zece-dimensional.}
+    \label{fig:lowdimplane}
+\end{figure}
+În practică, dacă alegem lungimea segmentului $D$ să fie suficient de mare, atunci toate segmentele eșantionate din aceeași funcție de predicție se află pe o suprafață cu o dimensiune intrinsecă $d$, semnificativ mai mică decât cea a spațiului ambiental $D$. De exemplu, dacă secvența este dată de următoarea autoregresie liniară:
+\begin{equation}
+    x_{n+2} = a\cdot x_{n+1} + b\cdot x_n,
+    \label{eqn:sequence-2d}
+\end{equation}
+pentru anumite constante $a, b \in \R$. Dacă eșantionăm segmente de lungime $D =10$ dintr-o astfel de secvență, atunci toate eșantioanele se află pe un plan sau subspațiu bidimensional în $\R^{10}$, așa cum este ilustrat în \Cref{fig:lowdimplane}. Dacă putem identifica acest subspațiu bidimensional, constantele $a$ și $b$ în \eqref{eqn:sequence-2d} pot fi determinate complet.
+
+
+Este ușor de văzut că dacă funcția de predicție $f$ este liniară, cum ar fi cazul cu sistemele liniare date în \eqref{eqn:lineary-system} și \eqref{eqn:lineary-system-closed}, segmentele lungi se află întotdeauna pe un anumit subspațiu liniar cu dimensiuni reduse. Identificarea funcției de predicție este în mare măsură echivalentă cu identificarea acestui subspațiu cu dimensiuni reduse, o problemă cunoscută în general ca analiza componentelor principale. Vom discuta astfel de modele și metode clasice în \Cref{ch:classic}.
+
+După cum se dovedește, acest lucru este în mare măsură adevărat și pentru secvențele previzibile generale: dacă cineva poate identifica suprafața cu dimensiuni reduse pe care se află toate eșantioanele de segmente, atunci poate identifica funcția predictivă asociată $f$.\footnote{În condiții blânde, există o mapare unu-la-unu între suprafața cu dimensiuni reduse și funcția $f$. Acest fapt a fost exploatat în probleme precum identificarea sistemului pe care o vom discuta mai târziu.} Nu putem sublinia suficient importanța acestei proprietăți a segmentelor dintr-o secvență previzibilă: {\em Toate eșantioanele de segmente lungi ale unei secvențe previzibile se află pe o subvarietate cu dimensiuni reduse.} După cum vom vedea în această carte, toate metodele moderne de învățare exploatează în esență această proprietate, implicit sau explicit.
+
+În scenariile din lumea reală, datele pe care le observăm adesea nu provin dintr-o singură secvență previzibilă. De obicei, ele conțin observații ale mai multor secvențe previzibile. De exemplu, o secvență video poate conține mai multe obiecte în mișcare. Este ușor de văzut că în astfel de scenarii, datele se află pe un amestec de mai multe subspații liniare cu dimensiuni reduse sau subvarietăți neliniare, așa cum este ilustrat în \Cref{fig:mixture-models}.
+\begin{figure}
+    \centering
+    \includegraphics[width=0.8\linewidth]{\toplevelprefix/chapters/chapter1/figs/mixture.pdf}
+    \caption{Date distribuite pe un amestec de subspații (ortogonale) (stânga) sau subvarietăți (dreapta).}
+    \label{fig:mixture-models}
+\end{figure}
+
+
+\paragraph{Proprietățile Dimensionalității Reduse.}
+Desigur, corelația temporală în secvențele previzibile nu este singurul motiv pentru care datele sunt cu dimensiuni reduse. De exemplu, spațiul tuturor imaginilor este imens, dar cea mai mare parte a spațiului constă din imagini care seamănă cu imagini aleatorii fără structură, așa cum se arată în \Cref{fig:noise-image} stânga. Cu toate acestea, imaginile și videoclipurile naturale sunt foarte redundante deoarece există o corelație spațială și temporală puternică între toate valorile pixelilor. Acesta este motivul pentru care putem recunoaște cu ușurință dacă o imagine este zgomotoasă sau curată, așa cum se arată în \Cref{fig:noise-image} mijloc și dreapta. Prin urmare, distribuția imaginilor naturale are o dimensiune intrinsecă foarte mică (în raport cu numărul total de pixeli ai unei imagini).
+
+\begin{figure}
+    \centering
+    \includegraphics[height=0.30\linewidth]{\toplevelprefix/chapters/chapter1/figs/Gaussian-noise.png}\hspace{2mm}
+    \includegraphics[height=0.30\linewidth]{\toplevelprefix/chapters/chapter1/figs/Standard-test-image-Barbara-of-size-512-512-pixels-including-Gaussian-noise-with.png} \hspace{2mm}
+    \includegraphics[height=0.30\linewidth]{\toplevelprefix/chapters/chapter1/figs/barbara.jpg}
+    \caption{O imagine de zgomot aleatoriu versus o imagine zgomotoasă și imaginea originală curată.}
+    \label{fig:noise-image}
+\end{figure}
+
+Datorită importanței și ubicuității sarcinii de învățare a structurilor cu dimensiuni reduse, cartea {\em „Analiza Datelor cu Dimensiuni Mari cu Modele cu Dimensiuni Reduse: Principii, Calcul și Aplicații"} \cite{Wright-Ma-2022} a declarat la început cu o afirmație: „{\em Problema identificării structurii cu dimensiuni reduse a semnalelor sau datelor în spații cu dimensiuni mari este una dintre cele mai fundamentale probleme care, printr-o istorie lungă, împletește multe domenii inginerești și matematice, cum ar fi teoria sistemelor, procesarea semnalelor, recunoașterea tiparelor, învățarea automată și statistica.}"
+
+Notați că prin a forța punctul de date observat $\vx$ să fie pe o suprafață cu dimensiuni reduse, am făcut în esență intrările din $\vx$ foarte dependente una de alta și într-un anumit sens am făcut intrările foarte „previzibile" din valorile altor intrări. De exemplu, dacă știm că datele sunt constrânse pe o suprafață $d$-dimensională în $\R^D$, atunci ne permite să facem multe lucruri utile cu datele în afară de predicție:
+\begin{itemize}
+    \item \textbf{completare}: în general, date mai mult de $d$ intrări ale unui eșantion tipic $\vx$, restul intrărilor sale pot fi de obicei determinate {\em unic}.\footnote{Predicția devine un caz special al acestei proprietăți.}
+    \item \textbf{îndepărtarea zgomotului}: să presupunem că intrările unui eșantion $\vx$ sunt perturbate de zgomote {\em mici}, ele pot fi îndepărtate eficient proiectând $\vx$ înapoi pe suprafață.
+    \item \textbf{corectarea erorilor}: să presupunem că un număr mic de intrări {\em necunoscute} ale lui $\vx$ sunt corupte arbitrar, ele pot fi corectate eficient și eficace.
+\end{itemize}
+\Cref{fig:low-dim-properties} ilustrează aceste proprietăți cu o structură liniară cu dimensiuni reduse: o linie unidimensională într-un plan bidimensional.
+
+\begin{figure}
+    \centering
+    \includegraphics[height=0.28\linewidth]{\toplevelprefix/chapters/chapter1/figs/Completion-low-dim.png}     \includegraphics[height=0.28\linewidth]{\toplevelprefix/chapters/chapter1/figs/Denoising-low-dim.png} \includegraphics[height=0.32\linewidth]{\toplevelprefix/chapters/chapter1/figs/Correction-low-dim.png}
+    \caption{Ilustrarea proprietăților unei structuri (liniare) cu dimensiuni reduse: permite completarea (stânga), îndepărtarea zgomotului (mijloc) și corectarea erorilor (dreapta).}
+    \label{fig:low-dim-properties}
+\end{figure}
+
+De fapt, în condiții blânde, proprietățile de mai sus sunt generalizabile la multe alte structuri cu dimensiuni reduse în spații cu dimensiuni mari \cite{Wright-Ma-2022}. Interesant, după cum vom vedea în această carte, aceste proprietăți utile precum completarea și îndepărtarea zgomotului vor inspira metode eficiente pentru a învăța astfel de structuri cu dimensiuni reduse.
+
+În cele de mai sus, pentru simplitate, am folosit doar cazul determinist pentru a introduce noțiunea importantă de predictibilitate și dimensionalitate redusă. Prin urmare, datele (sau segmentele eșantionate) se află precis pe anumite structuri geometrice precum subspații sau suprafețe. În practică, după cum am aluzionat înainte, există întotdeauna un anumit nivel de incertitudine sau aleatorie în date. În acest caz, putem presupune că datele au o distribuție de probabilitate, cu o funcție de densitate de probabilitate $p(\vx)$. Spunem că o distribuție este „cu dimensiuni reduse" dacă densitatea sa se concentrează în jurul unei structuri geometrice care este destul de cu dimensiuni reduse, să zicem un subspațiu, o suprafață sau un amestec al acestora, așa cum se arată în \Cref{fig:mixture-models}. Observați că, din punct de vedere practic, o astfel de funcție de densitate $p(\x)$, odată învățată, poate servi ca o prioritate foarte puternică pentru estimarea $\x$ pe baza observației parțiale, zgomotoase sau corupte, să zicem:
+\begin{equation}
+\y = f(\x) + \boldsymbol{n},
+\end{equation}
+prin calcularea estimării condiționate $\hat{\x}(\y) = \mathbb{E}(\x \mid \y)$ sau prin eșantionarea distribuției condiționate $\hat{\x}(\y) \sim p(\x\mid \y)$.\footnote{Tehnologiile moderne de AI generativă, cum ar fi generarea de imagini (condiționată), se bazează foarte mult pe acest fapt, așa cum vom elabora în \Cref{ch:conditional-inference}.}
+
+Discuțiile noastre de mai sus au condus la principala și singura presupunere pe care această carte o va face pentru o abordare deductivă pentru a înțelege inteligența și rețelele profunde în special:
+\begin{quote}
+\textbf{Presupunerea Principală:} {\em Orice sisteme inteligente sau metode de învățare ar trebui și ar putea să se bazeze pe faptul că lumea este previzibilă, prin urmare distribuția eșantioanelor de date observate cu dimensiuni mari au suporturi cu dimensiuni reduse.}
+\end{quote}
+Întrebarea rămasă este cum să învățăm astfel de structuri cu dimensiuni reduse corect din datele cu dimensiuni mari, prin mijloace calculabile eficiente și eficace. După cum vom vedea în această carte, modelele parametrice care au fost bine studiate în abordările analitice clasice și modelele non-parametrice precum rețelele profunde care sunt populare în practica modernă sunt doar mijloace diferite pentru a atinge același obiectiv.
+
+\section{Cum să Învățăm?}
+
+
+\subsection{Abordări Analitice}
+\label{sec:analytical}
+Notați că, chiar dacă o funcție predictivă este tractabilă de calculat, nu implică faptul că este tractabilă sau scalabilă să învățăm această funcție dintr-un număr de segmente eșantionate. Desigur, o abordare clasică pentru a asigura că problemele sunt tractabile sau susceptibile la soluții eficiente este să facem presupuneri explicite despre familia de structuri cu dimensiuni reduse cu care avem de-a face. Istoric, din cauza calculului și datelor limitate, modelele analitice simple și idealiste au fost întotdeauna primele studiate deoarece oferă adesea soluții eficiente în formă închisă sau numerice. În plus, ele pot oferi perspective asupra problemelor mai generale și oferă adesea deja soluții utile pentru cazuri importante, deși limitate. În vremurile vechi, când resursele computaționale erau rare, modelele analitice care permiteau soluții eficiente în formă închisă sau numerice erau singurele cazuri care puteau fi implementate. {\em Structurile liniare} au devenit primele clase de modele care au fost studiate temeinic.
+
+De exemplu, probabil cel mai simplu caz este să presupunem că datele sunt distribuite în jurul unui singur subspațiu cu dimensiuni reduse într-un spațiu cu dimensiuni mari. Sau într-un mod oarecum echivalent, se poate presupune că datele sunt distribuite conform unei gaussiene aproape degenerate cu dimensiuni reduse. Identificarea unui astfel de subspațiu sau gaussiană dintr-un număr finit de eșantioane (zgomotoase) este apoi problema clasică de analiză a componentelor principale (PCA) și au fost dezvoltați algoritmi eficienți pentru această clasă de modele \cite{JolliffeI2002}. Se poate face familia de modele din ce în ce mai complexă și expresivă. De exemplu, se poate presupune că datele sunt distribuite în jurul unui anumit amestec de componente cu dimensiuni reduse (subspații sau gaussiene cu dimensiuni reduse), ca în cazul analizei componentelor independente (ICA) \cite{Ans-1985}, învățării dicționarului (DL), analizei componentelor principale generalizate (GPCA) \cite{Vidal-GPCA}, sau clasa și mai generală de modele rare cu dimensiuni reduse care au fost studiate extensiv în ultimii ani în domenii precum detectarea comprimată \cite{Wright-Ma-2022}.
+
+În jurul tuturor acestor familii de modele analitice, problema centrală de studiu este întotdeauna cum să identificăm {\em cel mai compact} model din cadrul fiecărei familii care se potrivește cel mai bine datelor date. Mai jos, oferim o relatare foarte scurtă a acestor modele analitice clasice, dar lăsăm un studiu mai sistematic pentru \Cref{ch:classic}. În teorie, aceste modele analitice ne-au oferit perspective extraordinare asupra proprietăților geometrice și statistice ale structurilor cu dimensiuni reduse. Ele oferă adesea soluții în formă închisă sau algoritmi eficienți și scalabili care sunt foarte utili pentru date ale căror distribuții pot fi bine aproximate de astfel de modele. Mai important, pentru probleme mai generale, ele ne oferă o înțelegere generală despre cât de ușoară sau dificilă poate fi problema identificării structurilor cu dimensiuni reduse și care sunt ideile de bază pentru a aborda o astfel de problemă.
+
+
+
+
+\subsubsection{Sisteme Dinamice Liniare}
+\label{sec:linear-systems}
+
+\paragraph{Filtrul Wiener.}
+
+După cum am discutat înainte în \Cref{sec:predictability}, o sarcină principală a inteligenței este să învețe ceea ce este previzibil în secvențele de observații. Probabil cea mai simplă clasă de secvențe previzibile, sau semnale, sunt generate printr-un proces {\em liniar invariant în timp} (LTI):
+\begin{equation}
+    x[n] = h[n]*z[n] + \epsilon[n],
+    \label{eqn:Wiener-model}
+\end{equation}
+unde $z$ este intrarea și $h$ este funcția de răspuns la impuls.\footnote{În mod normal, se presupune că $h$ are anumite structuri frumoase, să zicem lungime finită sau spectru limitat.} Aici $\epsilon[n]$ este un anumit zgomot aditiv în observații. Problema este că, date fiind procesul de intrare $\{z[n]\}$ și observațiile procesului de ieșire $\{x[n]\}$, cum să găsim $h[n]$ optim astfel încât $\hat x[n] = h[n]*z[n]$ să prezică $x[n]$ într-un mod optim. În general, măsurăm calitatea predicției prin eroarea medie pătrată minimă (MMSE):
+\begin{equation}
+    \min_{h} \mathbb{E} \big[\epsilon[n]^2\big] = \mathbb{E} \big[\|x[n] - h[n]*z[n]\|_2^2\big].
+\end{equation}
+Soluția optimă $h[n]$ este denumită un filtru (de îndepărtare a zgomotului). Norbert Wiener, aceeași persoană care a inițiat mișcarea Cibernetică, a studiat această problemă în anii 1940 și a dat o soluție elegantă în formă închisă cunoscută sub numele de {\em filtrul Wiener} \cite{Wiener-1942,Wiener-1949}. Aceasta a devenit unul dintre cele mai fundamentale rezultate în domeniul Procesării Semnalelor.
+
+\paragraph{Filtrul Kalman.}
+Ideea de îndepărtare a zgomotului sau filtrare pentru un proces dinamic a fost extinsă mai târziu la un sistem liniar invariant în timp descris de un model de spațiu de stare (finit-dimensional) de Rudolph Kalman în anii 1960:
+\begin{equation}
+    \z[n] = \boldsymbol{A} \z[n-1] + \boldsymbol{B}\boldsymbol{u}[n] + \boldsymbol{\epsilon}[n].
+    \label{eqn:linear-state-space}
+\end{equation}
+Problema este cum putem estima starea sistemului $\z[n]$ din observații zgomotoase de forma: \begin{equation}\x[n] = \boldsymbol{C} \z[n] + \boldsymbol{w}[n],
+\label{eqn:Kalman-model}
+\end{equation}
+unde $\boldsymbol{w}$ este un anumit zgomot (alb). Estimatorul de stare cauzal optim\footnote{Ceea ce înseamnă că estimarea poate folosi doar observații până la pasul de timp curent $n$. Filtrul Kalman este întotdeauna cauzal, în timp ce filtrul Wiener nu trebuie să fie.} care minimizează eroarea de predicție de tip MMSE
+\begin{equation}
+    \min \mathbb{E}\big[ \|\x[n] - \boldsymbol{C}\z[n]\|_2^2\big]
+\end{equation}
+este dat în formă închisă de așa-numitul {\em filtru Kalman} \cite{kalman1960new}. Acesta este unul dintre pilonii Teoriei Moderne a Controlului deoarece ne permite să estimăm starea unui sistem dinamic din observațiile sale zgomotoase. Apoi se poate introduce ulterior un feedback de stare (liniar), să zicem de forma $\boldsymbol{u}[n] = \boldsymbol{F} \hat{\boldsymbol{z}}[n]$, și să facem sistemul în buclă închisă complet autonom, așa cum am văzut în ecuația \eqref{eqn:recursive-closed-loop}.
+
+\paragraph{Identificarea Sistemelor Dinamice Liniare.}
+Pentru a deriva filtrul Kalman, parametrii sistemului $(\boldsymbol{A}, \boldsymbol{B}, \boldsymbol{C})$ sunt presupuși a fi cunoscuți. Dacă nu sunt dați în avans, ar fi o problemă mai dificilă cunoscută sub numele de {\em identificarea sistemului}: cum să {\em învățăm} parametrii $(\boldsymbol{A}, \boldsymbol{B}, \boldsymbol{C})$ din (multe eșantioane ale) secvenței de intrare $\{\boldsymbol{u}[n]\}$ și secvenței de observație $\{\x[n]\}$. Aceasta este o problemă clasică în teoria sistemelor. Dacă sistemul este liniar, se poate arăta că secvențele de intrare și ieșire $\{\boldsymbol{u}[n], \x[n]\}$ s-ar afla împreună pe un anumit subspațiu cu dimensiuni reduse\footnote{care are aceeași dimensiune ca ordinea modelului de spațiu de stare \eqref{eqn:linear-state-space}.}. Prin urmare, problema de identificare este în esență echivalentă cu identificarea acestui subspațiu cu dimensiuni reduse \cite{OverscheeP1996,Liu-2009-CDC,Liu-2010-SIAM}.
+
+Notați că problemele de mai sus au două lucruri în comun: în primul rând, secvențele sau semnalele (fără zgomot) sunt presupuse a fi generate de o familie explicită de modele parametrice; în al doilea rând, aceste modele sunt în esență toate liniare. Deci, conceptual, fie $\x_o$ o variabilă aleatorie a cărei distribuție „adevărată" este susținută pe un subspațiu liniar cu dimensiuni reduse, să zicem $S$. Într-o mare măsură, filtrul Wiener și filtrul Kalman încearcă toate să estimeze un astfel de $\x_o$ din observațiile sale zgomotoase:
+\begin{equation}
+    \x = \x_o + \boldsymbol{\epsilon}, \quad \x_o \sim S,
+\end{equation}
+unde $\boldsymbol{\epsilon}$ este de obicei un zgomot gaussian aleatoriu (sau proces). Prin urmare, în esență, soluțiile lor se bazează toate pe identificarea unui subspațiu liniar cu dimensiuni reduse care se potrivește cel mai bine datelor observate (zgomotoase). Apoi, proiectând datele pe acest subspațiu, se obțin operațiile optime de îndepărtare a zgomotului, toate în formă închisă.
+
+
+\subsubsection{Modele Liniare și Mixte Liniare}
+\label{sec:PCA-ICA}
+\paragraph{Analiza Componentelor Principale.}
+Din problemele de mai sus în procesarea clasică a semnalelor și identificarea sistemelor, vedem că sarcina principală din spatele tuturor acestor probleme este să învățăm din observații zgomotoase un {\em singur} subspațiu liniar cu dimensiuni reduse. Matematic, putem modela o astfel de structură ca:
+\begin{equation}
+    \x = \boldsymbol{u}_1 z_1 + \boldsymbol{u}_2 z_2 + \cdots + \boldsymbol{u}_d z_d + \boldsymbol{\epsilon} =  \boldsymbol{U} \z + \boldsymbol{\epsilon}, \quad \boldsymbol{U} \in \mathbb{R}^{D\times d}
+    \label{eqn:PCA-model}
+\end{equation}
+unde $\boldsymbol{\epsilon} \in \mathbb{R}^D$ este un anumit zgomot aleatoriu mic. \Cref{fig:PCA} ilustrează o astfel de distribuție cu două componente principale.
+\begin{figure}
+    \centering
+    \includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter1/figs/PCA.png}
+    \caption{O distribuție cu două componente principale.}
+    \label{fig:PCA}
+\end{figure}
+Problema este să găsim baza subspațiului $\boldsymbol{U}$ din multe eșantioane de $\x$. O abordare tipică pentru a estima subspațiul $\boldsymbol{U}$ este să minimizăm varianța zgomotului, cunoscută și sub numele de eroarea medie pătrată minimă (MMSE):
+\begin{equation}
+    \min_{\boldsymbol{U}} \mathbb{E}\big[\|\boldsymbol{\epsilon}\|_2^2\big] = \mathbb{E}\big[\|\x - \boldsymbol{U} \z\|_2^2\big].
+\end{equation}
+Observați că aceasta este în esență o sarcină de îndepărtare a zgomotului: odată ce baza $\boldsymbol{U}$ este găsită corect, putem îndepărta zgomotul din eșantionul zgomotos $\x$ proiectându-l pe subspațiul cu dimensiuni reduse extins de $\boldsymbol{U}$ ca
+\begin{equation}
+\x \rightarrow \hat \x = \boldsymbol{U}\boldsymbol{U}^\top \x.
+\end{equation}
+Dacă zgomotul este mic și dacă am învățat subspațiul corect cu dimensiuni reduse $\boldsymbol{U}$, ar trebui să ne așteptăm $\x \approx \hat \x$. Adică, PCA este un caz special de auto-codare:
+\begin{equation}
+    \x   \xrightarrow{\hspace{2mm} \boldsymbol{U}^\top\hspace{2mm}} \z  \xrightarrow{\hspace{2mm} \boldsymbol{U} \hspace{2mm}} \hat \x.
+       \label{eqn:auto-encoding-PCA}
+\end{equation}
+Doar că aici, din cauza structurii simple a datelor, codificatorul $\mathcal{E}$ și decodificatorul $\mathcal{D}$ devin ambii operatori liniari simpli (proiectare și ridicare).
+
+Aceasta este o problemă clasică în statistică cunoscută sub numele de Analiza Componentelor Principale (PCA). A fost studiată pentru prima dată de Pearson în 1901 \cite{Pearson1901} și mai târziu independent de Hotelling în 1933 \cite{Hotelling1933}. Acest subiect este rezumat sistematic în cartea clasică \cite{Jolliffe1986,JolliffeI2002}.
+În plus, se poate presupune explicit că datele $\x$ sunt distribuite conform unei singure gaussiene cu dimensiuni reduse:
+\begin{equation}
+    \x \sim \mathcal{N}(\boldsymbol{0}, \boldsymbol{U}\boldsymbol{U}^\top + \sigma \I), \quad \boldsymbol{U} \in \mathbb{R}^{D\times d},
+\end{equation}
+care este echivalent cu presupunerea că $\z$ în modelul PCA de mai sus \eqref{eqn:PCA-model} este o distribuție normală standard.
+Aceasta este cunoscută ca PCA Probabilistică \cite{TippingM1999}.
+
+În această carte, vom revizita PCA în \Cref{ch:classic}, din perspectiva învățării unei distribuții cu dimensiuni reduse. Obiectivul nostru este să folosim acest model simplu și idealist pentru a transmite unele dintre ideile cele mai fundamentale pentru învățarea unei reprezentări compacte pentru o distribuție cu dimensiuni reduse, inclusiv noțiunea importantă de compresie prin îndepărtarea zgomotului și autocodare pentru o reprezentare consistentă.
+
+\paragraph{Analiza Componentelor Independente.}
+Analiza componentelor independente (ICA) a fost propusă inițial de \cite{Ans-1985} ca un model clasic pentru {\em învățarea unei reprezentări bune}. De fapt, a fost propusă inițial ca un model matematic simplu pentru memoria noastră. Modelul ICA ia o formă înșelător de similară cu modelul PCA de mai sus \eqref{eqn:PCA-model} presupunând că variabila aleatorie observată $\x$ este o suprapunere liniară a mai multor componente independente $z_i$:
+\begin{equation}
+    \x = \boldsymbol{u}_1 z_1 + \boldsymbol{u}_2 z_2 + \cdots + \boldsymbol{u}_d z_d  + \boldsymbol{\epsilon} =  \boldsymbol{U} \z + \boldsymbol{\epsilon}.
+    \label{eqn:ICA-model}
+\end{equation}
+Cu toate acestea, aici componentele $z_i$ sunt presupuse a fi variabile {\em non-gaussiene} independente. De exemplu, o alegere populară este
+\begin{equation}
+    z_i = \sigma_i \cdot w_i, \quad \sigma_i \sim B(1,p),
+    \label{eqn:ICA-modes}
+\end{equation}
+unde $\sigma_i$ este o variabilă Bernoulli și $w_i$ ar putea fi o valoare constantă sau o altă variabilă aleatorie, să zicem gaussiană.\footnote{Chiar dacă $w$ este gaussiană, $\sigma w$ nu mai este o variabilă gaussiană!} Problema ICA încearcă să identifice atât $\boldsymbol{U}$ cât și $\z$ din eșantioane observate de $\x$. \Cref{fig:ICA-PCA} ilustrează diferența dintre ICA și PCA.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.7\linewidth]{\toplevelprefix/chapters/chapter1/figs/PCA_ICA.png}
+    \caption{PCA (stânga) versus ICA (dreapta).}
+    \label{fig:ICA-PCA}
+\end{figure}
+
+Deși maparea (de decodare) de la $\z$ la $\x$ pare liniară și ușoară odată ce $\boldsymbol{U}$ și $\z$ sunt învățate, maparea (de codare) de la $\x$ la $\z$ poate fi complicată și s-ar putea să nu fie reprezentată de o simplă mapare liniară. Prin urmare, ICA oferă în general o autocodare de forma:
+\begin{equation}
+    \x   \xrightarrow{\hspace{2mm} \mathcal{E}\hspace{2mm}} \z  \xrightarrow{\hspace{2mm} \boldsymbol{U} \hspace{2mm}} \hat \x.
+       \label{eqn:auto-encoding-ICA}
+\end{equation}
+Prin urmare, spre deosebire de PCA, ICA este puțin mai dificil de analizat și rezolvat. În anii 1990, cercetători precum Erkki Oja și Aapo Hyv\"{a}rinen \cite{hyvarinen-1997,Hyvrinen-2000} au adus contribuții teoretice și algoritmice semnificative la ICA. În \Cref{ch:classic}, vom studia și vom oferi o soluție la ICA din care maparea de codare $\mathcal{E}$ va deveni clară.
+
+
+
+\paragraph{Structuri Rare și Detectare Comprimată.}
+După cum se poate vedea, dacă $p$ în \eqref{eqn:ICA-modes} este foarte mic, probabilitatea ca oricare dintre componente să fie diferită de zero este mică. În acest caz, spunem că $\x$ este generat rar și se concentrează pe un set de subspații liniare de dimensiune $k = p \cdot d$. Prin urmare, într-o oarecare măsură, putem extinde modelul ICA de mai sus la o familie mai generală de structuri cu dimensiuni reduse cunoscută sub numele de modele rare.
+
+Un model $k$-rar este definit ca fiind format din setul tuturor {\em vectorilor $k$-rari}:
+\begin{equation}
+    \mathcal{Z} = \{\z \in \mathbb{R}^n \mid \|\z\|_0 \le k\},
+\end{equation}
+unde $\| \cdot \|_0$ este norma $\ell^0$ care numără numărul de intrări diferite de zero într-un vector $\z$. Adică, $\mathcal{Z}$ este reuniunea tuturor subspațiilor $k$-dimensionale care se aliniază cu axele de coordonate, așa cum este ilustrat în \Cref{fig:mixture-models} stânga. O problemă importantă în procesarea clasică a semnalelor și statistică este cum să recuperăm un vector rar $\z$ din observațiile sale liniare:
+\begin{equation}
+    \x = \boldsymbol{A} \z + \boldsymbol{\epsilon}, \quad \boldsymbol{A} \in \mathbb{R}^{m\times n}
+    \label{eqn:sparse-model}
+\end{equation}
+unde $\boldsymbol{A}$ este dat, dar de obicei $m < n$ și $\boldsymbol{\epsilon}$ este un anumit zgomot mic. Această problemă aparent benignă se dovedește a fi NP-grea de calculat și este chiar greu de aproximat (vezi cartea \cite{Wright-Ma-2022} pentru detalii).
+
+Deci, în ciuda unei istorii foarte bogate și lungi de studiu care poate fi datată încă din secolul al XVIII-lea \cite{Boscovichca1750}, nu a existat niciun algoritm dovedit eficient pentru a rezolva această clasă de probleme, deși au fost propuși și dezvoltați mulți algoritmi euristici între anii 1960 și 1990. Unii sunt destul de eficienți în practică, dar fără nicio justificare riguroasă. O descoperire majoră a venit la începutul anilor 2000 când câțiva matematicieni renumiți, inclusiv David Donoho, Emmanuel Cand\`{e}s și Terence Tao \cite{donoho2005neighborly,Candes2005,CandesE2005-IT} au stabilit un cadru teoretic riguros care ne permite să caracterizăm condiții precise în care problema de recuperare rară poate fi rezolvată eficient și eficace, să zicem printr-o minimizare convexă $\ell^1$:
+\begin{equation}
+    \min \|\z\|_1 \quad \mbox{subiect la} \quad \| \x - \boldsymbol{A}\z\|_2 \le \epsilon,
+\end{equation}
+unde $\|\cdot \|_1$ este norma $\ell^1$ care promovează raritatea unui vector și $\epsilon$ este o constantă mică. Orice soluție la această problemă oferă în esență o mapare de codare rară:
+\begin{equation}
+    \x   \xrightarrow{\hspace{2mm} \mathcal{E} \hspace{2mm}}  \z.
+       \label{eqn:decoding-sparse}
+\end{equation}
+Vom oferi o scurtă relatare a unui astfel de algoritm, prin urmare mapare, în \Cref{ch:classic} care va dezvălui conexiuni fundamentale interesante între codarea rară și învățarea profundă.\footnote{Deși similaritățile dintre algoritmii pentru codarea rară și rețelele profunde au fost observate încă din 2010 \cite{gregor2010learning}.}
+
+După cum se dovedește, condițiile în care minimizarea $\ell^1$ reușește sunt surprinzător de generale. Numărul minim de măsurători $m$ necesar pentru o recuperare de succes este doar proporțional cu dimensiunea intrinsecă a datelor $k$. Aceasta este acum cunoscută sub numele de fenomenul {\em detectării comprimate} \cite{CandesE2006-ICM}. Mai mult, acest fenomen nu este unic pentru structurile rare. Se aplică și la familii foarte largi de structuri cu dimensiuni reduse, cum ar fi matricile de rang mic etc. Aceste rezultate au schimbat fundamental înțelegerea noastră despre recuperarea structurilor cu dimensiuni reduse în spații cu dimensiuni mari. Această inversare dramatică a norocului cu analiza datelor cu dimensiuni mari a fost chiar sărbătorită ca {\em „binecuvântarea dimensionalității"} de David Donoho \cite{DonohoD2000}, spre deosebire de credința pesimistă tipică în „blestemul dimensionalității" pentru problemele cu dimensiuni mari. Acest corp coerent și complet de rezultate a fost organizat sistematic în cartea \cite{Wright-Ma-2022}.
+
+Din perspectivă computațională, nu se poate supraestima semnificația acestui nou cadru. A schimbat fundamental viziunile noastre despre o clasă importantă de probleme despre care se credea anterior că sunt în mare parte intractabile. Ne-a permis să dezvoltăm algoritmi extrem de eficienți care se scalează grațios cu dimensiunea problemei, făcând astfel problema recuperării rare de la:
+\begin{equation}
+    \mbox{\textbf{intractabilă}} \;
+   \Longrightarrow \; \mbox{\textbf{tractabilă}} \; \Longrightarrow \;
+   \mbox{\textbf{scalabilă}}.
+\end{equation}
+Acești algoritmi vin și cu garanții teoretice riguroase ale corectitudinii lor, date cerințe precise în date și calcul. Natura riguroasă și precisă a acestei abordări este aproape opusă celei a practicării rețelelor neuronale profunde, care este în mare parte empirică. Cu toate acestea, în ciuda stilurilor și standardelor lor aparent opuse, știm acum că ambele abordări împărtășesc un obiectiv comun: {\em încercarea de a urmări structuri cu dimensiuni reduse în spații cu dimensiuni mari.}
+
+\paragraph{Învățarea Dicționarului.}
+Conceptual, o problemă și mai dificilă decât problema codării rare \eqref{eqn:sparse-model} este atunci când matricea de observație $\boldsymbol{A}$ nu este nici măcar cunoscută în avans și trebuie să învățăm $\boldsymbol{A}$ dintr-un set de observații (posibil zgomotoase), să zicem $\X = [\x_1, \x_2, \ldots, \x_n]$:
+\begin{equation}
+    \X = \boldsymbol{A} \Z + \boldsymbol{E}, \quad \boldsymbol{A} \in \mathbb{R}^{m\times n}.
+    \label{eqn:dictionary-learning}
+\end{equation}
+Aici ni se dă doar $\X$ dar nu și $\Z = [\z_1, \z_2, \ldots, \z_n]$ corespunzător sau termenul de zgomot $\boldsymbol{E}= [\boldsymbol{\epsilon}_1, \boldsymbol{\epsilon}_2, \ldots, \boldsymbol{\epsilon}_n]$, cu excepția faptului că știm că $\z_i$ sunt rari. Aceasta este cunoscută sub numele de problema {\em învățării dicționarului}, care poate fi văzută ca o generalizare a problemei ICA \eqref{eqn:ICA-model} discutată mai devreme. Cu alte cuvinte, dată fiind distribuția datelor $\X$ ca fiind imaginea unei distribuții rare standard $\Z$ sub o transformare liniară $\boldsymbol{A}$, am dori să învățăm $\boldsymbol{A}$ și maparea sa „inversă" $\mathcal{E}$ astfel încât să obținem un autocodor:
+\begin{equation}
+    \X   \xrightarrow{\hspace{2mm} \mathcal{E} \hspace{2mm}}  \Z \xrightarrow{\hspace{2mm} \boldsymbol{A} \hspace{2mm}} \X?
+       \label{eqn:decoding-DL}
+\end{equation}
+
+Se poate vedea ce au în comun PCA, ICA și Învățarea Dicționarului este că toate presupun că distribuția datelor este susținută în jurul structurilor liniare sau mixte liniare cu dimensiuni reduse. Toate necesită învățarea unei baze (globale sau locale) a structurilor liniare, din eșantioane probabil zgomotoase ale distribuției. În \Cref{ch:classic}, vom studia cum să identificăm structuri cu dimensiuni reduse prin aceste modele clasice. În special, vom vedea un fapt interesant și important: toate aceste modele (pe bucăți) liniare cu dimensiuni reduse pot fi învățate eficient și eficace de același tip de algoritmi rapizi, cunoscuți sub numele de {\em iterație de putere} \cite{Zhai-2020}. Deși modelele liniare sau mixte liniare de mai sus sunt oarecum prea simpliste sau idealiste pentru majoritatea datelor din lumea reală, înțelegerea acestor modele este un prim pas important către înțelegerea distribuțiilor mai generale cu dimensiuni reduse.
+
+\subsubsection{Distribuții Generale}\label{sec:denoising-intro}
+
+Distribuțiile datelor din lumea reală, cum ar fi imaginile, videoclipurile și sunetul, sunt prea complexe pentru a fi modelate de modelele liniare oarecum idealiste de mai sus. În mod normal, nu știm {\em a priori} din care familie de modele parametrice sunt generate.\footnote{Deși în istorie au existat multe încercări de a dezvolta modele analitice pentru aceste date, cum ar fi câmpuri aleatorii sau procese stochastice pentru date imagistice \cite{Mumford-1999}, așa cum am discutat în secțiunea anterioară.} În practică, de obicei avem doar multe eșantioane din distribuțiile lor -- distribuțiile empirice. Evident, în astfel de cazuri, în mod normal nu ne putem aștepta să avem soluții în formă închisă pentru structurile lor cu dimensiuni reduse, nici pentru operatorii de îndepărtare a zgomotului rezultați.\footnote{Spre deosebire de cazurile PCA, filtrul Wiener și filtrul Kalman.} Deci trebuie să dezvoltăm o soluție mai generală pentru aceste distribuții empirice, nu neapărat în formă închisă, dar cel puțin calculabilă eficient. Dacă am face acest lucru corect, soluțiile la modelele liniare menționate anterior ar trebui să devină cazurile lor speciale.
+
+\paragraph{Îndepărtarea zgomotului.} În anii 1950, statisticienii au devenit interesați de problema îndepărtării zgomotului din date extrase dintr-o distribuție arbitrară. Fie $\x_o$ o variabilă aleatorie cu funcția de densitate de probabilitate $p_o(\cdot)$. Deci, dacă observăm o versiune zgomotoasă a $\x_o$:
+\begin{equation}
+    \x = \x_o + \sigma \vg,
+\end{equation}
+unde $\vg \sim \dNorm(\vzero, \vI)$ este zgomot gaussian standard și $\sigma$ este nivelul de zgomot al observației. Fie $p(\cdot)$ funcția de densitate de probabilitate a $\x$,\footnote{Adică, $p(\x) = \int_{-\infty}^{\infty} \phi_{\sigma}(\x - \z)p_o(\z) \odif{\z}$, unde $\phi_{\sigma}$ este funcția de densitate a distribuției gaussiene $\mathcal{N}(\boldsymbol{0}, \sigma^2 \boldsymbol{I})$.} Uimitor, așteptarea posterioară a $\x_o$ dat $\x$ poate fi calculată printr-o formulă elegantă, cunoscută sub numele de formula lui Tweedie \cite{Robbins1956AnEB}:\footnote{Herbert Robbins a dat creditul pentru această formulă lui Maurice Kenneth Tweedie din corespondența lor personală.}
+\begin{equation}
+    \hat \x_o = \mathbb{E}[\x_o\mid \x] = \x + \sigma^2 \nabla \log p(\x).
+\end{equation}
+După cum se poate vedea din formulă, funcția $\nabla \log p(\x)$ joacă un rol foarte special în îndepărtarea zgomotului din observația $\x$ aici. Zgomotul $\vg$ poate fi estimat explicit ca
+\begin{equation}
+    \hat{\vg} = \frac{\x - \hat \x_o}{\sigma} = -\sigma \nabla \log p(\x),
+\end{equation}
+pentru care avem nevoie doar să cunoaștem distribuția $p(\cdot)$ a $\x$, nu adevărul de bază $p_o(\cdot)$ pentru $\x_o$. O implicație importantă a acestui rezultat este că, dacă adăugăm zgomot gaussian la orice distribuție, procesul de îndepărtare a zgomotului poate fi făcut ușor dacă putem cumva să obținem funcția $\nabla \log p(\x)$.
+
+Deoarece acesta este un rezultat atât de important și util, a fost redescoperit și folosit în multe contexte și domenii diferite. De exemplu, după formula lui Tweedie \cite{Robbins1956AnEB}, a fost redescoperită câțiva ani mai târziu de \cite{Miyasawa61}. La începutul anilor 2000, funcția $\nabla \log p(\x)$ a fost redescoperită din nou în contextul învățării unei distribuții generale și a fost numită „funcția de scor" de Aapo Hyv\"{a}rinen \cite{hyvarinen05a}. Dar conexiunea sa cu îndepărtarea zgomotului (Bayesian empiric) a fost recunoscută curând de \cite{Vincent2011}.
+Generalizări la alte distribuții de măsurare (dincolo de zgomotul gaussian) au fost făcute de grupul lui Eero Simoncelli \cite{Raphan10} și aplicate ulterior la îndepărtarea zgomotului din imagini \cite{Kadkhodaie21a,ho2020denoising}.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=1\linewidth]{\toplevelprefix/chapters/chapter1/figs/Density-compress.png}
+    \caption{Interpretarea geometrică a unei funcții de scor $\nabla \log p(\x)$ pentru o distribuție cu densitatea $p(\x)$ pe stânga. Operația generată de funcția de scor împinge distribuția către zone cu densitate mai mare. Obiectivul este ca, printr-o anumită măsură de compactitate (de exemplu, entropie sau lungime de codare), distribuția rezultată să fie mai „comprimată". În cele din urmă, distribuția converge la una care are un suport cu dimensiuni mai reduse, așa cum $p^*(\x)$ arătat pe dreapta.}
+    \label{fig:score-function}
+\end{figure}
+
+\paragraph{Minimizarea entropiei.} De fapt, această funcție are o interpretare foarte intuitivă din punct de vedere teoretic-informațional și geometric. Notați că în teoria informației $-\log p(\x)$ corespunde în general numărului de biți necesari pentru a codifica $\x$\footnote{cel puțin în cazul unei variabile discrete, așa cum vom explica mai detaliat în \Cref{ch:compression}.}. Gradientul $\nabla \log p(\x)$ indică o direcție în care densitatea este mai mare, așa cum se arată în \Cref{fig:score-function} stânga. Numărul de biți necesari pentru a codifica $\x$ scade dacă se mișcă în acea direcție. Prin urmare, efectul general al operatorului $\nabla \log p(\x)$ este să împingă distribuția să „se micșoreze" către zone cu densitate mai mare. De fapt, se poate arăta formal că entropia (diferențială) a distribuției
+\begin{equation}
+H(\x) = - \int p(\boldsymbol{w}) \log p(\boldsymbol{w}) \odif{\boldsymbol{w}}    \end{equation}
+scade într-adevăr sub o astfel de operație (vezi \Cref{ch:compression} și \Cref{app:diffusion-denoising}). Prin urmare, dacă o codificăm cu o carte de coduri optimă, lungimea/rata generală de codare a distribuției rezultate este redusă, prin urmare mai „comprimată". Intuitiv, ne putem imagina că, dacă repetăm un astfel de proces de îndepărtare a zgomotului la nesfârșit, distribuția va ajunge în cele din urmă să se micșoreze la una a cărei masă este concentrată pe un suport de dimensiune inferioară. De exemplu, distribuția $p(\x)$ prezentată în stânga din \Cref{fig:score-function}, sub acțiunea funcției de scor $\nabla \log p(\x)$, va converge în cele din urmă la distribuția $p^*(\x)$ din dreapta\footnote{Strict vorbind, $p^*(\x)$ este o distribuție a cărei densitate este o funcție generalizată: $p^*(\x) = p^*(\x_1)\delta(\x-\x_1) + p^*(\x_2) \delta(\x-\x_2)$, cu $p^*(\x_1) + p^*(\x_2) = 1$.}:
+\begin{equation}
+H(\x) = - \int p(\boldsymbol{w}) \log p(\boldsymbol{w}) \odif{\boldsymbol{w}}  \quad \xrightarrow{\hspace{1mm} \mbox{descrescând} \hspace{1mm}} \quad H^*(\x) = - \int p^*(\boldsymbol{w}) \log p^*(\boldsymbol{w}) \odif{\boldsymbol{w}}.
+\end{equation}
+Strict vorbind, pe măsură ce distribuția converge la $p^*(\x)$, entropia sa diferențială converge la infinit negativ. Aceasta se datorează unei diferențe tehnice între definiția entropiei diferențiale pentru variabilele aleatoare continue și variabilele aleatoare discrete, respectiv. Vom vedea cum să rezolvăm această dificultate tehnică în \Cref{ch:compression}, folosind o măsură mai uniformă de {\em distorsiune a ratei}.
+
+
+Vom discuta mai târziu în acest capitol și în \Cref{ch:compression} cum un concept aparent simplu de îndepărtare a zgomotului și compresie duce la o metodă foarte unificatoare și puternică pentru învățarea distribuțiilor generale cu dimensiuni reduse într-un spațiu cu dimensiuni mari, inclusiv distribuția imaginilor naturale.
+
+\subsection{Abordări Empirice}
+În practică, pentru multe date importante din lumea reală, cum ar fi imagini, sunete și texte, este dificil să le modelăm cu modele liniare sau mixte liniare idealiste. De exemplu, există o istorie lungă și bogată în domeniile procesării imaginilor și vederii pe calculator care încearcă să modeleze distribuția imaginilor naturale analitic. David Mumford, un medaliat Fields, a depus un efort considerabil în anii 1990 încercând să înțeleagă și să modeleze statistica imaginilor naturale \cite{Mumford1996TheSD}. El și studenții săi, inclusiv Song-Chun Zhu, au tras inspirație și tehnici din fizica statistică și au propus multe modele statistice și stochastice pentru distribuția imaginilor naturale \cite{Zhu-Entropy-1997,Zhu1997LearningGP,Zhu1997Prior,Huang-Mumford,Mumford-1999,Lee-Mumford}. Cu toate acestea, aceste modele analitice au întâmpinat un succes limitat în producerea de eșantioane care să semene îndeaproape cu imaginile naturale. Evident, pentru date din lumea reală precum imaginile, trebuie să dezvoltăm metode mai puternice și unificatoare pentru a urmări structurile lor mai generale cu dimensiuni reduse.
+
+Prin urmare, istoric, au fost propuse multe modele empirice pentru a modela date importante din lumea reală, inclusiv imagini și texte. Aceste modele au tras adesea inspirație din caracteristicile sistemului nervos biologic, deoarece creierul unui animal sau om pare să proceseze aceste date extrem de eficient și eficace.
+
+\subsubsection{Rețele Neuronale Artificiale Clasice}
+\paragraph{Neuronul artificial.}
+
+\begin{figure}[t]
+    \centering
+\includegraphics[width=0.55\linewidth]{\toplevelprefix/chapters/chapter1/figs/neuron.png} \hspace{3mm}
+\includegraphics[width=0.40\linewidth]{\toplevelprefix/chapters/chapter1/figs/Artificial_neuron.png}
+    \caption{Primul model matematic al unui neuron artificial (dreapta) care emulează modul în care un neuron (stânga) procesează semnale.}
+    \label{fig:neuron}
+\end{figure}
+
+Inspirat de sistemul nervos din creier, modelul matematic al primului neuron artificial\footnote{cunoscut ca Unitatea de Prag Liniar sau un perceptron.} a fost propus de Warren McCulloch\footnote{Un profesor de psihiatrie la Universitatea din Chicago la acea vreme} și Walter Pitts în 1943 \cite{McCulloch-Pitts}. Acesta descrie relația dintre intrarea $x_i$ și ieșirea $o_j$ ca:
+\begin{equation}
+    o_j = \varphi\Big( \sum_i w_{ji}x_i\Big),
+\end{equation}
+unde $\varphi(\cdot)$ este o anumită activare neliniară, modelată în mod normal de o funcție de prag. Acest model este ilustrat în \Cref{fig:neuron}. După cum putem vedea, această formă împărtășește deja caracteristicile principale ale unei unități de bază în rețelele neuronale profunde moderne. Modelul este derivat din observații despre cum funcționează un singur neuron în sistemul nostru nervos. Cu toate acestea, oamenii nu știau exact ce funcții dorește să realizeze și să efectueze o colecție de astfel de neuroni. La un nivel mai tehnic, nici nu erau siguri ce funcție de activare neliniară $\varphi(\cdot)$ ar trebui folosită. Prin urmare, istoric au fost propuse multe variante.\footnote{Funcție treaptă, pragare dură sau moale, Unitate Liniară Rectificată (ReLU), sigmoid etc.}
+
+\begin{figure}[t]
+\centering
+\includegraphics[width=0.85\linewidth]{\toplevelprefix/chapters/chapter1/figs/single-deep.png}
+    \caption{O rețea cu un singur strat ascuns (stânga) versus o rețea profundă (dreapta).}
+    \label{fig:single-deep}
+\end{figure}
+\paragraph{Rețea neuronală artificială.}
+În anii 1950, Frank Rosenblatt a fost primul care a construit o mașină cu o {\em rețea} de astfel de neuroni artificiali, prezentată în \Cref{fig:perceptron}. Mașina se numește Mark I Perceptron, care constă dintr-un strat de intrare, un strat de ieșire și un singur strat ascuns format din 512 neuroni artificiali, așa cum se arată în \Cref{fig:perceptron} stânga, care este similar cu ceea ce este ilustrat în \Cref{fig:single-deep} stânga. A fost concepută pentru a clasifica imagini optice de litere. Cu toate acestea, capacitatea unei rețele cu un singur strat este limitată și poate învăța doar tipare separabile liniar. Într-o carte din 1969 {\em Perceptrons: O Introducere în Geometria Computațională} de Marvin Minsky și Seymour Papert \cite{Minsky-1969}, s-a arătat că arhitectura cu un singur strat a Mark I Perceptron nu poate învăța o funcție XOR. Acest rezultat a diminuat semnificativ interesul oamenilor pentru rețelele neuronale artificiale, chiar dacă s-a dovedit ulterior că o rețea cu mai multe straturi este capabilă să învețe o funcție XOR \cite{Rumelhart1986}. De fapt, o rețea multi-strat (suficient de mare), așa cum se arată în \Cref{fig:single-deep} dreapta, constând din astfel de neuroni simpli poate simula orice mașină cu stare finită, chiar și mașina Turing universală.\footnote{Nu confundați ce sunt capabile să facă rețelele neuronale în principiu cu dacă este tractabil sau ușor să învățați o rețea neuronală care realizează anumite funcții dorite.} Cu toate acestea, ulterior, studiul rețelelor neuronale artificiale a intrat în prima sa iarnă în anii 1970.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.45\linewidth]{\toplevelprefix/chapters/chapter1/figs/visu-large.jpg}
+    \hspace{2mm} \includegraphics[width=0.45\linewidth]{\toplevelprefix/chapters/chapter1/figs/Original-Mark-I-perceptron-as-seen-in-its-operators-manual-20.ppm.png}
+    \caption{Mașina Mark I Perceptron dezvoltată de Frank Rosenblatt la sfârșitul anilor 1950.}
+    \label{fig:perceptron}
+\end{figure}
+
+
+\paragraph{Rețele neuronale convoluționale.}
+Experimentarea oarecum dezamăgitoare timpurie cu rețele neuronale artificiale precum Mark I Perceptron în anii 50 și 60 a sugerat că s-ar putea să nu fie suficient să conectăm pur și simplu neuronii într-o manieră generală ca perceptroni multistrat (MLP). Pentru a construi rețele efective și eficiente, trebuie să înțelegem ce scop sau funcție trebuie să realizeze neuronii într-o rețea în mod colectiv, astfel încât aceștia să fie organizați și învățați într-un anumit mod special. Din nou, studiul inteligenței mașinilor s-a întors la a trage inspirație din modul în care funcționează sistemul nervos al animalelor.
+
+Se știe că cea mai mare parte a creierului nostru este dedicată procesării informațiilor vizuale. În anii 1950 și 1960, David Hubel și Torsten Wiesel au studiat sistematic cortexurile vizuale ale pisicilor. S-a descoperit că cortexul vizual conține diferite tipuri de celule (cunoscute ca celule simple și celule complexe), care sunt sensibile la stimuli vizuali de diferite orientări și locații \cite{Hubel-Wiesel-1959}. Hubel și Wiesel au câștigat Premiul Nobel pentru Fiziologie sau Medicină în 1981 pentru descoperirea lor revoluționară.
+
+
+Pe partea rețelelor neuronale artificiale, lucrarea lui Hubel și Wiesel l-a inspirat pe Kunihiko Fukushima care a proiectat rețeaua „neocognitron" în 1980, care constă din neuroni artificiali care emulează neuronii biologici din cortexurile vizuale \cite{Fukushima1980NeocognitronAS}. Aceasta este cunoscută ca prima {\em rețea neuronală convoluțională} (CNN), iar arhitectura sa este ilustrată în \Cref{fig:neocognitron}. Spre deosebire de perceptron, neocognitronul avea mai mult de un strat ascuns și putea fi văzut ca o rețea profundă, așa cum este comparat în \Cref{fig:single-deep} dreapta.
+
+De asemenea, inspirat de modul în care funcționează neuronii în cortexul vizual al pisicii, el a fost și primul care a introdus utilizarea {\em unității liniare rectificate} (ReLU):
+\begin{equation}
+    \varphi(x) = \max\{0, x\} = \casework{x, & \text{dacă} \, x > 0, \\ 0, \quad & \text{dacă} \, x \leq 0,}
+\end{equation}
+pentru funcția de activare $\varphi(\cdot)$ în 1969 \cite{Fukushima-1969}. Dar abia în anii recenți ReLU a devenit o funcție de activare larg utilizată în rețelele neuronale (convoluționale) profunde moderne. Vom învăța din această carte de ce aceasta este o alegere bună odată ce explicăm operațiile principale pe care rețelele profunde încearcă să le implementeze: compresia.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.6\linewidth]{\toplevelprefix/chapters/chapter1/figs/neocognitron.png}
+    \caption{Originea rețelelor neuronale convoluționale: Neocognitronul de Kunihiko Fukushima în 1980. Observați că straturile intercalate de convoluții și pooling încearcă să emuleze funcțiile celulelor simple și ale celulelor complexe descoperite în cortexurile vizuale ale pisicilor.}
+    \label{fig:neocognitron}
+\end{figure}
+
+Rețelele de tip CNN au continuat să evolueze în anii 1980 și au fost introduse și studiate multe variante diferite. Cu toate acestea, în ciuda capacităților remarcabile ale rețelelor profunde și a arhitecturilor îmbunătățite inspirate de neuroștiință, a rămas extrem de dificil să antrenăm astfel de rețele profunde pentru o sarcină reală precum clasificarea imaginilor. Cum să faci o rețea să funcționeze depindea de multe euristici și trucuri inexplicabile care au limitat cu adevărat atractivitatea și aplicabilitatea rețelelor neuronale. O descoperire majoră a venit în jurul anului 1989 când Yann LeCun a folosit cu succes {\em propagarea înapoi} (BP) pentru a învăța o rețea neuronală convoluțională profundă pentru recunoașterea cifrelor scrise de mână \cite{LeCun-1989}, cunoscută mai târziu sub numele de LeNet (vezi \Cref{fig:LeNet-5}). După câțiva ani de dezvoltare persistentă, perseverența sa a dat roade: performanța LeNet a devenit în cele din urmă suficient de bună pentru utilizare practică la sfârșitul anilor 1990 \cite{LeCun-1998}: a fost folosită de Poșta SUA pentru recunoașterea cifrelor scrise de mână (pentru codurile poștale). LeNet a fost considerat rețeaua „prototip" pentru toate rețelele neuronale profunde moderne, cum ar fi AlexNet și ResNet, pe care le vom discuta mai târziu. Datorită acestei lucrări, Yann LeCun a primit Premiul Turing 2018.\footnote{Împreună cu alți doi pionieri ai rețelelor profunde, Yoshua Bengio și Geoffrey Hinton.}
+
+\begin{figure}
+    \centering
+\includegraphics[width=0.95\linewidth]{\toplevelprefix/chapters/chapter1/figs/LeNet-5.png}
+    \caption{Rețeaua neuronală convoluțională LeNet-5 proiectată de Yann LeCun în 1989.}
+    \label{fig:LeNet-5}
+\end{figure}
+
+\paragraph{Propagarea înapoi.}
+În istorie, soarta rețelelor neuronale profunde pare să fie strâns legată de cum pot fi antrenate ușor și eficient. Propagarea înapoi (BP) a fost introdusă din acest motiv. Știm că un perceptron cu straturi multiple poate fi exprimat ca o compoziție a unei secvențe de mapări liniare și activări neliniare după cum urmează:
+\begin{equation}
+h(\bm W_1, \ldots, \bm W_L) = f^L(\bm W_Lf^{L-1}(\bm W_{L-1} \cdots f^2(\bm W_2f^1(\bm W_1\x)))).
+\end{equation}
+Pentru a antrena ponderile rețelei $\{\bm W_l\}_{l=1}^L$ pentru a reduce eroarea de predicție/clasificare pe baza unui algoritm de coborâre pe gradient, trebuie să evaluăm gradientul ${\partial h}/{\partial \bm W_l}$. Este bine cunoscut, din {\em regula lanțului} din calcul, că gradienții pot fi calculați eficient pentru acest tip de funcții, cunoscut mai târziu ca propagare înapoi (BP). Vezi \Cref{app:optimization} pentru o descriere detaliată. Tehnica propagării înapoi era deja cunoscută și practicată de oameni în domenii precum controlul optim și programarea dinamică în anii 1960 și 1970. De exemplu, a apărut în teza de doctorat din 1974 a Dr. Paul Werbos \cite{Werbos-1974, Werbos1994TheRO}. În 1986, David Rumelhart și colab. au fost primii care au aplicat propagarea înapoi pentru a antrena o rețea cu perceptron multistrat (MLP) \cite{Rumelhart1986}. De atunci, BP a devenit din ce în ce mai popular deoarece oferă un algoritm {\em scalabil} pentru a învăța rețele neuronale profunde mari.\footnote{deoarece poate fi implementat eficient pe platforme de calcul care facilitează calculul paralel și distribuit.} Este acum o tehnică aproape dominantă pentru antrenarea rețelelor neuronale profunde astăzi. Cu toate acestea, se crede că natura nu învață prin propagare înapoi, deoarece un astfel de mecanism este încă mult prea costisitor pentru implementarea fizică de către natură\footnote{După cum am discutat mai devreme, natura învață aproape omniprezent să corecteze erorile prin feedback în buclă închisă.}. Acest lucru lasă evident un spațiu enorm pentru îmbunătățiri în viitor, așa cum vom discuta mai mult.
+
+Cu toate acestea, în ciuda progresului algoritmic de mai sus și a practicii promițătoare din anii 1980, antrenarea rețelelor neuronale profunde a rămas extrem de capricioasă și costisitoare pentru sistemele de calcul din anii 1980 și 1990. La sfârșitul anilor 1990, mașinile cu vectori suport (SVM) \cite{SVM-1995} au devenit foarte populare deoarece erau văzute ca o alternativă mai bună la rețelele neuronale pentru sarcini precum clasificarea.\footnote{De fapt, idei similare pentru a rezolva probleme de clasificare pot fi urmărite înapoi la lucrarea de disertație de doctorat a lui Thomas Cover, care a fost condensată și publicată într-o lucrare în 1964 \cite{Cover-1964}.} Existau două motive principale: în primul rând, SVM se baza pe un cadru riguros de învățare statistică cunoscut sub numele de teoria Vapnik-Chervonenkis (VC); și în al doilea rând, duce la algoritmi destul de eficienți bazați pe optimizare convexă \cite{BoydVa04}. Ascensiunea SVM a adus o a doua iarnă studiului rețelelor neuronale în jurul începutului anilor 2000.
+
+\paragraph{Autocodare compresivă.}
+La sfârșitul anilor 1980 și 1990, rețelele neuronale artificiale au fost deja adoptate pentru a învăța reprezentări cu dimensiuni reduse ale datelor cu dimensiuni mari, cum ar fi imaginile. S-a arătat că rețelele neuronale pot fi folosite pentru a învăța PCA din date \cite{Oja1982SimplifiedNM,Baldi89}, în loc să folosească metodele clasice discutate în \Cref{sec:PCA-ICA}. S-a argumentat, de asemenea, la sfârșitul anilor 1980 că, datorită capacității sale de a modela transformări neliniare, rețelele neuronale au fost sugerate pentru a învăța reprezentări cu dimensiuni reduse pentru date cu distribuții neliniare. Similar cu cazul PCA liniar, se poate încerca să învețe simultan un codificator neliniar de reducere a dimensionalității $f$ și un decodificator $g$, fiecare modelat de o rețea neuronală profundă \cite{Rumelhart1986,Kramer1991NonlinearPC}:
+\begin{equation}
+    \X   \xrightarrow{\hspace{2mm} f \hspace{2mm}} \Z  \xrightarrow{\hspace{2mm} g \hspace{2mm}} \hat \X.
+       \label{eqn:auto-encoding-deep-networks}
+\end{equation}
+Prin impunerea ca datele decodate $\hat \X$ să fie consistente cu originalul $\X$, să zicem prin minimizarea unei erori de reconstrucție de tip MMSE\footnote{Deși erorile de tip MMSE sunt cunoscute ca fiind problematice pentru datele imagistice care au structuri neliniare complexe. După cum vom discuta curând, o mare parte din munca recentă în metodele generative, inclusiv GAN-urile, a fost pentru a găsi înlocuitori ai funcțiilor de distanță mai bune între datele originale $\X$ și cele regenerate $\hat \X$.}:
+\begin{equation}
+    \min_{f,g} \big\|\X - \hat \X\big\|_2^2 = \big\|\X - g(f( \X))\big\|_2^2,
+\end{equation}
+un autocodor poate fi învățat din datele $\X$ însele.
+
+Dar cum putem garanta că o astfel de autocodare captează într-adevăr structurile adevărate cu dimensiuni reduse din $\X$ în loc să dea o reprezentare redundantă trivială? De exemplu, putem alege pur și simplu $f$ și $g$ să fie maparea identitate și $\Z = \X$. Deci, pentru a asigura că autocodarea merită, se dorește ca reprezentarea rezultată să fie compresivă, în termenii unei anumite măsuri calculabile de complexitate. În 1993, Geoffrey Hinton și colegii au propus să folosească lungimea de codare ca o astfel de măsură, prin urmare obiectivul autocodării a devenit să găsească o astfel de reprezentare care minimizează lungimea de codare \cite{Hinton-1993}. Această lucrare a stabilit, de asemenea, o conexiune fundamentală între principiul lungimii minime de descriere \cite{Rissanen-1978} și minimizarea energiei libere (Helmholtz). Lucrarea ulterioară \cite{Hinton504} din grupul lui Hinton a arătat empiric că o astfel de autocodare este capabilă să învețe reprezentări semnificative cu dimensiuni reduse pentru imagini din lumea reală. Un sondaj mai cuprinzător al autocodorilor a fost făcut de Pierre Baldi în 2011 \cite{Baldi2011}, chiar înainte ca rețelele profunde să devină populare. Vom discuta mai multe despre măsura complexității și autocodare mai târziu în \Cref{sec:unifying-approach} și vom oferi un studiu sistematic al autocodării compresive în \Cref{ch:consistent}, cu o viziune mai unificatoare.
+
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.8\linewidth]{\toplevelprefix/chapters/chapter1/figs/Comparison_image_neural_networks.svg.png}
+    \caption{Arhitectura LeNet \cite{LeCun-1989} versus cea a AlexNet \cite{krizhevsky2012imagenet}.}
+    \label{fig:LeNet-AlexNet}
+\end{figure}
+
+
+\subsubsection{Rețele Neuronale Profunde Moderne}
+Timp de aproape 30 de ani, din anii 1980 până în anii 2010, pentru studiul învățării automate și al inteligenței mașinilor, rețelele neuronale nu au fost considerate serios de mainstream. Rețelele neuronale (profunde) timpurii, cum ar fi LeNet, au arătat performanțe promițătoare pentru probleme de clasificare la scară mică, cum ar fi recunoașterea cifrelor. Cu toate acestea, proiectarea și practica rețelelor erau destul de empirice, seturile de date disponibile la acea vreme erau mici, iar algoritmul BP era o povară computațională uriașă pentru calculatoarele de atunci. Acești factori au dus la lipsa de interes pentru rețelele neuronale, iar progresul a stagnat, cu doar o mână de cercetători lucrând la ele.
+
+\paragraph{Clasificare și recunoaștere.}
+După cum se dovedește, potențialul enorm al rețelelor neuronale profunde putea fi eliberat doar odată ce există suficiente date și putere de calcul. Avansând rapid până în anii 2010, seturi de date mult mai mari, cum ar fi ImageNet, au devenit disponibile, iar GPU-urile au devenit suficient de puternice pentru a face BP mult mai accesibil, chiar și pentru rețele mult mai mari decât LeNet. În jurul anului 2012, o rețea neuronală convoluțională profundă cunoscută sub numele de AlexNet a atras atenția, deoarece a depășit metodele de clasificare existente cu o marjă semnificativă cu setul de date ImageNet \cite{krizhevsky2012imagenet}.\footnote{De fapt, înainte de aceasta, rețelele profunde au demonstrat performanțe de ultimă generație în sarcinile de recunoaștere a vorbirii. Dar nu au primit atâta atenție până la succesul lor cu clasificarea imaginilor.} \Cref{fig:LeNet-AlexNet} arată comparația dintre AlexNet și LeNet. AlexNet împărtășește multe caracteristici comune cu LeNet, doar că este mai mare și a adoptat ReLU ca activare neliniară în loc de funcția Sigmoid folosită în LeNet. Parțial datorită influenței acestei lucrări, Geoffrey Hinton a primit Premiul Turing 2018.
+
+
+Acest succes timpuriu a inspirat comunitatea inteligenței mașinilor, în următorii câțiva ani, să exploreze noi variații și îmbunătățiri ale designului rețelei. În special, oamenii au descoperit empiric că cu cât rețelele sunt mai mari și mai profunde, cu atât performanța este mai bună în sarcini precum clasificarea imaginilor. Au fost încercate, testate și popularizate multe arhitecturi de rețele profunde. Câteva notabile includ VGG \cite{Simonyan15}, GoogLeNet \cite{Szegedy2014GoingDW}, ResNet \cite{He2016-lc} și mai recent Transformers \cite{vaswani2017attention} etc. În ciuda progresului rapid în performanța empirică, a existat o lipsă de explicație teoretică pentru aceste arhitecturi descoperite empiric, inclusiv relațiile dintre ele, dacă există. Un scop al acestei cărți este să dezvăluie ce obiectiv comun pot servi toate aceste rețele și de ce împărtășesc anumite caracteristici comune, inclusiv straturi multiple de operator liniar intercalate cu activare neliniară (vezi \Cref{ch:representation}).
+
+\paragraph{Învățare prin întărire.}
+Succesele timpurii ale rețelelor profunde au fost în principal pentru sarcini de clasificare într-un cadru de învățare supravegheată, cum ar fi recunoașterea vorbirii și recunoașterea imaginilor. Rețelele profunde au fost adoptate ulterior de echipa DeepMind, condusă de Demis Hassabis, pentru a învăța politici de luare a deciziilor sau control pentru jocuri. În acest context, rețelele profunde sunt folosite pentru a modela politica optimă de decizie/control sau funcția de valoare optimă asociată, așa cum se arată în \Cref{fig:Alpha-Go}. Acești parametri de rețea sunt optimizați incremental\footnote{Să zicem pe baza propagării înapoi (BP).} pe baza recompensei returnate din succesul sau eșecul jocului cu politica actuală. Această metodă de învățare este denumită în general {\em învățare prin întărire} \cite{Sutton-Barto}, originată din practica sistemelor de control la sfârșitul anilor 1960 \cite{Waltz1965AHA,Mendel1970ReinforcementlearningCA}. Rădăcinile sale anterioare pot fi urmărite înapoi la o istorie mult mai lungă și mai bogată a {\em programării dinamice} de Richard Bellman \cite{Bellman-DP} și {\em învățării prin încercare și eroare} de Marvin Minsky \cite{Minsky-1954} în anii 1950.
+
+Din perspectivă de implementare, combinația dintre rețelele profunde și învățarea prin întărire s-a dovedit a fi destul de puternică: rețelele profunde pot fi folosite pentru a aproxima politica de control și funcția de valoare pentru medii din lumea reală care sunt dificil de modelat analitic. Această practică a condus în cele din urmă la sistemul AlphaGo, dezvoltat de compania DeepMind, care a surprins lumea în 2016 învingând un jucător uman de top Lee Sedol în jocul Go și apoi pe campionul mondial Ke Jie în 2017.\footnote{În 1996, sistemul Deep Blue al IBM a făcut istorie învingându-l pe marele maestru rus Garry Kasparov la șah. A folosit în principal tehnici tradiționale de învățare automată, cum ar fi căutarea în arbore și tăierea, care nu erau atât de scalabile și nu s-au dovedit de succes pentru jocuri mai provocatoare precum Go timp de peste 20 de ani.}
+
+Succesul AlphaGo a venit ca o mare surpriză pentru societatea de calcul care crede în general că spațiul de stare pentru căutare este prea prohibitiv de mare pentru a admite orice soluție eficientă, în termeni de calcul și dimensiunea eșantionului. Singura explicație rezonabilă pentru succesul său este că trebuie să existe structuri foarte bune în funcția optimă de valoare/politică a jocului Go. Dimensiunea lor intrinsecă nu este atât de mare și pot fi aproximate bine de o rețea neuronală, învățabilă din nu atât de prohibitiv multe eșantioane.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter1/figs/Policy-Value.png}
+    \caption{AlphaGo: Folosirea rețelelor neuronale profunde pentru a modela politica optimă sau funcția de valoare optimă pentru jocul Go.}
+    \label{fig:Alpha-Go}
+\end{figure}
+
+\paragraph{Generare și predicție.}
+Se poate vedea practicile timpurii ale rețelelor profunde din anii 2010 ca fiind concentrate mai mult pe extragerea informațiilor relevante din datele $\X$ și codificarea lor pentru o anumită reprezentare specifică sarcinii $\Z$ (să zicem că $\Z$ reprezintă etichete de clasă în sarcinile de clasificare):
+\begin{equation}
+    \X   \xrightarrow{\hspace{2mm} f \hspace{2mm}} \Z.
+       \label{eqn:encoding-deep-networks}
+\end{equation}
+În această setare, maparea $f$ care trebuie învățată nu trebuie să păstreze majoritatea informațiilor distribuite despre $\X$, ci doar statisticile suficiente necesare pentru o sarcină specifică. De exemplu, un eșantion $\x$ din $\X$ ar putea fi o imagine a unui măr, care este mapată de $f$ la eticheta sa de clasă $\z =$ „măr". {\em Cadrul gâtului de sticlă informațional} \cite{Tishby-ITW2015} a fost propus în 2015 pentru a analiza rolul rețelelor profunde într-un astfel de context.
+
+Cu toate acestea, în multe situații moderne, cum ar fi cele numite modele mari de fundație, oamenii trebuie adesea să decodeze $\Z$ pentru a recupera $\X$ corespunzător cu un anumit grad de precizie:
+\begin{equation}
+    \Z   \xrightarrow{\hspace{2mm} g  \hspace{2mm}} \hat \X.
+       \label{eqn:decoding-deep-networks}
+\end{equation}
+Deoarece $\X$ reprezintă de obicei date observate din lumea externă, un decodificator bun ne-ar permite să simulăm sau să prezicem ce se întâmplă în lume. De exemplu, într-o sarcină „text la imagine" sau „text la video", $\z$ reprezintă în mod normal textele care descriu conținutul unei imagini dorite $\x$. Decodificatorul ar trebui să poată genera un $\hat \x$ care are același conținut ca $\x$. De exemplu, dată fiind o clasă de obiecte $\z = $ „măr", decodificatorul $g$ ar trebui să genereze o imagine $\hat \x$ care arată ca un măr, deși nu neapărat exact la fel ca originalul $\x$.
+
+
+
+\paragraph{Generare prin abordări discriminative.}
+Pentru ca imaginile generate $\hat \X$ să fie similare cu imaginile naturale adevărate $\X$, trebuie să putem evalua și minimiza o anumită distanță:
+\begin{equation}
+    \min d(\X, \hat \X).
+\end{equation}
+După cum se dovedește, majoritatea distanțelor motivate teoretic sunt extrem de dificile, dacă nu imposibile, de calculat și optimizat pentru distribuții în spațiu cu dimensiuni mari dar cu dimensiune intrinsecă mică.\footnote{Acesta este cazul chiar dacă este dată o familie parametrică de distribuție pentru $\X$. Distanța devine adesea prost condiționată sau prost definită pentru distribuții cu suporturi cu dimensiuni reduse. Ceea ce ar putea fi și mai rău este că familia aleasă ar putea să nu poată aproxima bine distribuția adevărată de interes.}
+
+În 2007, Zhuowen Tu, un fost student al lui Song-Chun Zhu, probabil dezamăgit de încercările analitice timpurii de a modela și genera imagini naturale (discutate mai devreme), a decis să încerce o abordare drastic diferită. Într-o lucrare publicată în CVPR 2007 \cite{Tu-2007}, el a fost primul care a sugerat că se poate învăța un model generativ pentru imagini printr-o abordare discriminativă. Ideea este simplă: dacă este dificil să evaluezi distanța $d(\X, \hat \X)$, ai putea încerca să înveți un discriminator $d$ pentru a separa $\hat \X$ de $\X$:
+\begin{equation}
+    \Z   \xrightarrow{\hspace{2mm} g  \hspace{2mm}} \hat \X, \X \xrightarrow{\hspace{2mm} d  \hspace{2mm}} \boldsymbol{0}, \boldsymbol{1},
+       \label{eqn:gan-networks}
+\end{equation}
+unde $\boldsymbol{0}, \boldsymbol{1}$ indică dacă o imagine este generată sau nu.
+Intuitiv, cu cât este mai greu să separăm $\hat \X$ și $\X$, probabil cu atât sunt mai aproape.
+
+Lucrarea lui Tu \cite{Tu-2007} a fost prima care a demonstrat fezabilitatea învățării unui model generativ dintr-o abordare discriminativă. Cu toate acestea, lucrarea a adoptat metode tradiționale pentru a genera imagini și a clasifica distribuții (cum ar fi boosting), și erau lente și greu de implementat. După 2012, rețelele neuronale profunde au devenit foarte populare pentru clasificarea imaginilor. În 2014, Ian Goodfellow și colegii au propus din nou să genereze imagini naturale cu o abordare discriminativă \cite{Goodfellow-2014}. Ei au sugerat să folosească rețele neuronale profunde pentru a modela generatorul $g$ și discriminatorul $d$ în schimb. Mai mult, au propus să învețe generatorul $g$ și discriminatorul $d$ printr-un joc minimax:
+\begin{equation}
+    \min_g \max_d \ell(\X, \hat \X),
+\end{equation}
+unde $\ell(\cdot)$ este o anumită funcție de pierdere naturală asociată cu clasificarea. În cuvinte, discriminatorul $d$ încearcă să maximizeze succesul său în separarea $\X$ și $\hat \X$, în timp ce generatorul $g$ încearcă să facă opusul. Din acest motiv, această abordare este numită {\em rețele generative adversariale} (GAN). S-a arătat că odată antrenate pe un set de date mare, GAN-urile pot genera într-adevăr imagini foto-realiste. Parțial datorită influenței acestei lucrări, Yoshua Bengio a primit Premiul Turing 2018.
+
+Abordarea discriminativă pare să fie o modalitate destul de inteligentă de a ocoli o dificultate fundamentală în învățarea distribuției. Cu toate acestea, riguros vorbind, această abordare nu rezolvă pe deplin această dificultate fundamentală deloc. Este arătat de \cite{Goodfellow-2014} că, cu o pierdere aleasă corespunzător, formularea minimax este matematic echivalentă cu minimizarea {\em distanței Jensen-Shannon} (vezi \cite{Cover-Thomas}) între $\X$ și $\hat \X$. Aceasta este cunoscută ca fiind o problemă dificilă pentru două distribuții cu dimensiuni reduse într-un spațiu cu dimensiuni mari. Ca rezultat, în practică, GAN-urile se bazează de obicei pe multe euristici și trucuri inginerești și suferă adesea de probleme de instabilitate, cum ar fi {\em colapsul modului}.\footnote{Cu toate acestea, o astfel de formulare minimax oferă o aproximare practică a distanței. Simplifică implementarea și evită anumite capcane în calcularea directă a distanței.} În general, a existat o lipsă de îndrumare teoretică cu privire la modul de îmbunătățire a practicii GAN-urilor.
+
+\paragraph{Generare prin îndepărtarea zgomotului și difuzie.}
+În 2015, la scurt timp după ce GAN a fost introdus și a devenit popular, Surya Ganguli și studenții săi și-au dat seama și au sugerat că un proces iterativ de îndepărtare a zgomotului modelat de o rețea profundă poate fi folosit pentru a învăța o distribuție generală, cum ar fi cea a imaginilor naturale \cite{Sohl-Dickstein2015}. Metoda lor a fost inspirată de proprietățile proceselor speciale gaussiene și binomiale, studiate de William Feller încă din 1949 \cite{Feller1949OnTT}.\footnote{Din nou, în era magică a anilor 1940!}
+
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter1/figs/diffusion_pipeline.png}
+    \caption{Ilustrarea unui proces iterativ de îndepărtare a zgomotului și compresie care, pornind de la o distribuție gaussiană $q^0 = \mathcal{N}(\boldsymbol{0}, \boldsymbol{I})$, converge la o distribuție arbitrară de date cu dimensiuni reduse $q^L = p(\x)$.}
+    \label{fig:diffusion}
+\end{figure}
+
+Curând, operatorii de îndepărtare a zgomotului bazați pe funcția de scor \cite{hyvarinen05a}, introduși pe scurt în Secțiunea \ref{sec:denoising-intro}, s-au dovedit a fi mai generali și au unificat procesele și algoritmii de îndepărtare a zgomotului și difuzie \cite{song2019,song2020score,ho2020denoising}. Figura \ref{fig:diffusion} oferă o ilustrare a procesului care transformă o distribuție gaussiană generică $q^0 = \mathcal{N}(\boldsymbol{0}, \boldsymbol{I})$ într-o distribuție empirică (arbitrară) $p(\x)$ prin efectuarea unei secvențe de operații iterative de îndepărtare a zgomotului (sau compresie):
+\begin{equation}
+        \z^0 \sim  \mathcal{N}(\boldsymbol{0}, \boldsymbol{I})\xrightarrow{\hspace{2mm} g^0  \hspace{2mm}} \z^1 \xrightarrow{\hspace{2mm} g^1 \hspace{2mm}} \cdots \xrightarrow{\hspace{2mm} g^{L-1}  \hspace{2mm}} \z^L \sim p(\x).
+\end{equation}
+Până acum, îndepărtarea zgomotului (și difuzia) au înlocuit GAN-urile și au devenit o metodă principală pentru învățarea distribuțiilor imaginilor și videoclipurilor, ducând la motoare comerciale populare de generare a imaginilor, cum ar fi Midjourney și Stability.ai.
+În \Cref{ch:compression} vom introduce și studia sistematic metoda de îndepărtare a zgomotului și difuzie pentru învățarea unei distribuții generale cu dimensiuni reduse.
+
+
+
+\section{O Abordare Unificatoare}\label{sec:unifying-approach}
+Până acum, am oferit o relatare scurtă a obiectivului principal și istoriei inteligenței mașinilor și multe idei și abordări importante asociate cu aceasta. În ultimii ani, după succesul empiric al rețelelor neuronale profunde, au fost depuse eforturi enorme pentru a dezvolta cadre teoretice care să ne ajute să înțelegem toate rețelele neuronale profunde proiectate empiric, fie anumite componente aparent necesare (de exemplu, dropout, normalizare, atenție etc.) sau comportamentele lor generale (de exemplu, dublă coborâre, colaps neuronal etc.).
+
+Parțial motivată de aceasta, această carte își propune să atingă mai multe obiective importante și provocatoare:
+\begin{itemize}
+    \item Dezvoltarea unui cadru teoretic care ne-ar permite să derivăm interpretarea matematică riguroasă a rețelelor neuronale profunde.
+    \item Asigurarea corectitudinii distribuției de date învățate și consistenței cu reprezentarea învățată.
+    \item Demonstrarea că cadrul poate duce la arhitecturi performante și poate ghida îmbunătățiri suplimentare în practică.
+\end{itemize}
+În ultimii câțiva ani, există dovezi din ce în ce mai multe că aceste obiective pot fi într-adevăr atinse, valorificând teoria și soluțiile modelelor analitice clasice cu dimensiuni reduse discutate pe scurt mai devreme (mai amănunțit în \Cref{ch:classic}) și integrând idei fundamentale din câteva domenii conexe, și anume teoria informației/codării, teoria controlului/jocurilor și optimizarea. Această carte își propune să ofere o introducere sistematică în această nouă abordare.
+
+\subsection{Învățarea Reprezentărilor Parcimonioase}
+\label{sec:computational-approach-compression}
+O condiție necesară pentru ca orice sarcină de învățare să fie posibilă este ca secvențele de interes să fie {\em calculabile}, cel puțin în sensul lui Alan Turing \cite{Turing-1936}. Adică, o secvență poate fi calculată printr-un program pe un computer tipic.\footnote{Există într-adevăr secvențe bine definite care nu sunt calculabile.} Pe lângă faptul de a fi calculabile, cerem ca calculul să fie {\em tractabil}.\footnote{Nu trebuie să luăm în considerare prezicerea lucrurilor a căror complexitate computațională este intractabilă, să zicem că crește exponențial în lungimea sau dimensiunea secvenței.} Adică, costul computațional (spațiu și timp) pentru învățarea și calcularea secvenței nu ar trebui să crească exponențial în lungime. Mai mult, așa cum vedem în natură (și în practica modernă a inteligenței mașinilor), pentru majoritatea sarcinilor practice, un sistem inteligent trebuie să învețe ceea ce este previzibil din date masive într-un spațiu cu dimensiuni foarte mari, cum ar fi din vedere, sunet și atingere. Prin urmare, pentru inteligență, nu trebuie să luăm în considerare toate secvențele sau structurile calculabile și tractabile. Ar trebui să ne concentrăm doar pe secvențe și structuri previzibile care admit realizări {\em scalabile} ale algoritmilor săi de învățare și calcul:
+\begin{equation}
+\mbox{\textbf{calculabil}} \;
+   \Longrightarrow \; \mbox{\textbf{tractabil}} \; \Longrightarrow \;
+   \mbox{\textbf{scalabil}}.
+\end{equation}
+
+Acest lucru se datorează faptului că orice algoritmi pe care ființele inteligente îi folosesc pentru a învăța informații utile trebuie să fie {\em scalabili}. Mai specific, complexitatea computațională a algoritmilor ar fi mai bine să se scaleze grațios, de obicei liniar sau chiar subliniar, în dimensiunea și dimensiunea datelor. La nivel tehnic, aceasta necesită ca operațiile pe care algoritmii se bazează pentru a învăța să poată utiliza doar informații oracol care pot fi calculate eficient din date. Mai specific, când dimensiunea este mare și scara este mare, singurul oracol pe care ni-l putem permite să-l calculăm este fie informația geometrică de ordinul întâi despre date\footnote{cum ar fi aproximarea unei structuri neliniare local cu subspații liniare și calcularea gradientului unei funcții obiectiv.} sau informația statistică de ordinul doi\footnote{cum ar fi covarianța sau corelația datelor sau a caracteristicilor lor.}.
+Obiectivul principal al acestei cărți este să dezvolte un cadru teoretic și computațional în care putem dezvolta sistematic soluții sau algoritmi eficienți și eficace cu astfel de oracole și operații scalabile pentru a {\em învăța} structuri cu dimensiuni reduse din datele eșantionate și ulterior funcția predictivă.
+
+
+\paragraph{Urmărirea dimensionalității reduse prin compresie.}
+Din exemplele de secvențe pe care le-am dat în Secțiunea \ref{sec:predictability}, este clar că unele secvențe sunt ușor de modelat și calculat, iar altele sunt mai dificile. Evident, costul computațional al unei secvențe depinde de cât de complexă este funcția de predicție $f$. Cu cât gradul de regresie $d$ este mai mare, cu atât este mai costisitor de calculat. $f$ poate fi o funcție liniară simplă și poate fi, de asemenea, o funcție neliniară care poate fi arbitrar de dificil de specificat și calculat.
+
+Este rezonabil să credem că, dacă o secvență este mai grea, prin orice măsură pe care o putem alege, de specificat și calculat, atunci va fi și mai dificil să o învățăm din segmentele sale eșantionate. Cu toate acestea, pentru orice secvență previzibilă dată, există de fapt multe, adesea infinit de multe, modalități de a o specifica. De exemplu, pentru o secvență simplă $x_{n+1} = a x_{n}$, am putea defini și aceeași secvență cu $x_{n+1} = a x_n + b x_{n-1} - b x_{n-1}.$
+Prin urmare, ar fi foarte util dacă am putea dezvolta o noțiune obiectivă și riguroasă de „complexitate" pentru orice secvență calculabilă dată.
+
+Andrey Kolmogorov, un matematician rus, a fost unul dintre primii care a dat o definiție a complexității pentru orice secvență calculabilă.\footnote{Mulți au contribuit la această noțiune de complexitate a secvențelor, în special Ray Solomonoff și Greg Chaitin. Se crede că toți trei au dezvoltat și studiat teoria informației algoritmice independent, Ray Solomonoff în 1960, Andrey Kolmogorov în 1965 \cite{Kolmogorov1998OnTO} și Gregory Chaitin în jurul anului 1966 \cite{Chaitin-1966}.} El a sugerat că dintre toate programele care pot calcula aceeași secvență, putem folosi lungimea celui mai scurt program ca măsură pentru complexitatea sa. Această idee este foarte mult în concordanță cu faimosul principiu „Briciul lui Occam" al parcimoniei: {\em întotdeauna alege cea mai simplă dintre toate teoriile care pot explica aceeași observație.} Pentru a fi mai precis, fie $p$ să reprezinte un program de calculator care poate genera o secvență $S$ pe un computer universal $\mathcal{U}$. Complexitatea Kolmogorov a secvenței $S$ este definită ca fiind:
+\begin{equation}
+    K(S) = \min_{p\,:\, \mathcal{U}(p) = S} L(p).
+\end{equation}
+Prin urmare, complexitatea unei secvențe este măsurată prin cât de „parcimonios" o putem specifica sau calcula. Această definiție a complexității, sau parcimoniei, pentru secvențe este de mare importanță conceptuală și are multe proprietăți interesante. Istoric, a inspirat multe studii profunde în teoria calculului, în special în domeniul teoriei informației algoritmice.
+
+Lungimea celui mai scurt program poate fi văzută ca compresia ultimă a secvenței considerate, oferind o măsură cantitativă a cât de mult am câștigat prin învățarea mecanismului generativ corect al secvenței. Cu toate acestea, în ciuda importanței sale teoretice, complexitatea Kolmogorov nu este în general o funcție calculabilă \cite{Cover-Thomas} (chiar intractabilă de aproximat cu acuratețe). Ca rezultat, această măsură de complexitate este de puțin folos practic. Nici nu ne poate spune în avans cât de dificil este să învățăm o secvență dată, nici nu ne poate spune cât de bine am învățat.
+
+
+
+
+
+\paragraph{Măsură calculabilă a parcimoniei.}
+Prin urmare, în scopuri practice, avem nevoie de o măsură eficient calculabilă a complexității pentru secvențele care sunt generate din aceeași funcție de predicție.\footnote{Notați că în practică, de obicei ne pasă de învățarea funcției de predicție $f$, în loc de orice secvență particulară generată de $f$.} Notați că o parte din motivul pentru care complexitatea Kolmogorov nu este calculabilă este că definiția sa este neconstructivă.
+
+Deci, pentru a introduce o măsură calculabilă a complexității, putem adopta o abordare mai constructivă, așa cum a susținut Claude Shannon prin cadrul teoriei informației \cite{Shannon-1948,Cover-Thomas}.\footnote{care a ghidat cu succes practica inginerească a industriei comunicațiilor pentru mai mult de 80 de ani.} În esență, presupunând că secvența $S$ este extrasă dintr-o distribuție probabilistică $p(S)$, așa-numita {\em entropie} a distribuției:\footnote{Aici luăm în considerare entropia diferențială deoarece presupunem că secvența constă din variabile continue. Dacă constă din variabile discrete, am putea lua în considerare entropia: $H(S) = - \sum_{i}p(s_i) \log p(s_i).$ }
+\begin{equation}
+    h(S) \doteq -\int p(s) \log p(s) \odif{s}
+    \label{eqn:entropy-definition}
+\end{equation}
+oferă o măsură naturală a complexității sale. Această măsură are, de asemenea, o interpretare naturală a numărului mediu de biți binari necesari pentru a codifica o astfel de secvență, așa cum vom vedea în \Cref{ch:compression}.
+
+Pentru a ilustra ideile principale ale acestei viziuni, să luăm un număr mare de segmente de secvență lungi:
+\begin{equation}
+    \{S_1, S_2, \ldots, S_i, \ldots, S_N\} \subset \mathbb{R}^D,
+\end{equation}
+generate de o funcție de predicție $f$. Notați că fără pierderea generalității, aici am presupus că toate secvențele au aceeași lungime $D$. Prin urmare, fiecare secvență poate fi văzută ca un vector în $\mathbb{R}^D$. În al doilea rând, putem introduce o schemă de codare (cu o carte de coduri), notată ca $\mathcal E$, care convertește fiecare segment $S_i$ într-un flux unic de biți binari $\mathcal{E}(S_i)$. Cea mai simplă schemă de codare este să umplem spațiul extins de toate segmentele cu bile $\epsilon$, așa cum se arată în Figura \ref{fig:coding-schemes}. Apoi numerotăm toate bilele. Fiecare secvență este codificată ca numărul (binar) al celei mai apropiate bile. Prin urmare, fiecare segment poate fi recuperat\footnote{până la precizia $\epsilon$ deoarece o astfel de schemă de codare este cu pierderi.} din fluxul său corespunzător de biți.
+\begin{figure}
+    \centering
+    \includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter1/figs/Coding-schemes.png}
+    \caption{Comparație între două scheme de codare. Imaginați-vă că distribuția adevărată a datelor este în jurul celor două linii cu săgeți. Se pot codifica eșantioanele din cele două linii cu o carte de coduri constând din toate bilele albastre; se pot codifica și eșantioanele cu o carte de coduri constând doar din bilele verzi. Evident, a doua schemă de codare va duce la o lungime/rată de codare mult mai mică, sub rezerva aceleiași precizii.}
+    \label{fig:coding-schemes}
+\end{figure}
+
+
+Apoi complexitatea funcției de predicție $f$ poate fi evaluată ca lungimea medie de codare a tuturor secvențelor, cunoscută sub numele de rata de codare:\footnote{Se poate face acest lucru mai precis luând $R(f\mid \mathcal{E})$ să fie lungimea așteptată de codare pentru toate segmentele de lungime $D$. }
+\begin{equation}
+   R(f \mid \mathcal E) = \mathbb{E}[L(\mathcal{E}(S))] \approx \frac{1}{N}\sum_{i=1}^N L(\mathcal{E}(S_i)).
+   \label{eqn:coding-rate}
+\end{equation}
+Evident, măsura ratei de codare se va schimba dacă se folosește o schemă de codare diferită (sau o carte de coduri). În practică, cu cât cunoaștem mai bine structura cu dimensiuni reduse în jurul căreia sunt distribuite segmentele, cu atât o carte de coduri mai eficientă putem proiecta, ca exemplul arătat în Figura \ref{fig:coding-schemes}. Cititorii atenți ar fi putut recunoaște că, conceptual, procesul de îndepărtare a zgomotului ilustrat în Figura \ref{fig:diffusion} seamănă foarte mult cu trecerea de la schema de codare cu bilele albastre la cea cu cele verzi.
+
+
+Având două scheme de codare $\mathcal{E}_1$ și $\mathcal{E}_2$ pentru segmente, dacă diferența în ratele de codare este pozitivă:
+\begin{equation}
+   R(f \mid \mathcal E_1) -  R(f \mid \mathcal E_2) > 0,
+\end{equation}
+putem spune că schema de codare $\mathcal{E}_2$ este mai bună. Această diferență poate fi văzută ca o măsură a cât de multă informație are $\mathcal{E}_2$ peste $\mathcal{E}_1$ despre distribuția datelor. Într-o mare măsură, obiectivul învățării $f$ este echivalent cu găsirea celei mai eficiente scheme de codare care minimizează rata de codare:
+\begin{equation}
+   \min_{\mathcal{E}} R(f \mid \mathcal E).
+\end{equation}
+După cum vom vedea în Capitolul \ref{ch:compression}, rata minimă realizabilă este strâns legată de noțiunea de entropie $H(S)$ \eqref{eqn:entropy-definition}.
+
+
+\begin{remark}\label{rem:computable-complexity}
+    {Perspectiva măsurării complexității datelor cu scheme de codare explicite a motivat mai multe obiective de învățare care au fost propuse pentru a revizui complexitatea Kolmogorov pentru o mai bună calculabilitate \cite{WallaceC1999}, inclusiv lungimea minimă a mesajului (MML) propusă mai târziu în 1968 \cite{WallaceC1968} și lungimea minimă de descriere (MDL) în 1978 \cite{Rissanen-1978,HansenM2001}. Aceste obiective numără în mod normal lungimea de codare pentru schema de codare $\mathcal{E}$ însăși (inclusiv cartea sa de coduri) în plus față de datele $S$ de interes: $L(\mathcal E(S)) + L(\mathcal E)$. Cu toate acestea, dacă obiectivul este să înveți o carte de coduri de dimensiune finită și să o aplici unui număr mare de secvențe, costul amortizat al cărții de coduri poate fi ignorat deoarece $$\frac{1}{N}\Big( L(\mathcal{E}) + \sum_{i=1}^N L(\mathcal{E}(S_i))\Big) \approx \frac{1}{N}\sum_{i=1}^N L(\mathcal{E}(S_i))$$ pe măsură ce $N$ devine mare.}
+\end{remark}
+
+Din nou, se poate vedea schema de codare optimă rezultată ca cea care obține cea mai bună compresie a datelor observate. În general, comparativ cu complexitatea Kolmogorov, lungimea de codare dată de orice schemă de codare va fi întotdeauna mai mare:
+\begin{equation}
+    K(S) < L( \mathcal E(S)).
+\end{equation}
+Prin urmare, minimizarea ratei/lungimii de codare este în esență minimizarea unei limite superioare a complexității Kolmogorov altfel necalculabile.
+
+\subsection{Învățarea Reprezentărilor Informative}
+Notați că dacă obiectivul ar fi pur și simplu să comprimăm datele date doar de dragul compresiei, atunci în teorie codurile optime care se apropie de complexitatea Kolmogorov ar deveni aproape aleatorii sau fără structură \cite{Chaitin-1966}.\footnote{Deoarece orice coduri cu structuri pot fi comprimate în continuare.} Cu toate acestea, adevăratul nostru scop de a învăța funcția predictivă $f$ este să o folosim în mod repetat cu ușurință în predicții viitoare. Prin urmare, în timp ce compresia ne permite să identificăm distribuția cu dimensiuni reduse în date, am dori să codificăm distribuția într-un mod {\em structurat și organizat}, astfel încât reprezentarea rezultată să fie foarte informativă și eficientă de utilizat.\footnote{De exemplu, pentru a eșantiona distribuția în condiții diferite.} Figura \ref{fig:expansion} arată un exemplu care explică intuitiv de ce o astfel de transformare este dorită.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.98\linewidth]{\toplevelprefix/chapters/chapter1/figs/coding-transform.png}
+    \caption{Transformarea distribuției de date cu dimensiuni reduse identificate într-o reprezentare mai informativă și structurată.}
+    \label{fig:expansion}
+\end{figure}
+După cum vom arăta în Capitolul \ref{ch:compression}, aceste structuri dorite în reprezentarea finală pot fi promovate precis prin alegerea unei măsuri naturale de {\em câștig de informație} bazată pe ratele de codare ale schemelor de codare alese. După cum vedem în această carte, o astfel de abordare de codare explicită și constructivă oferă un cadru computațional puternic pentru învățarea reprezentărilor bune ale structurilor cu dimensiuni reduse pentru datele din lumea reală, deoarece în multe cazuri de importanță practică, funcția de lungime a codării poate fi calculată eficient sau aproximată cu acuratețe. În unele cazuri benigne, putem obține chiar formule în formă închisă, de exemplu, subspațiu și gaussiană (vezi Capitolul \ref{ch:compression}).
+
+În plus, un astfel de cadru computațional duce la o abordare principială care dezvăluie în mod natural rolul pe care rețelele profunde îl joacă în acest proces de învățare. După cum vom deriva sistematic în Capitolul \ref{ch:representation}, straturile unei rețele profunde încearcă să efectueze operații care optimizează funcția obiectiv de interes într-o manieră incrementală. Din această perspectivă, rolul rețelelor profunde poate fi interpretat precis ca emularea unui anumit algoritm de optimizare iterativă, să zicem coborârea pe gradient, pentru a optimiza obiectivul câștigului de informație. Straturile arhitecturilor profunde rezultate pot fi înzestrate cu interpretare statistică și geometrică precisă, și anume efectuarea operațiilor incrementale de codare și decodare compresivă. Ca rezultat, rețelele profunde derivate devin „cutii albe" transparente care sunt complet explicabile matematic.
+
+
+
+
+
+
+
+
+
+
+\subsection{Învățarea Reprezentărilor Consistente}
+
+\label{sec:consistency}
+Pentru a rezuma discuțiile noastre de până acum, să notăm datele ca:
+\begin{equation}
+    \boldsymbol{X} = \{S_1, S_2, \ldots, S_i, \ldots, S_N\} \subset \mathbb{R}^D,
+\end{equation}
+și fie $\boldsymbol{Z} = \mathcal{E}(\X)$ codurile lui $\X$ printr-un anumit codificator $\mathcal{E}$:
+\begin{equation}
+    \X  \xrightarrow{\hspace{2mm} \mathcal{E}\hspace{2mm}} \Z.
+    \label{eqn:open-loop}
+\end{equation}
+În contextul învățării automate, $\Z$ este adesea numit „caracteristici" sau „reprezentare latentă". Notați că fără a cunoaște distribuția de bază a lui $\X$, nu știm care codificator $\mathcal{E}$ ar trebui să fie cel care poate păstra cele mai utile informații despre distribuția lui $\X$. În practică, oamenii încep adesea cu încercarea unei anumite scheme de codare compacte care servește bine pentru o sarcină specifică. În special, ar încerca să învețe un codificator care optimizează o anumită măsură (empirică) de parcimonie pentru reprezentarea învățată:
+\begin{equation}
+    \min \rho(\Z).
+\end{equation}
+
+\begin{example}
+De exemplu, clasificarea imaginilor este un astfel de caz: atribuim toate imaginile din aceeași clasă unui singur cod și imaginile din clase diferite la coduri diferite, să zicem vectori „one-hot":
+\begin{equation}
+  \x \mapsto \z \in \{  [1, 0, 0, \ldots , 0, 0], \;  [0, 1, 0 \ldots, 0, 0], \; \ldots, \;  [0,0,0, \ldots, 0, 1].\}
+  \label{eqn:class-labels}
+\end{equation}
+Acum, un clasificator $f(\cdot)$ poate fi modelat ca o funcție care prezice probabilitatea ca un $\x$ dat să aparțină fiecăreia dintre cele $k$ clase: $\hat{\z} = f(\x) \in \mathbb{R}^K$. Apoi „bunătatea" unui clasificator poate fi măsurată prin așa-numita {\em entropie încrucișată}:\footnote{Entropia încrucișată poate fi văzută ca o măsură de distanță între distribuția adevărului de bază a lui $\z$ și cea a predicției $\hat\z$. Poate fi văzută și ca lungimea așteptată de codare a lui $\z$ dacă folosim cartea de coduri optimă pentru $\hat \z$ pentru a codifica $\z$. Entropia încrucișată atinge minimul când $\z$ și $\hat \z$ au aceeași distribuție.}
+\begin{equation}
+    L(\hat{\z}, \z) = \sum_{k=1}^K - z_k \log \hat{z}_k,
+\end{equation}
+unde $z_k$ indică a $k$-a intrare a vectorului $\z$. După cum a indicat practica timpurie a rețelelor profunde \cite{krizhevsky2012imagenet}, dacă sunt date suficiente date, o astfel de schemă de codare poate fi adesea reprezentată de o rețea profundă și învățată într-o manieră de la cap la coadă prin optimizarea entropiei încrucișate.
+\end{example}
+
+Pierderea entropiei încrucișate $L(\hat \z, \z)$ poate fi văzută ca o măsură specială de parcimonie $\rho(\z)$ asociată cu o familie particulară de scheme de codare care sunt potrivite pentru clasificare. Cu toate acestea, o astfel de codare este evident {\em foarte cu pierderi}. $\z$ învățat nu conține nicio altă informație despre $\x$ cu excepția tipului său de clasă. De exemplu, prin atribuirea unei imagini cu (un cod reprezentând) eticheta de clasă „măr", nu mai știm ce tip specific de măr se află în imaginea originală doar din etichetă.
+
+Desigur, cealaltă extremă este să cerem ca schema de codare să fie {\em fără pierderi}. Adică, există o mapare unu-la-unu între $\x$ și codul său $\z$. Cu toate acestea, după cum vom vedea în \Cref{ch:compression}, codarea fără pierderi (sau compresia) este impracticabilă decât dacă $\x$ este discret. Pentru o variabilă aleatorie continuă, putem lua în considerare doar scheme de codare cu pierderi, astfel încât lungimea de codare pentru date să poată fi finită. Adică, codificăm datele doar până la o anumită precizie prescrisă. După cum vom elabora mai mult în \Cref{ch:compression}, codarea cu pierderi nu este doar o alegere practică; joacă un rol fundamental în a face posibilă învățarea distribuției continue de bază din eșantioane finite ale distribuției.
+
+Pentru multe scopuri de învățare, dorim ca caracteristica $\z$, deși {\em cu pierderi}, să păstreze mai multe informații despre $\x$ decât doar tipul său de clasă. În această carte, vom introduce o măsură mai generală de parcimonie bazată pe lungimea/rata de codare asociată cu o familie mai generală de scheme de codare -- codarea cu un amestec de subspații sau gaussiene. Această familie are capacitatea de a aproxima îndeaproape distribuții arbitrare din lumea reală până la o anumită precizie. După cum vom vedea în \Cref{ch:compression} și \Cref{ch:representation}, o astfel de măsură nu numai că va păstra majoritatea informațiilor despre distribuția lui $\X$, dar va promova și anumite structuri geometrice și statistice frumoase dorite pentru reprezentarea învățată $\Z$.
+
+
+\paragraph{Autocodare Bidirecțională pentru Consistență.}
+Într-un context de învățare mai larg, obiectivul principal al unei scheme de codare compresive $\mathcal{E}$ este să identifice structurile cu dimensiuni reduse din datele $\X$, astfel încât acestea să poată fi folosite pentru a prezice lucruri în spațiul original al datelor. Aceasta necesită ca schema de codare învățată $\mathcal{E}$ să permită o schemă de decodare eficientă, notată ca $\mathcal D$. Aceasta mapează $\Z$, adesea cunoscută ca reprezentare latentă, înapoi la spațiul datelor:
+\begin{equation}
+    \X   \xrightarrow{\hspace{2mm} \mathcal{E}\hspace{2mm}} \Z  \xrightarrow{\hspace{2mm} \mathcal{D} \hspace{2mm}} \hat \X.
+       \label{eqn:auto-encoding}
+\end{equation}
+În general, numim o astfel de pereche de codare și decodare $(\mathcal{E}, \mathcal{D})$ o {\em autocodare}. \Cref{fig:autoencoder} ilustrează procesul unui astfel de autocodor.
+\begin{figure}
+    \centering
+    \includegraphics[width=0.7\linewidth]{\toplevelprefix/chapters/chapter1/figs/Autoencoder.jpg}
+    \caption{Ilustrarea arhitecturii unui autocodor.}
+    \label{fig:autoencoder}
+\end{figure}
+
+
+În general, am prefera ca decodarea să fie aproximativ un „invers" al codării, astfel încât datele (distribuția) $\hat \X$ decodate din $\Z$ să fie similare cu datele (distribuția) originale $\X$ într-o anumită măsură.\footnote{Vom face mai precis ce înțelegem prin a fi similar mai târziu.} Dacă da, am putea recupera sau prezice din $\Z$ ce se întâmplă în spațiul original al datelor. În acest caz, spunem că perechea $(\mathcal{E}, \mathcal{D})$ oferă o autocodare {\em consistentă}. Pentru majoritatea scopurilor practice, nu numai că avem nevoie ca o astfel de decodare să existe, dar să poată fi și realizată eficient și implementată fizic. De exemplu, dacă $\x$ este o variabilă cu valori reale, este necesară cuantificarea pentru ca orice schemă de decodare să fie realizabilă pe o mașină cu stare finită, așa cum vom explica mai mult în Capitolul \ref{ch:compression}. Prin urmare, în general, ar trebui să ne așteptăm ca schemele de codare și decodare realizabile să fie neapărat cu pierderi. O întrebare centrală este cum să învățăm o reprezentare compactă (cu pierderi) $\Z$ astfel încât să poată fi folosită pentru a prezice bine $\X$.
+
+În general vorbind, după cum vom vedea, atât codificatorul, cât și decodificatorul ar putea fi modelate și realizate de rețele profunde și învățate prin rezolvarea unei probleme de optimizare de următoarea formă:
+\begin{equation}
+   \min \, d( \X, \hat \X) + \rho(\Z),
+   \label{eqn:auto-encoding-objective}
+\end{equation}
+unde $d(\cdot, \cdot)$ este o anumită funcție de distanță care promovează similaritatea între $\X$ și $\hat \X$\footnote{Fie similar pe eșantion, fie similar pe distribuție, în funcție de alegerea funcției de distanță $d$.} și $\rho(\Z)$ este o anumită măsură care promovează parcimonia și bogăția informațională a lui $\Z$. Analiza clasică a componentelor principale (PCA) \cite{JolliffeI2002} este un exemplu tipic de autocodare consistentă, pe care o vom studia în detaliu în Capitolul \ref{ch:classic}, ca precursor al structurilor mai generale cu dimensiuni reduse. În Capitolul \ref{ch:autoencoding}, vom studia cum să învățăm autocodare consistentă pentru distribuții generale (să zicem neliniare) cu dimensiuni reduse.
+
+
+\subsection{Învățarea Reprezentărilor Auto-Consistente}
+Notați că în obiectivul de autocodare de mai sus, trebuie să evaluăm cât de aproape sau consistente sunt datele decodate $\hat \X$ cu originalul $\X$. Acest lucru necesită adesea o anumită supraveghere externă sau cunoștințe despre ce măsură de similaritate să folosim. Calcularea similarității între $\hat \X$ și $\X$ poate fi foarte costisitoare, dacă nu în întregime imposibilă sau intractabilă.\footnote{Să zicem că cineva vrea să minimizeze o anumită distanță distribuțională între cele două.} Notați că în natură, animalele sunt capabile să învețe toate de la sine fără a compara estimarea lor $\hat \X$ cu adevărul de bază $\X$ în spațiul datelor. De obicei, nici măcar nu au acea opțiune.
+
+Atunci cum este capabil un sistem să învețe autonom fără supraveghere externă sau comparație? Cum pot să știe că $\hat \X$ este consistent cu $\X$ chiar fără a le compara direct? Aceasta duce la ideea de „închidere a buclei". După cum se dovedește, în condiții blânde pe care le vom face precise în Capitolul \ref{ch:closed-loop}, pentru a asigura că $\X$ și $\hat \X$ sunt consistente, trebuie doar să codificăm $\hat \X$ ca $\hat \Z$ și să verificăm dacă $\Z$ și $\hat \Z$ sunt consistente. Numim această noțiune de consistență {\em auto-consistență}, care poate fi ilustrată prin următoarea diagramă:
+\begin{equation}
+    \X   \xrightarrow{\hspace{2mm} \mathcal{E}\hspace{2mm}} \Z  \xrightarrow{\hspace{2mm} \mathcal{D} \hspace{2mm}} \hat \X \xrightarrow{\hspace{2mm} \mathcal{E}\hspace{2mm}} \hat \Z,
+    \label{eqn:closed-loop}
+\end{equation}
+Ne referim la acest proces ca o {\em transcriere în buclă închisă},\footnote{Inspirat de procesul de transcriere între ADN și ARN sau alte proteine.} care este ilustrat în Figura \ref{fig:closed-loop}.
+
+\begin{figure}[t]
+    \centering
+\includegraphics[width=0.9\linewidth]{\toplevelprefix/chapters/chapter1/figs/diagrams_redu_gan_2.pdf}
+\caption{Ilustrarea unei transcrieri în buclă închisă. Aici folosim o mapare $f$ pentru a reprezenta codificatorul $\mathcal{E}$ și $g$ pentru a reprezenta decodificatorul $\mathcal{D}$.}  \label{fig:closed-loop}
+\end{figure}
+
+Este probabil adevărat că orice ființă inteligentă autonomă trebuie doar să învețe o reprezentare auto-consistentă $\Z$ a datelor observate $\X$, deoarece verificarea consistenței în spațiul original al datelor (adesea însemnând în lumea externă) este fie prea costisitoare, fie chiar nu este fezabilă fizic. Formularea în buclă închisă permite să învățăm o codare optimă $f(\cdot, \theta)$ și decodare $g(\cdot, \eta)$ printr-un joc minmax care depinde doar de caracteristica internă (învățată) $\Z$:
+\begin{equation}
+\max_{\theta}\min_{\eta} \ell( \Z, \hat \Z) + \rho(\Z),
+   \label{eqn:closed-loop-objective}
+\end{equation}
+unde $\ell( \Z, \hat \Z)$ este o funcție de pierdere bazată pe ratele de codare ale caracteristicilor $\Z$ și $\hat \Z$, care, după cum vom vedea, poate fi mult mai ușor de calculat. Aici din nou, $\rho(\Z)$ este o anumită măsură care promovează parcimonia și bogăția informațională a lui $\Z$. Oarecum surprinzător, după cum vom vedea în Capitolul \ref{ch:closed-loop}, în condiții destul de blânde, cum ar fi $\X$ fiind suficient de cu dimensiuni reduse, auto-consistența între $(\Z, \hat \Z)$ implică consistență în $(\X, \hat \X)$! În plus, vom vedea și că un sistem în buclă închisă ne va permite să învățăm distribuția într-o manieră {\em continuă și incrementală},\footnote{Adică să învățăm cu o clasă la un moment dat sau chiar un eșantion la un moment dat.} fără a suferi de probleme precum uitarea catastrofală asociată cu modelele în buclă deschisă.
+
+\section{Punți între Teorie și Practică pentru Inteligența Mașinilor}
+Până acum, am introdus trei cadre conexe pentru învățarea unei reprezentări compacte și structurate $\Z$ pentru o distribuție de date dată $\X$:
+\begin{itemize}
+\item Codarea deschisă \eqref{eqn:open-loop};
+\item Autocodarea bidirecțională \eqref{eqn:auto-encoding};
+\item Transcrierea în buclă închisă \eqref{eqn:closed-loop}.
+\end{itemize}
+În această carte, vom studia sistematic toate cele trei cadre, unul după altul:
+\begin{equation}
+    \mbox{\textbf{deschis}} \; \Longrightarrow \;
+    \mbox{\textbf{bidirecțional}} \;  \Longrightarrow \; \mbox{\textbf{buclă închisă}},
+\end{equation}
+în Capitolul \ref{ch:representation}, Secțiunea \ref{sec:consistent-representation} și Secțiunea \ref{sec:self-consistency} din Capitolul \ref{ch:autoencoding}, respectiv.
+
+În ultimii câțiva ani, au fost propuse și dezvoltate multe cadre teoretice pentru a ajuta la înțelegerea rețelelor profunde. Cu toate acestea, multe nu au putut oferi soluții scalabile care să egaleze performanța metodelor empirice pe date și sarcini din lumea reală. Multe teorii nu oferă îndrumări utile despre cum să îmbunătățim în continuare practica. Capitolele \ref{ch:conditional-inference} și \ref{ch:applications} vor arăta cum cadrul prezentat în această carte poate ajuta la reducerea decalajului dintre teorie și practică. Capitolul \ref{ch:conditional-inference} va arăta cum să folosim distribuția învățată și reprezentarea sa pentru a efectua inferență (Bayesiană) pentru aproape toate sarcinile practice care depind de generarea, estimarea și predicția (condiționată). Capitolul \ref{ch:applications} va oferi dovezi experimentale convingătoare că rețelele și sistemele proiectate din primele principii pot obține performanțe competitive și potențial mai bune pe o varietate de sarcini, cum ar fi învățarea reprezentării vizuale, clasificarea imaginilor, completarea imaginilor, segmentarea și generarea de text.
+
+
+\paragraph{Înapoi la Inteligență.}
+După cum am menționat la început, o sarcină comună și fundamentală a oricărei ființe inteligente este să învețe informații previzibile din datele sale percepute. Acum am înțeles puțin despre natura computațională a acestei sarcini și cineva ar trebui să realizeze că acesta este un proces fără sfârșit, din următoarele motive:
+\begin{itemize}
+    \item Cunoștințele învățate până acum din date, să zicem prin schemele de codare și decodare, este puțin probabil să fie corecte sau optime. Inteligența ar trebui să aibă capacitatea de a se îmbunătăți dacă există încă erori în prezicerea noilor observații.
+    \item Datele observate până acum nu acoperă încă toate informațiile previzibile. Inteligența ar trebui să poată recunoaște că cunoștințele actuale sunt inadecvate și să aibă capacitatea de a învăța și dobândi informații noi ori de câte ori sunt disponibile.
+\end{itemize}
+
+Prin urmare, inteligența {\em nu} este despre simpla colectare a tuturor datelor în avans și antrenarea unui model pentru a memoriza toate informațiile previzibile din date. În schimb, este despre a fi echipat cu mecanisme computaționale care pot îmbunătăți constant cunoștințele actuale și pot dobândi informații noi când sunt disponibile și necesare. Adică, o caracteristică fundamentală a oricărei ființe sau sistem inteligent\footnote{Un animal, o ființă umană, un robot inteligent, comunitatea științifică și chiar întreaga civilizație.} este {\em a putea să se îmbunătățească continuu sau să câștige informații (sau cunoștințe) pe cont propriu}. Conceptual, putem ilustra simbolic relația dintre inteligență și informație (sau cunoaștere) după cum urmează:
+\begin{equation}
+\operatorname{Inteligență}(t) = \odv*{\operatorname{Informație}}{t}(t), \qquad
+\operatorname{Informație}(t)  = \int_0^t \operatorname{Inteligență}(s) \odif{s}.
+\end{equation}
+Credem că cadrul în buclă închisă este un mecanism universal care permite auto-îmbunătățirea și auto-învățarea, prin feedback\footnote{Întărirea poate fi văzută ca o formă primitivă de feedback, să zicem selecția naturală de către natură.} sau joc\footnote{Investigațiile științifice pot fi văzute ca o formă cea mai avansată de joc, prin formularea și verificarea ipotezelor.}. Toate ființele sau sistemele inteligente din natură utilizează mecanisme în buclă închisă pentru învățare la toate nivelurile și pe toate scările. Omniprezența sa a inspirat studii timpurii care au încercat să modeleze și să emuleze inteligența prin mașini și calculatoare, în special mișcarea Cibernetică inițiată de Norbert Wiener în anii 1940.
+
+Sperăm că această carte va ajuta oamenii să înțeleagă mai bine obiectivele, principiile și mecanismele computaționale din spatele inteligenței. Servește ca o fundație pentru studiul ulterior al inteligenței umane de nivel superior, adevărata „inteligență artificială", în viitor, pentru care vom prezenta câteva probleme deschise semnificative în aceste noi direcții la sfârșitul cărții în Capitolul \ref{ch:future}.
+
+\end{document}

--- a/chapters/chapter2/classic-models_ro.tex
+++ b/chapters/chapter2/classic-models_ro.tex
@@ -1,0 +1,1593 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Învățarea Structurilor Liniare și Independente}
+\label{ch:classic}\label{ch:linear-independent}
+
+\begin{quote}
+\hfill  ``{\em Arta de a face matematică constă în a găsi acel caz special care conține toate germenele generalității}.''
+
+
+$~$\hfill -- David Hilbert
+\end{quote}
+\vspace{5mm}
+
+
+
+
+
+
+
+\textit{Datele reale au structură cu dimensiune redusă.} Pentru a vedea de ce acest lucru este adevărat, să considerăm cazul nepretențios al paraziților pe un televizor când satelitul nu funcționează. La fiecare cadru (aproximativ la fiecare \(\frac{1}{30}\) secunde), paraziții RGB pe un ecran de dimensiune \(H \times W\) sunt, aproximativ, eșantionați independent dintr-o distribuție uniformă pe \([0, 1]^{3 \times H \times W}\). În teorie, paraziții \textit{ar putea} să se rezolve într-o imagine naturală la orice cadru dat, dar chiar dacă petreceți o mie de ani uitându-vă la ecranul televizorului, nu se va întâmpla. Această discrepanță este explicată de faptul că setul de imagini naturale \(H \times W\) ocupă o fracțiune dispărut de mică din hipercubul \([0, 1]^{3 \times H \times W}\). În particular, este extrem de mic-dimensional, comparativ cu dimensiunea spațiului ambiental. Fenomene similare apar pentru toate celelalte tipuri de date naturale, cum ar fi text, audio și video. Astfel, când proiectăm sisteme și metode pentru a procesa date naturale și a învăța structura sau distribuția lor, aceasta este o proprietate centrală a datelor naturale pe care trebuie să o luăm în considerare. %
+
+Prin urmare, sarcina noastră centrală este să învățăm o distribuție care are dimensiune intrinsecă redusă într-un spațiu cu dimensiune mare. În restul acestei secțiuni, discutăm câteva metode \textit{clasice} pentru a îndeplini această sarcină pentru câteva modele oarecum {\em idealiste} pentru distribuție, și anume modele care sunt geometric liniare sau statistic independente. Deși aceste modele și metode sunt importante și utile în sine, le discutăm aici deoarece motivează, inspiră și servesc ca un predecesor sau analog pentru metode mai moderne pentru distribuții mai generale care implică învățare profundă (de reprezentare).
+
+Abordarea noastră principală (și formularea generală a problemei) poate fi rezumată ca:
+\begin{tcolorbox}\centering
+    \textbf{Problemă:} \textit{Având una sau mai multe observații (zgomotoase sau incomplete) ale unui eșantion de adevăr de bază din distribuția datelor, obțineți o estimare a acestui eșantion.}
+\end{tcolorbox}
+Această abordare stă la baza mai multor metode clasice pentru procesarea datelor, pe care le discutăm în acest capitol.
+\begin{itemize}
+    \item \Cref{sec:lowrank} --- Analiza Componentelor Principale (PCA): Având eșantioane zgomotoase dintr-o distribuție susținută pe {\em un subspațiu cu dimensiune redusă}, obțineți o estimare a eșantionului adevărat care se află pe acest subspațiu.
+    \item  \Cref{sec:ica} --- Învățarea Completă a Dicționarului și Analiza Componentelor Independente (ICA): Având eșantioane zgomotoase dintr-o distribuție susținută pe {\em o reuniune (\textit{nu} extensia) a câtorva subspații cu dimensiune redusă}, obțineți o estimare a eșantioanelor adevărate.
+    \item \Cref{sec:dictionary_learning} --- Codificare Rară și Învățarea Dicționarului Supracomplet: Având eșantioane zgomotoase din {\em o distribuție susținută pe combinații de câțiva vectori incoerenți}, cum ar fi axele de coordonate, obțineți o estimare a eșantionului adevărat, care are și această proprietate.
+\end{itemize}
+După cum vom dezvălui curând în capitolele ulterioare, în era învățării profunde, metodele moderne adoptă în esență aceeași abordare pentru a învăța.
+
+În acest capitol, așa cum s-a descris mai sus, facem ipoteze simplificatoare de modelare care presupun în esență că datele au structuri geometric (aproape, pe bucăți) liniare și componente statistic independente. În \Cref{ch:intro}, ne-am referit la astfel de modele ale datelor ca „modele analitice". Aceste ipoteze de modelare ne permit să derivăm algoritmi eficienți cu garanții de eficiență demonstrabile\footnote{Atât în ceea ce privește complexitatea datelor, cât și cea computațională.} pentru procesarea datelor la scară. Cu toate acestea, ele sunt modele imperfecte pentru distribuțiile de date din lumea reală, adesea complexe, și astfel ipotezele lor fundamentale sunt valabile doar aproximativ. Aceasta înseamnă că garanțiile oferite de analiza detaliată a acestor algoritmi sunt și ele valabile doar aproximativ în cazul datelor reale. Cu toate acestea, tehnicile discutate în acest capitol sunt utile în sine și, dincolo de asta, servesc drept „cazul special cu germenele generalității", ca să spunem așa, în sensul că prezintă o motivație și intuiție ghidatoare pentru paradigmele mai generale din învățarea (profundă) a distribuțiilor mai generale pe care le abordăm ulterior. %
+
+
+
+
+
+
+\section{Un Subspațiu cu Dimensiune Redusă} \label{sec:lowrank}
+
+\subsection{Analiza Componentelor Principale (PCA)}\label{sub:pca}
+
+Poate cea mai simplă ipoteză de modelare posibilă pentru structură cu dimensiune redusă
+este așa-numita ipoteză de \textit{rang redus}. Lăsând \(D\) să fie dimensiunea
+spațiului nostru de date, presupunem că datele noastre aparțin unui subspațiu cu dimensiune redusă de dimensiune \(d \ll D\), posibil plus unele perturbări mici. Aceasta ajunge să fie o ipoteză aproape validă pentru unele date surprinzător de complexe, cum ar fi imagini cu cifre scrise de mână și date faciale \cite{BasriR2003-PAMI} așa cum se arată în \Cref{fig:faces-digits}, totuși, după cum vom vedea, se va preta extrem de bine la o analiză cuprinzătoare.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.4\linewidth]{\toplevelprefix/chapters/chapter2/figs/faces.png}
+    \hspace{5mm} \includegraphics[width=0.395\linewidth]{\toplevelprefix/chapters/chapter2/figs/handwritten-digits.png}   
+    \caption{Imagini cu fețe umane și cifre scrise de mână. În ciuda varietății aparent mari în aparențele lor, fiecare set de aceste date acoperă (aproximativ) un subspațiu (aproape) liniar cu dimensiune foarte redusă.}
+    \label{fig:faces-digits}
+\end{figure}
+
+\paragraph{Formularea problemei.}
+Pentru a scrie aceasta în notație matematică, reprezentăm un subspațiu \(\cS \subseteq \R^{D}\) de dimensiune \(d\) printr-o matrice ortonormală \(\vU \in \O(D, d) \subseteq \R^{D \times d}\) astfel încât coloanele lui \(\vU\) să acopere \(\cS\). Apoi, spunem că datele noastre \(\{\vx_{i}\}_{i = 1}^{N} \subseteq \R^{D}\) au structură de rang redus (aproximativ) dacă există o matrice ortonormală \(\vU \in \O(D, d)\), vectori \(\{\vz_{i}\}_{i = 1}^{N} \subseteq \R^{d}\), și vectori \textit{mici} \(\{\veps_{i}\}_{i = 1}^{N} \subseteq \R^{D}\) astfel încât 
+\begin{equation}\label{eq:pca_dgp}
+    \vx_{i} = \vU\vz_{i} + \veps_{i}, \quad \forall i \in [N].
+\end{equation}
+Aici \(\veps_{i}\) sunt perturbări care împiedică datele să fie perfect
+de rang redus; prezența lor în modelul nostru ne permite să cuantificăm gradul în care
+analiza noastră rămâne relevantă în prezența abaterilor de la modelul nostru. Subspațiul
+suport adevărat este \(\cS \doteq \mathop{\mathrm{col}}(\vU)\), extensia
+coloanelor lui $\vU$. Pentru a procesa tot ce putem din
+aceste date, trebuie să recuperăm \(\cS\); pentru a face aceasta este suficient să recuperăm
+\(\vU\), numite și \textit{componentele principale}. Din fericire, aceasta este
+o sarcină tractabilă computațional numită {\bf Analiza Componentelor Principale}, și
+discutăm acum cum să o rezolvăm.
+
+Având date \(\{\vx_{i}\}_{i = 1}^{N}\) distribuite ca în \eqref{eq:pca_dgp}, ne
+propunem să recuperăm modelul \(\vU\). O abordare naturală este să găsim subspațiul
+\(\vU^{\star}\) și vectorii latenți \(\{\vz_{i}^{\star}\}_{i = 1}^{N}\) care
+dau cea mai bună aproximare \(\vx_{i} \approx \vU^{\star}\vz_{i}^{\star}\). Și anume, ne propunem să rezolvăm problema 
+\begin{equation}\label{eq:pca_sparse_recovery_problem}
+    \min_{\tilde{\vU}, \{\tilde{\vz}_{i}\}_{i = 1}^{N}}\frac{1}{N}\sum_{i = 1}^{N}\norm{\vx_{i} - \tilde{\vU}\tilde{\vz}_{i}}_{2}^{2},
+\end{equation}
+unde $\tilde{\vU}$ este constrâns să fie o matrice ortonormală, ca mai sus. Vom omite
+această constrângere în afirmații similare de mai jos pentru concizie.
+
+\paragraph{Codificare-decodificare subspațiu prin denoising.}
+Pentru a simplifica această problemă, pentru un \(\tilde{\vU}\) fixat, avem (demonstrație ca exercițiu):
+\begin{align}
+    \min_{\{\tilde{\vz}_{i}\}_{i = 1}^{N}}\frac{1}{N}\sum_{i = 1}^{N}\norm{\vx_{i} - \tilde{\vU}\tilde{\vz}_{i}}_{2}^{2} 
+    &= \frac{1}{N}\sum_{i = 1}^{N}\min_{\tilde{\vz}_{i}}\norm{\vx_{i} - \tilde{\vU}\tilde{\vz}_{i}}_{2}^{2} \\
+    &= \frac{1}{N}\sum_{i = 1}^{N}\norm{\vx_{i} - \tilde{\vU}\tilde{\vU}^{\top}\vx_{i}}_{2}^{2}. 
+\end{align}
+Adică, soluția optimă \((\vU^{\star}, \{\vz_{i}^{\star}\}_{i = 1}^{N})\)
+la problema de optimizare de mai sus are $\vz_i^{\star} = (\vU^{\star})^\top\vx_i$.
+
+Acum, putem scrie problema de optimizare originală în \(\tilde{\vU}^{\star}\)
+și \(\{\tilde{\vz}_{i}\}_{i = 1}^{N}\) ca o problemă de optimizare doar peste
+\(\tilde{\vU}\), adică, pentru a obține baza \(\vU^{\star}\) și codurile compacte
+\(\{\vz_{i}^{\star}\}_{i = 1}^{N}\) este suficient să rezolvăm oricare dintre următoarele două probleme echivalente:
+\begin{equation}\label{eq:pca_equals_denoising}
+    \min_{\tilde{\vU}, \{\tilde{\vz}_{i}\}_{i = 1}^{N}}\frac{1}{N}\sum_{i = 1}^{N}\norm{\vx_{i} - \tilde{\vU}\tilde{\vz}_{i}}_{2}^{2} = \min_{\tilde{\vU}}\frac{1}{N}\sum_{i = 1}^{N}\norm{\vx_{i} - \tilde{\vU}\tilde{\vU}^{\top}\vx_{i}}_{2}^{2}.
+\end{equation}
+Observați că problema din partea dreaptă a \eqref{eq:pca_equals_denoising}
+este o problemă de \textit{denoising}: având observații zgomotoase \(\vx_{i}\) ale
+datelor de rang redus, ne propunem să găsim copia \textit{fără zgomot} a \(\vx_{i}\), care
+sub modelul \eqref{eq:pca_dgp} este $\vU\vz_{i}$. Adică, intrarea denoisată
+$\hat{\vx}_i = \vU\vU^\top \vx_i$. Observați că acesta este punctul de pe subspațiu
+care este cel mai apropiat de $\vx_i$, așa cum este vizualizat în \Cref{fig:pca-geometry}. Aici prin
+rezolvarea problemei echivalente de găsire a celui mai bun subspațiu, parametrizat de
+baza învățată \(\vU^{\star}\), învățăm o aproximare a
+\textit{denoiser}-ului, adică, matricea de proiecție \(\vU^{\star}(\vU^{\star})^{\top} \approx \vU\vU^{\top}\) care proiectează punctul de date zgomotos $\vx_i$ pe subspațiul \(\cS\). %
+
+\begin{figure}
+    \centering
+    \begin{tikzpicture}
+       \node (zero) at (0, 0) {};
+       \node (u1) at (5, 1) {\(\vu_{1}\)};
+       \draw[blue, ->, thick] (zero) -- (u1);
+       \node[circle, inner sep=1.25pt, fill=red, draw=black] (x) at (3, 1.5) {};
+       \node[circle, inner sep=1.25pt, fill=green, draw=black] (x_hat) at (3.2, 0.64)  {};
+       \node at ($(x) + (0.5, 0.0)$) {\(\vx\)};
+       \node at ($(x_hat) + (1, -0.2)$) {\(\hat{\vx} = \vu_{1}\vu_{1}^{\top}\vx\)};
+       \draw[brown, ->, thick] (x_hat) -- (x);
+       \node at (2.75, 1) {\color{brown}\(\varepsilon\)};
+    \end{tikzpicture}
+    \caption{\small \textbf{Geometria PCA.} Un punct de date $\vx$ (roșu) este proiectat pe subspațiul unidimensional învățat acoperit de vectorul bază unitar $\vu_1$ (săgeată albastră). Proiecția $\vU\vU^\top\vx = \vu_{1}\vu_{1}^{\top}\vx$ (verde) este versiunea denoisată a $\vx$ folosind structura cu dimensiune redusă dată de $\vu_{1}$, și $\boldsymbol{\varepsilon}$ (săgeată maro) reprezintă reziduul de proiecție sau zgomotul.}
+    \label{fig:pca-geometry}
+\end{figure}
+
+Punând împreună procesul de mai sus, obținem în esență o schemă simplă de codificare-decodificare care mapează un punct de date $\vx$ în $\R^D$ către un spațiu (latent) cu dimensiune mai mică $\R^d$ și apoi înapoi la $\R^D$:
+\begin{equation}
+\x \xrightarrow{\hspace{2mm} \mathcal{E} = (\vU^\star)^\top \hspace{2mm}}  \z
+    \xrightarrow{\hspace{2mm} \mathcal{D} = \vU^\star \hspace{2mm}}   \hat{\x}.  
+\label{eqn:autoencoding-PCA}
+\end{equation}
+Aici, $\vz \in \R^d$ poate fi văzut ca codul compact cu dimensiune redusă (sau
+o reprezentare latentă) a unui punct de date  $\vx \in \R^D$ și baza subspațiului învățat
+$\vU^\star$ ca dicționarul asociat ale cărui coloane sunt cuvintele de cod
+(învățate) optime. Procesul realizează funcția de denoising a $\vx$ prin
+proiectarea lui pe subspațiul acoperit de $\vU^\star$.
+
+\paragraph{Calcularea bazei subspațiului.}
+Pentru moment, continuăm calculul nostru. Fie \(\vX = \mat{\vx_{1}, \dots, \vx_{N}} \in \R^{D \times N}\) matricea ale cărei coloane sunt observațiile \(\vx_{i}\). Avem (demonstrație ca exercițiu)
+\begin{align}
+    \argmin_{\tilde{\vU}}\frac{1}{N}\sum_{i = 1}^{N}\norm{\vx_{i} - \tilde{\vU}\tilde{\vU}^{\top}\vx_{i}}_{2}^{2}
+    &= \argmax_{\tilde{\vU}}\frac{1}{N}\sum_{i = 1}^{N}\norm{\tilde{\vU}^{\top}\vx_{i}}_{F}^{2} \\ 
+    &= \argmax_{\tilde{\vU}}\tr\rc{\tilde{\vU}^{\top}\bp{\frac{\vX\vX^{\top}}{N}}\tilde{\vU}}.
+\end{align}
+Astfel, pentru a calcula componentele principale, găsim matricea ortogonală
+\(\tilde{\vU}\) care maximizează termenul
+\(\tr(\tilde{\vU}^{\top}(\vX\vX^{\top}/N)\tilde{\vU})\). Putem demonstra prin
+inducție că această matrice \(\vU^{\star}\) are coloane care sunt \textit{primii \(d\) vectori proprii unitari} ai \(\vX\vX^{\top}/N\). Lăsăm demonstrația întreagă cititorului în \Cref{exercise:principal-components-derivation}, dar tratăm cazul de bază al inducției aici. Să presupunem că \(d = 1\). Atunci avem doar un singur vector unitar \(\vu\) de recuperat, astfel încât problema de mai sus se reduce la
+\begin{equation}
+    \max_{\tilde{\vu} \colon \norm{\tilde{\vu}}_{2} = 1} \tilde{\vu}^{\top}(\vX\vX^{\top}/N)\tilde{\vu}.
+\end{equation}
+Acesta este așa-numitul \textit{coeficient Rayleigh} al \(\vX\vX^{\top}/N\). Invocând teorema spectrală diagonalizăm \(\vX\vX^{\top}/N = \vV\vLambda\vV^{\top}\), unde \(\vV\) este ortogonală și \(\vLambda\) este diagonală cu intrări nenagative. Prin urmare 
+\begin{equation}
+    \tilde{\vu}^{\top}(\vX\vX^{\top}/N)\tilde{\vu} = \tilde{\vu}^{\top}\vV\vLambda\vV^{\top}\vu = (\vV^{\top}\tilde{\vu})^{\top}\vLambda(\vV^{\top}\tilde{\vu}).
+\end{equation}
+Deoarece \(\vV\) este o transformare ortogonală inversabilă, \(\vV^{\top}\tilde{\vu}\) este un vector unitar, și optimizarea peste \(\tilde{\vu}\) este echivalentă cu optimizarea peste \(\tilde{\vw} \doteq \vV^{\top}\tilde{\vu}\). Prin urmare, putem scrie
+\begin{equation}
+    \tilde{\vu}^{\top}(\vX\vX^{\top}/N)\tilde{\vu} = \tilde{\vw}^{\top}\vLambda\tilde{\vw},
+\end{equation}
+ale cărei soluții optime \(\vw^{\star}\) dintre vectorii unitari sunt vectori one-hot a căror singură intrare diferită de zero (deci unitară) este într-unul dintre indicii corespunzători celei mai mari valori proprii a \(\vX\vX^{\top}/N\). Aceasta înseamnă că \(\tilde{\vu} = \vV\tilde{\vw}\), soluția optimă la problema originală, corespunde unui vector propriu unitar al \(\vX\vX^{\top}/N\) (adică, coloană a \(\vV\)) care corespunde celei mai mari valori proprii. Generalizând în mod adecvat aceasta la cazul \(d > 1\), și rezumând toată discuția anterioară, avem următoarea Teoremă informală.
+\begin{theorem}\label{thm:pca}
+    Să presupunem că setul nostru de date \(\{\vx_{i}\}_{i = 1}^{N} \subseteq \R^{D}\) poate fi scris ca 
+    \begin{equation}
+        \vx_{i} = \vU\vz_{i} + \veps_{i}, \qquad \forall i \in [N],
+    \end{equation}
+    unde \(\vU \in \O(D, d)\) captează \textit{structura de rang redus},
+    \(\{\vz_{i}\}_{i = 1}^{N} \subseteq \R^{d}\) sunt \textit{codurile compacte}
+    ale datelor, și \(\{\veps_{i}\}_{i = 1}^{N} \subseteq \R^{D}\) sunt vectori
+    mici care indică abaterea datelor noastre de la modelul de rang redus. Atunci
+    \textit{componentele principale} \(\vU^{\star} \in \O(D, d)\) ale setului
+    nostru de date sunt date de primii \(d\) vectori proprii ai \(\vX\vX^{\top}/N\),
+    unde \(\vX = [\vx_{1}, \dots, \vx_{N}] \in \R^{D \times N}\), și
+    corespund aproximativ denoiser-ului liniar optim:
+    \(\vU^{\star}(\vU^{\star})^{\top} \approx \vU\vU^{\top}\).
+\end{theorem}
+Nu dăm rate explicite de aproximare aici deoarece pot deveni destul de
+tehnice. În cazul special că \(\veps_{i} = \vzero\) pentru toți \(i\),
+\(\vU^{\star}\) învățat acoperă suportul eșantioanelor \(\{\vx_{i}\}_{i
+= 1}^{N}\). Dacă în plus \(\vz_{i}\) sunt suficient de diverse (să zicem,
+acoperind tot \(\R^{d}\)) atunci am avea recuperare perfectă:
+\(\vU^{\star}(\vU^{\star})^{\top} = \vU\vU^{\top}\).
+
+\begin{remark}
+    În unele sarcini de analiză a datelor, matricea de date \(\vX\) este formatată astfel încât fiecare punct de date este un \textit{rând} mai degrabă decât o \textit{coloană} așa cum este prezentat aici. În acest caz, componentele principale sunt primii \(d\) vectori proprii ai \(\vX^{\top}\vX/N\).
+\end{remark}
+
+\begin{remark}[Selecția Bazei prin Valorile Proprii de Denoising]
+    În multe cazuri, fie datele noastre nu vor fi cu adevărat distribuite conform unui model subspațiu-plus-zgomot, fie nu vom cunoaște dimensiunea adevărată de bază \(d\) a subspațiului. În acest caz, trebuie să alegem \(d\); această problemă se numește \textit{selecție de model}. În cazul restrâns al PCA, o modalitate de a efectua selecția modelului este să calculăm \(\vX\vX^{\top}/N\) și să căutăm cazuri în care valorile proprii adiacente scad brusc; acesta este un indicator că indicele valorii proprii mai mari este „dimensiunea adevărată \(d\)", și restul valorilor proprii ale \(\vX\vX^{\top}/N\) sunt contribuite de zgomot sau perturbări \(\veps_{i}\). Selecția modelului este o problemă dificilă și, în zilele noastre în era învățării profunde unde se numește „optimizarea hiperparametrilor", se face de obicei prin forță brută sau optimizare Bayesiană. %
+\end{remark}
+
+\begin{remark}[Denoising-ul Eșantioanelor]
+    Expresia din partea dreaptă a \eqref{eq:pca_equals_denoising}, adică,
+    \begin{equation}\label{eq:orthogonal_denoising}
+        \min_{\tilde{\vU}}\frac{1}{N}\sum_{i = 1}^{N}\norm{\vx_{i} - \tilde{\vU}\tilde{\vU}^{\top}\vx_{i}}_{2}^{2},
+    \end{equation}
+    este ceea ce se numește o problemă de \textit{denoising}, numită astfel deoarece este o problemă de optimizare a cărei soluție \textit{elimină zgomotul din eșantioane astfel încât să se potrivească pe subspațiu}. Denoising-ul---învățarea unei funcții care elimină zgomotul din eșantioane zgomotoase astfel încât să se potrivească pe structura datelor (cum ar fi în \eqref{eq:pca_dgp}, dar poate mai complicat)---este o metodă comună pentru învățarea distribuțiilor care va fi discutată în continuare și pe parcursul manuscrisului. Observați că am discutat deja această noțiune, dar merită repetată datorită importanței sale centrale în capitolele ulterioare.
+\end{remark}
+
+\begin{remark}[Interpretarea prin Rețele Neuronale]
+    Dacă facem o PCA, recuperăm aproximativ suportul distribuției
+    codificat de parametrul \(\vU^{\star}\). Funcția de denoising învățată ia apoi
+    forma \(\vU^{\star}(\vU^{\star})^{\top}\). Pe lângă faptul că este
+    un denoiser, aceasta poate fi văzută ca o \textit{rețea neuronală liniară simplă
+    cu două straturi cu ponderile legate}: primul strat înmulțește cu
+    \((\vU^{\star})^{\top}\), și al doilea strat înmulțește cu \(\vU^{\star}\), și anume
+    \begin{equation}
+        \operatorname{denoise}(\vx) = \underbrace{\vU^{\star} \circ
+        \underbrace{\id \circ \underbrace{(\vU^{\star})^{\top}\vx}_{\text{primul ``strat''}}}_{\text{post-activare a primului ``strat''}}}_{\text{ieșirea ``NN''}}
+    \end{equation}
+    Contrastând aceasta cu o rețea neuronală standard cu două straturi, vedem o similaritate structurală:
+    \begin{equation}
+        \operatorname{NN}(\vx) = \underbrace{\vW^{\star} \circ
+        \underbrace{\mathrm{ReLU} \circ \underbrace{(\vU^{\star})^{\top}\vx}_{\text{primul strat}}}_{\text{post-activare a primului strat}}}_{\text{ieșirea NN}}
+    \end{equation}
+    În particular, PCA poate fi interpretat ca \textit{învățarea unui autoencoder
+    de denoising simplu cu două straturi},\footnote{De fapt, așa cum am menționat în
+    capitolul anterior, PCA a fost una dintre primele probleme pe care rețelele neuronale
+    au fost folosite pentru a le rezolva \cite{Oja1982SimplifiedNM,Baldi89}.} unul dintre cele mai simple
+    exemple de rețea neuronală non-trivială. În acest cadru,
+    \textit{reprezentările învățate} ar fi doar \((\vU^{\star})^{\top}\vx \approx \vz\). În acest fel, PCA servește ca o problemă model pentru învățarea (profundă) a reprezentărilor, pe care o vom dezvolta în continuare în monografie. Observați că în această analogie, reprezentările reflectă, sau sunt proiecții ale, datelor de intrare către o structură cu dimensiune redusă învățată. Această proprietate va fi deosebit de relevantă în viitor.
+\end{remark}
+
+\subsection{Urmărirea Structurii de Rang Redus prin Iterația Puterii}\label{subsec:power iterations}
+
+Există o modalitate eficientă din punct de vedere computațional de a estima primii vectori proprii ai \(\vX\vX^{\top}/N\) sau orice matrice simetrică pozitiv semidefinită \(\vM\), numită \textit{iterația puterii}. Această metodă este blocul de construcție al mai multor abordări algoritmice pentru analiza datelor cu dimensiune mare pe care le discutăm mai târziu în capitol, așa că o discutăm aici.
+
+Fie \(\vM\) o matrice simetrică pozitiv semidefinită. Există o bază ortonormală pentru \(\R^{D}\) constând din vectori proprii \((\vw_{i})_{i = 1}^{D}\) ai \(\vM\), cu valorile proprii corespunzătoare \(\lambda_{1} \geq \cdots \geq \lambda_{D} \geq 0\). Prin definiție, orice vector propriu $\vw_i$ satisface $\lambda_i \vw_i = \vM \vw_i$. Prin urmare, pentru orice $\lambda_i > 0$, $\vw_i$ este un „punct fix" la următoarea ecuație:
+\begin{equation}
+    \vw = \frac{\vM\vw}{\norm{\vM\vw}_{2}}.
+    \label{eqn:PCA-fixed-point}
+\end{equation}
+
+\begin{theorem}[Iterația Puterii]
+Presupunem că \(\lambda_{1} > \lambda_{i}\) pentru toți \(i > 1\). Dacă calculăm punctul fix al \eqref{eqn:PCA-fixed-point} folosind următoarea iterație:
+\begin{equation}\label{eq:power_iteration}
+    \vv_{0} \sim \dNorm(\vzero, \vone), \qquad \vv_{t + 1} \gets \frac{\vM\vv_{t}}{\norm{\vM\vv_{t}}_{2}},
+\end{equation}
+atunci, în limită, \(\vv_{t}\) va converge către un vector propriu unitar principal al \(\vM\).
+\end{theorem}
+
+\begin{proof} În primul rând, observați că pentru toți \(t\), avem 
+\begin{equation}
+    \vv_{t} = \frac{\vM\vv_{t - 1}}{\norm{\vM\vv_{t - 1}}_{2}} = \frac{\vM^{2}\vv_{t - 2}}{\norm{\vM\vv_{t - 1}}_{2}\norm{\vM\vv_{t - 2}}_{2}} = \cdots = \frac{\vM^{t}\vv_{0}}{\prod_{s = 1}^{t}\norm{\vM\vv_{s}}_{2}}.
+\end{equation}
+Astfel, \(\vv_{t}\) are aceeași direcție ca \(\vM^{t}\vv_{0}\) și este de normă unitară, astfel încât putem scrie 
+\begin{equation}
+    \vv_{t} = \frac{\vM^{t}\vv_{0}}{\norm{\vM^{t}\vv_{0}}_{2}}.
+\end{equation}
+Deoarece toți vectorii proprii \(\vw_{i}\) ai $\vM$ formează o bază ortonormală pentru \(\R^{D}\), putem scrie 
+\begin{equation}
+    \vv_{0} = \sum_{i = 1}^{D}\alpha_{i}\vw_{i},
+\end{equation}
+unde deoarece \(\vv_{0}\) este Gaussian, \(\alpha_{i}\) sunt toți diferit de zero cu probabilitate \(1\). Astfel, putem folosi expresia noastră anterioară pentru \(\vv_{t}\) pentru a scrie
+\begin{equation}
+    \vv_{t} = \frac{\vM^{t}\vv_{0}}{\norm{\vM^{t}\vv_{0}}_{2}} = \frac{\sum_{i = 1}^{D}\lambda_{i}^{t}\alpha_{i}\vw_{i}}{\norm{\sum_{i = 1}^{D}\lambda_{i}^{t}\alpha_{i}\vw_{i}}_{2}} = \frac{\sum_{i = 1}^{D}\lambda_{i}^{t}\alpha_{i}\vw_{i}}{\sum_{i = 1}^{D}\lambda_{i}^{t}\abs{\alpha_{i}}}. 
+\end{equation}
+Acum, să considerăm cazul în care \(\lambda_{1} > \lambda_{2} \geq \cdots \geq \lambda_{D} \geq 0\). (Cazul cu valori proprii principale repetate merge similar.) Atunci putem scrie
+\begin{equation}
+    \vv_{t} = \frac{\alpha_{1}\vw_{1} + \sum_{i = 2}^{D}(\lambda_{i}/\lambda_{1})^{t}\alpha_{i}\vw_{i}}{\abs{\alpha_{1}} + \sum_{i = 2}^{D}(\lambda_{i}/\lambda_{1})^{t}\abs{\alpha_{i}}}.
+\end{equation}
+Deoarece \(\lambda_{1} > \lambda_{i}\) pentru toți \(i > 1\), termenii din interiorul sumei merg la \(0\) exponențial rapid, și restul este limita 
+\begin{equation}
+    \lim_{t \to \infty}\vv_{t} = \frac{\alpha_{1}}{\abs{\alpha_{1}}}\vw_{1} = \sign(\alpha_{1})\vw_{1},
+\end{equation}
+care este un vector propriu unitar principal al \(\vM\). Valoarea proprie principală \(\lambda_{1}\) a \(\vM\) poate fi estimată prin \(\vv_{t}^{\top}\vM\vv_{t}\), care converge similar de rapid la \(\lambda_{1}\). 
+\end{proof}
+
+Pentru a găsi al doilea vector propriu principal, aplicăm algoritmul de iterare a puterii la \(\vM - \lambda_{1}\vv_{1}\vv_{1}^{\top}\), care are vectori proprii \((\vw_{i})_{i = 2}^{D}\) și valorile proprii corespunzătoare \((\lambda_{i})_{i = 2}^{D}\). Repetând această procedură de \(d\) ori în secvență, putem estima foarte eficient primii \(d\) vectori proprii ai \(\vM\) pentru orice matrice simetrică pozitiv semidefinită \(\vM\). Astfel putem aplica și la \(\vX\vX^{\top}/N\) pentru a recupera primele \(d\) componente principale, ceea ce urmăream de la început. Observați că această abordare recuperează o componentă principală la un moment dat; vom contrasta aceasta cu alte abordări algoritmice, cum ar fi coborârea gradientului pe funcții obiectiv globale, în secțiunile viitoare.
+
+
+
+
+\subsection{PCA Probabilistică}\label{subsec:probabilistic PCA}
+
+Observați că formularea de mai sus nu face ipoteze statistice asupra
+procesului de generare a datelor. Cu toate acestea, este obișnuit să includem elemente statistice
+într-un model de date dat, deoarece poate adăuga interpretări suplimentare iluminatoare
+despre rezultatul analizei. Ca atare, punem întrebarea naturală:
+\textit{care este analogul statistic al structurii cu dimensiune redusă?} Răspunsul nostru este că o \textit{distribuție} cu dimensiune redusă este una al cărei suport este concentrat în jurul unei structuri geometrice cu dimensiune redusă.
+
+Pentru a ilustra acest punct, discutăm \textit{analiza componentelor principale probabilistică (PPCA).} Această formulare poate fi văzută ca o variantă statistică a PCA obișnuită. Matematic, considerăm acum datele noastre ca eșantioane dintr-o variabilă aleatoare \(\vx\) care ia valori în \(\R^{D}\) (numită uneori și \textit{vector aleator}). Spunem că \(\vx\) are structură statistică de rang redus (aproximativ) dacă și numai dacă există o matrice ortonormală \(\vU \in \O(D, d)\), o variabilă aleatoare \(\vz\) care ia valori în \(\R^{d}\), și o variabilă aleatoare \textit{mică} \(\veps\) care ia valori în \(\R^{D}\) astfel încât \(\vz\) și \(\veps\) sunt independente, și
+\begin{equation}
+    \vx = \vU\vz + \veps.
+\end{equation}
+Scopul nostru este din nou să recuperăm \(\vU\). În acest sens, configurăm problema analogă ca în \Cref{sub:pca}, adică, optimizând peste suporturile subspațiului \(\tilde{\vU}\) și variabilele aleatoare \(\vz\) pentru a rezolva următoarea problemă:
+\begin{equation}
+    \min_{\tilde{\vU}, \tilde{\vz}}\Ex\norm{\vx - \tilde{\vU}\tilde{\vz}}_{2}^{2}.
+\end{equation}
+Deoarece găsim cea mai bună astfel de variabilă aleatoare \(\vz\) putem găsi realizarea sa \(\vz(\vx)\) separat pentru fiecare valoare a \(\vx\). Efectuând aceleași calcule ca în \Cref{sub:pca}, obținem %
+\begin{equation}\label{eq:ppca_denoising}
+    \min_{\tilde{\vU}, \tilde{\vz}}\Ex\norm{\vx - \tilde{\vU}\tilde{\vz}}_{2}^{2} = \min_{\tilde{\vU}}\Ex\min_{\tilde{\vz}(\vx)}\norm{\vx - \tilde{\vU}\tilde{\vz}(\vx)}_{2}^{2} = \min_{\tilde{\vU}}\Ex\norm{\vx - \tilde{\vU}\tilde{\vU}^{\top}\vx}_{2}^{2},
+\end{equation}
+subliniind din nou faptul că subspațiul estimat cu componentele principale \(\vU^{\star}\) corespunde unui denoiser \(\vU^{\star}(\vU^{\star})^{\top}\) care proiectează pe acel subspațiu. Ca înainte, obținem 
+\begin{align}\label{eq:PPCA}
+    \argmin_{\tilde{\vU}}\Ex\norm{\vx - \tilde{\vU}\tilde{\vU}^{\top}\vx}_{2}^{2} 
+    &= \argmax_{\tilde{\vU}}\Ex\norm{\tilde{\vU}^{\top}\vx}_{2}^{2} \\
+    &= \argmax_{\tilde{\vU}}\tr(\tilde{\vU}^{\top}\Ex[\vx\vx^{\top}]\tilde{\vU}),
+\end{align}
+și soluția la ultima problemă este doar primele \(d\) componente principale ale matricei de moment de ordinul doi \(\Ex[\vx\vx^{\top}]\). De fapt, problemele de mai sus sunt vizual foarte similare cu ecuațiile pentru calcularea componentelor principale din subsecțiunea anterioară, cu excepția că \(\Ex[\vx\vx^{\top}]\) înlocuiește \(\vX\vX^{\top}/N\). De fapt, ultima cantitate este o estimare pentru prima. Ambele formulări fac efectiv același lucru și au aceeași soluție practică---calculați vectorii singulari stângi ai matricei de date \(\vX\), sau echivalent primii vectori proprii ai matricei de covarianță estimate \(\vX\vX^{\top}/N\). Formularea statistică, însă, are o interpretare suplimentară. Să presupunem că \(\Ex[\vz] = \vzero\) și \(\Ex[\veps] = \vzero\). Avem
+\begin{equation}
+    \Ex[\vx] = \vU\Ex[\vz] + \Ex[\veps] = \vzero,
+\end{equation}
+astfel încât \(\Cov[\vx] = \Ex[\vx\vx^{\top}]\). Acum calculând \(\Cov[\vx]\) avem 
+\begin{equation}
+    \Cov[\vx] = \vU\Cov[\vz]\vU^{\top} + \Cov[\veps] = \vU\Ex[\vz\vz^{\top}]\vU^{\top} + \Cov[\veps].
+\end{equation}
+În particular, dacă \(\Cov[\veps]\) este mic, rezultă că \(\Cov[\vx] = \Ex[\vx\vx^{\top}]\) este aproximativ o matrice de rang redus, în particular rangul \(d\). Astfel primii \(d\) vectori proprii ai \(\Ex[\vx\vx^{\top}]\) rezumă în esență întreaga matrice de covarianță. Dar ei sunt și componentele principale, astfel încât putem interpreta analiza componentelor principale ca efectuând o descompunere de rang redus a \(\Cov[\vx]\).
+
+\begin{remark}
+    Folosind punctul de vedere probabilistic al PCA, obținem o înțelegere mai clară și mai cantitativă a modului în care se leagă de denoising. În primul rând, luați în considerare problema de denoising din \eqref{eq:ppca_denoising}, și anume
+    \begin{equation}
+        \min_{\tilde{\vU}}\Ex\norm{\vx - \tilde{\vU}\tilde{\vU}^{\top}\vx}_{2}^{2}.
+    \end{equation}
+    Nu este prea greu să demonstrăm că dacă $\tilde{\vU}$ are $d$ coloane și dacă
+    \(\veps\) este o variabilă aleatoare Gaussiană izotropă, adică cu distribuție \(\veps \sim \dNorm(\vzero,
+    \sigma^{2}\vI)\),\footnote{Alte distribuții funcționează atât timp cât suportă
+    tot \(\R^{D}\), dar Gaussiana este cea mai ușor de lucrat aici.} atunci
+    pentru \textit{orice} soluție optimă
+    \(\vU^{\star}\) la această problemă, avem 
+    \begin{equation}
+        \vU^{\star}(\vU^{\star})^{\top} = \vU\vU^{\top}
+    \end{equation}
+    și astfel subspațiul suport adevărat, să zicem \(\cS \doteq \mathop{\mathrm{col}}(\vU)\), este
+    recuperat ca extensia coloanelor lui \(\vU^{\star}\), deoarece 
+    \begin{equation}
+        \cS = \mathop{\mathrm{col}}(\vU) = \mathop{\mathrm{col}}(\vU\vU^{\top})
+        = \mathop{\mathrm{col}}(\vU^{\star}(\vU^{\star})^{\top})
+        = \mathop{\mathrm{col}}(\vU^{\star}).
+    \end{equation}
+    În particular, \textit{funcția de denoising} învățată \(\vU^{\star}(\vU^{\star})^{\top}\) este o proiecție ortogonală pe \(\cS\), împingând punctele zgomotoase pe subspațiul suport de adevăr. Putem stabili un rezultat tehnic similar în cazul în care avem doar eșantioane finite, ca în \Cref{thm:pca}, dar aceasta necesită mai mult efort și tehnicitate. Rezumând această discuție, avem următoarea Teoremă informală.
+\end{remark}
+
+
+\begin{theorem}\label{thm:ppca}
+    Să presupunem că variabila aleatoare \(\vx\) poate fi scrisă ca
+    \begin{equation}
+        \vx = \vU\vz + \veps
+    \end{equation}
+    unde \(\vU \in \O(D, d)\) captează \textit{structura de rang redus}, \(\vz\)
+    este un vector aleator care ia valori în \(\R^{d}\), și \(\veps\) este un vector
+    aleator care ia valori în \(\R^{D}\) astfel încât \(\vz\) și \(\veps\) sunt
+    independente, și \(\veps\) este mic. Atunci \textit{componentele principale}
+    \(\vU^{\star} \in \O(D, d)\) ale setului nostru de date sunt date de primii \(d\)
+    vectori proprii ai \(\Ex[\vx\vx^{\top}]\), și corespund aproximativ
+    denoiser-ului liniar optim: \(\vU^{\star}(\vU^{\star})^{\top} \approx \vU\vU^{\top}\).
+\end{theorem}
+
+
+
+\subsection{Completarea Matricei}
+
+În subsecțiunile anterioare, am discutat problema \textit{învățării unei distribuții geometrice sau statistice de rang redus}, unde datele au fost eșantionate dintr-un subspațiu cu zgomot aditiv. Dar aceasta nu este singurul tip de perturbare dintr-o distribuție cu dimensiune redusă care merită studiat. În această subsecțiune, introducem încă o clasă de erori non-aditive care devin din ce în ce mai importante în învățarea profundă. Să considerăm cazul în care avem unele date \(\{\vx_{i}\}_{i = 1}^{N}\) generate conform \eqref{eq:pca_dgp}. Acum le aranjăm într-o matrice \(\vX = \mat{\vx_{1}, \dots, \vx_{N}} \in \R^{D \times N}\). Spre deosebire de înainte, nu observăm \(\vX\) direct; în schimb ne imaginăm că observația noastră a fost coruptă pe drum și am obținut 
+\begin{equation}
+    \vY = \vM \hada \vX,
+\end{equation}
+unde \(\vM \in \{0, 1\}^{D \times N}\) este o \textit{mască} care este cunoscută de noi,
+și \(\hada\) este înmulțirea element cu element. În acest caz, scopul nostru este să recuperăm \(\vX\) (de unde putem folosi PCA pentru a recupera \(\vU\), etc), având doar observația coruptă \(\vY\), masca \(\vM\), și cunoașterea că \(\vX\) este (aproximativ) de rang redus. Aceasta se numește \textit{completarea matricei de rang redus}.
+
+Există multe resurse excelente care discută algoritmi și abordări pentru a rezolva această problemă \cite{Wright-Ma-2022}. Într-adevăr, aceasta și generalizări similare ale acestei probleme de recuperare a structurii de rang redus sunt rezolvate de „PCA robust". Nu vom intra în metoda de soluție aici. În schimb, vom discuta în ce condiții această problemă este \textit{plauzibilă} de rezolvat. Pe de o parte, în cazul cel mai absurd, să presupunem că fiecare intrare a matricei \(\vX\) ar fi aleasă independent de toate celelalte. Atunci nu ar exista nicio speranță de a recupera \(\vX\) exact chiar dacă ar lipsi o singură intrare și am avea \(DN - 1\) intrări. Pe de altă parte, să presupunem că am ști că \(\vX\) are rangul 1 exact, care este o condiție extrem de puternică asupra structurii cu dimensiune redusă a datelor, și ne-am confrunta cu masca
+\begin{equation}
+    \vM = \mat{\vone_{(D - 1) \times 1} & \vzero_{(D - 1) \times (N - 1)} \\ 1 & \vone_{1 \times (N - 1)} }.
+\end{equation}
+Atunci știm că datele sunt distribuite pe o linie și cunoaștem un vector pe
+acea linie---este doar prima coloană a matricei \(\vY = \vM \hada \vX\). Din ultima coordonată a fiecărei coloane, de asemenea dezvăluită nouă de mască, putem rezolva pentru fiecare coloană deoarece pentru fiecare coordonată finală există un singur vector pe linie cu această coordonată. Astfel putem reconstrui \(\vX\) cu o acuratețe perfectă și avem nevoie doar de un număr liniar de observații \(D + N - 1\).
+
+În lumea reală, problemele reale sunt undeva între cele două cazuri limită discutate mai sus. Cu toate acestea, diferențele dintre aceste două extreme, precum și discuția anterioară despre PCA, dezvăluie un nucleu general de adevăr:
+\begin{quote}
+    \centering
+    \textit{Cu cât distribuția datelor este mai mică dimensional și mai structurată, cu atât este mai ușor de procesat și sunt necesare mai puține observații---cu condiția ca algoritmul să utilizeze eficient această structură cu dimensiune redusă.}
+\end{quote}
+După cum este poate previzibil, vom întâlni acest motiv în mod repetat în restul manuscrisului, începând chiar în secțiunea următoare.
+
+
+
+
+
+
+
+
+\section{Un Amestec de Subspații Complete cu Dimensiune Redusă}%
+\label{sec:ica}
+După cum am văzut, modelele de semnal de rang redus sunt suficient de bogate pentru a oferi o imagine completă a interacțiunii dintre dimensionalitatea redusă în date și algoritmii computaționali eficienți și scalabili pentru reprezentare și recuperare sub erori.
+Aceste modele implică o conductă de învățare a reprezentării \textit{liniară} și simetrică \eqref{eqn:autoencoding-PCA}:
+\begin{equation*}
+    \vz = \cE(\vx) = \vU^\top \vx, \quad \hat{\vx} = \cD(\vz) = \vU \vz,
+\end{equation*}
+care poate fi învățată demonstrabil din eșantioane finite de $\vx$ cu analiza componentelor principale (rezolvată eficient, să zicem, cu metoda puterii) ori de câte ori distribuția de $\vx$ este cu adevărat liniară.
+Aceasta este o ipoteză restrictivă---căci, așa cum Harold Hotelling, distinsul statistician din secolul 20,\footnote{Întâmplător, de asemenea faimos pentru contribuțiile sale la dezvoltarea și denumirea Analizei Componentelor Principale \cite{Hotelling1933}.} a obiectat în urma prezentării teoriei sale de programare liniară de către George Dantzig pentru prima dată \cite{Dantzig2002-eh},
+\begin{quote}
+\centering
+    \textit{``...cu toții știm că lumea este neliniară.''}
+\end{quote}
+
+
+\begin{figure}
+    \centering
+    \includegraphics[height=0.35\linewidth]{\toplevelprefix/chapters/chapter2/figs/motion.png} \hspace{5mm}
+    \includegraphics[height=0.349\linewidth]{\toplevelprefix/chapters/chapter2/figs/segment.png} 
+    \caption{\textbf{Stânga:} caracteristici urmărite pe obiecte care se mișcă independent într-o scenă. \textbf{Dreapta:} patch-uri de imagine asociate cu diferite regiuni ale unei imagini.}
+    \label{fig:multiple-subspaces}
+\end{figure}
+Chiar ținând cont de eleganța și simplitatea sa, ipoteza de rang redus este prea restrictivă pentru a fi aplicabilă în general la modelarea datelor din lumea reală.
+O limitare cheie este ipoteza unui \textit{singur} subspațiu liniar care este responsabil pentru generarea observațiilor structurate.
+În multe aplicații practice, structura generată de un \textit{amestec} de
+subspații distincte cu dimensiune redusă oferă un model mai realist.
+De exemplu, considerați o secvență video care capturează mișcarea mai multor obiecte distincte, fiecare supus propriei deplasări independente (\Cref{fig:multiple-subspaces} stânga).
+Sub ipoteze adecvate asupra mișcărilor individuale, fiecare obiect devine responsabil pentru un subspațiu independent cu dimensiune redusă în secvența concatenată de cadre video \cite{VidalR2004-ECCV}.
+Ca un alt exemplu, considerați modelarea imaginilor naturale prin învățarea unui model pentru
+distribuția \textit{patch-urilor}, colecții contigue spațial de
+pixeli, în cadrul unei imagini (\Cref{fig:multiple-subspaces} dreapta). Spre deosebire de
+exemplul Eigenface pe care l-am văzut anterior, unde imaginile fețelor cu poze
+potrivite pot fi bine aproximate printr-un singur subspațiu cu dimensiune redusă, patch-ul
+dintr-o locație specifică dintr-o imagine naturală poate corespunde obiectelor cu
+proprietăți foarte diferite---de exemplu, culoare sau formă distinctă din cauza
+limitelor de ocluzie. Prin urmare, modelarea distribuției patch-urilor cu un singur
+subspațiu este inutilă, dar un \textit{amestec} de subspații, unul pentru fiecare regiune,
+funcționează surprinzător de bine în practică, să zicem pentru segmentare sau compresie
+\cite{Mobahi-IJCV2011}.\footnote{Vom reveni la această observație în
+\Cref{ch:representation}, unde vom arăta că poate fi generalizată semnificativ
+pentru a învăța reprezentări pentru seturi de date moderne la scară largă.} Vom vedea un exemplu concret în capitolul următor (\Cref{eg:image-segmentation}).
+
+
+
+\begin{figure}
+    \centering
+    \includegraphics[height=0.35\linewidth]{\toplevelprefix/chapters/chapter2/figs/subspaces.png}
+    \caption{Date pe un amestec de subspații cu dimensiune redusă, să zicem $\mathcal{S}_j
+    = \mathop{\mathrm{col}}(\vU_j)$.}
+    \label{fig:subspaces}
+\end{figure}
+
+În această secțiune, vom începe prin a discuta fundamentele conceptuale și algoritmice
+pentru învățarea reprezentării structurate când distribuția datelor
+poate fi modelată prin {\em un amestec de subspații cu dimensiune redusă}, așa cum este ilustrat în \Cref{fig:subspaces}. În această setare, maparea decodorului va fi aproape la fel de simplă ca în cazul unui singur subspațiu: reprezentăm simplu prin
+\begin{equation}\label{eq:mixture-subspaces-decoder-first-cut}
+    \hat{\x} = \cD(\vz) = \left( \sum_{k=1}^K \pi_k(\vz)\vU_k \right) \vz,
+\end{equation}
+unde $\pi_k : \R^d \to \set{0,1}$ sunt un set de variabile aleatoare de ponderare \textit{rare},
+astfel încât doar un singur subspațiu $\mathcal{S}_k
+= \mathop{\mathrm{col}}(\vU_k) $ este selectat în sumă.
+Cu toate acestea, sarcina de a codifica astfel de date $\vx$ în reprezentări adecvate $\vz$, și de a învăța o astfel de pereche codor-decodor din date, se va dovedi a fi mai complexă.
+
+Vom vedea cum ideile din bogata literatură despre \textit{reprezentare rară}
+și \textit{analiza componentelor independente} duc la o reformulare naturală a
+arhitecturii decodorului de mai sus prin prisma rarității, arhitectura codorului corespunzătoare
+(obținută printr-un algoritm de tip metodă a puterii analog
+cu cel al analizei componentelor principale), și garanții puternice de corectitudine
+și eficiență pentru învățarea unor astfel de perechi codor-decodor din date. În acest sens,
+cazul structurii liniare mixte cu dimensiune redusă duce deja la multe dintre
+componentele conceptuale cheie ale învățării reprezentării structurate pe care le vom dezvolta în
+generalitate mult mai mare în această carte.
+
+
+\subsection{Amestecuri de Subspații și Dicționare Folosite Rar}\label{sec:mixture-and-dict}
+
+
+Fie $\vU_1, \dots, \vU_K$, fiecare de dimensiune $D \times d$, să denoteze o colecție de baze ortonormale pentru $K$ subspații de dimensiune $d$ în $\R^D$.
+A spune că $\vx$ urmează o distribuție de amestec de subspații parametrizată de $\vU_1, \dots, \vU_K$ înseamnă, geometric vorbind,
+că 
+\begin{equation}\label{eq:mixture-of-subspaces-geometric}
+    \vx = \vU_k \vz  \quad \text{pentru un anumit} \enspace k \in [K],\enspace \vz \in \R^d.
+\end{equation}
+Analogul statistic al acestui model geometric, așa cum am văzut pentru cazul PCA și al structurii liniare,
+este că $\vx$ urmează o distribuție de \textit{amestec de Gaussiene}: adică,
+\begin{equation}\label{eq:mixture-of-subspaces-statistical}
+    \vx \sim \sum_{k=1}^K \pi_k \cN(\mathbf{0}, \vU_k\vU_k^\top), \quad \text{pentru unele} \enspace \pi_k \geq 0,\enspace \sum_{k=1}^K \pi_k = 1.
+\end{equation}
+Cu alte cuvinte, pentru fiecare $k \in [K]$, $\vx$ este Gaussian pe subspațiul cu dimensiune redusă
+$\mathop{\mathrm{col}}(\vU_k)$ cu probabilitate $\pi_k$.
+
+\begin{remark}[Un Amestec de Gaussiene vs. O Suprapunere de Gaussiene]
+Ar trebui să fim conștienți că modelul de mai sus
+    \eqref{eq:mixture-of-subspaces-statistical} este un \textit{amestec} de
+    distribuții Gaussiene, să nu fie confundat cu un amestec de
+    variabile Gaussiene prin suprapunere, să zicem 
+\begin{equation}
+    \vx = \sum_{i=1}^n w_i \vx_i, \quad \vx_i \sim \cN(\mathbf{0}, \vU_i\vU_i^\top),
+\end{equation}
+unde $\vx_i$ sunt vectori Gaussieni aleatori independenți și $w_i$ sunt un set de ponderi fixe. După cum știm din proprietățile vectorilor Gaussieni, o astfel de suprapunere $\vx$ va rămâne o distribuție Gaussiană.
+\end{remark}
+
+Pentru moment, ne concentrăm pe perspectiva geometrică oferită de \eqref{eq:mixture-of-subspaces-geometric}.
+Există o alternativă convenabilă algebric la această reprezentare condiționată. Considerați un vector de reprezentare \textit{ridicat} $\vz = [\vz_1^\top, \dots, \vz_K^\top]^\top \in \R^{dK}$, astfel încât $\vz$ este \textit{$d$-rar} cu suport pe unul dintre cele $K$ blocuri consecutive neîncălecate de $d$ coordonate din $dK$. 
+Atunci \eqref{eq:mixture-of-subspaces-geometric} poate fi scris echivalent ca
+\begin{equation}\label{eq:mixture-of-subspaces-dictionary-pre}
+    \vx = 
+    \underbrace{
+    \begin{bmatrix} 
+    | & \hdots & |  \\
+    \vU_1 & \hdots & \vU_K  \\
+    | & \hdots & | 
+    \end{bmatrix} 
+    }_{\vU}
+    \underbrace{
+    \begin{bmatrix} \vz_1 \\ \vdots \\ \vz_K \end{bmatrix}
+    }_{\vz},
+    \quad
+    \norm*{
+    \begin{bmatrix} \norm*{\vz_1}_2 \\ \vdots \\ \norm*{\vz_K}_2 \end{bmatrix}
+    }_0 = 1.
+\end{equation}
+Aici, „norma" $\ell^0$ $\norm{\,\cdot\,}_0$ măsoară raritatea numărând numărul de intrări diferite de zero:
+\begin{equation}\label{eq:ell-zero-norm}
+    \norm{\vz}_0 = \abs*{\set{i \given z_i \neq 0}},
+\end{equation}
+și matricea $\vU \in \R^{D \times Kd}$ se numește \textit{dicționar} cu toate $\{\vU_i\}_{i=1}^K$ ca cuvinte de cod. În general, dacă numărul de subspații din amestec $K$ este suficient de mare, nu există o limită a numărului de coloane conținute în dicționarul $\vU$. În cazul în care $Kd < D$, $\vU$ se numește \textit{subcomplet};
+când $Kd = D$, se numește \textit{complet}; și când $Kd > D$, se numește \textit{supracomplet}. 
+
+Acum, \eqref{eq:mixture-of-subspaces-dictionary-pre} sugerează o relaxare convenabilă pentru tractabilitatea analizei: în loc să modelăm $\vx$ ca provenind dintr-un amestec de $K$ subspații \textit{specifice} $\vU_1, \dots, \vU_K$, putem începe în schimb cu un dicționar $\vU \in \R^{D \times m}$, unde $m$ poate fi mai mic sau mai mare decât $D$, și pur și simplu căutăm să reprezentăm $\vx = \vU \vz$ cu raritatea $\norm{\vz}_0$ suficient de mică.
+Aceasta duce la \textit{modelul de dicționar rar} pentru $\vx$:
+\begin{equation}\label{eq:mixture-of-subspaces-dictionary}
+    \vx =  \vU \vz + \veps,
+    \quad
+    \norm{\vz}_0 \ll d,
+\end{equation}
+unde $\veps$ reprezintă un vector de zgomot necunoscut.
+Geometric, aceasta implică că $\vx$ se află aproape de extensia unui subset de $\norm{\vz}_0$ coloane ale $\vU$,
+făcând aceasta o instanțiere a modelului de amestec de subspații \eqref{eq:mixture-of-subspaces-geometric} cu o valoare foarte mare a $K$, și corelații specifice între subspațiile $\vU_k$.
+
+
+\paragraph{Dicționar ortogonal pentru codificare rară.}
+Acum putem formula problema de învățare a reprezentării structurate pentru amestecuri de subspații cu dimensiune redusă pe care o vom studia în această secțiune.
+Presupunem că avem eșantioane $\vX = [\vx_1, \dots, \vx_N]$ dintr-un model de dicționar rar necunoscut \eqref{eq:mixture-of-subspaces-dictionary}, posibil cu zgomote adăugate $\veps_i$.
+Să începem de la ipoteza că dicționarul $\vU$ în modelul de dicționar
+rar \eqref{eq:mixture-of-subspaces-dictionary} este complet și
+ortogonal,\footnote{Se poate arăta că pentru cazul complet, nu pierdem nicio generalitate făcând ipoteza ortogonală (\Cref{exercise:whitening}).} și că fiecare vector de coeficienți $\vz$ este $d$-rar, cu $d \ll D$.
+În această setare, învățarea reprezentării echivalează cu învățarea corectă a dicționarului ortogonal $\vU$ prin optimizare: putem
+lua apoi $\cE(\vx) = \vU^\top \vx$ ca encoder și $\cD(\vz) = \vU \vz$
+ca decoder, și $\cD = \cE^{-1}$. În formă de diagramă:
+\begin{equation}
+\vx \xrightarrow{\hspace{2mm} \mathcal{E} = \vU^\top \hspace{2mm}}  \vz \xrightarrow{\hspace{2mm} \mathcal{D} = \vU \hspace{2mm}}   \hat{\vx}.  
+\label{eqn:autoencoding-DL}
+\end{equation}    
+Vedem că perechea de autocodificare $(\cE, \cD)$ pentru învățarea completă a dicționarului este simetrică, ca în cazul unui singur subspațiu liniar, făcând sarcina computațională de codificare și decodificare nu mai dificilă decât în cazul liniar. Pe de altă parte, sarcina de a învăța dicționarul $\vU$ este strict mai dificilă decât învățarea unui singur subspațiu liniar prin PCA.
+Pentru a vedea de ce nu putem folosi pur și simplu PCA pentru a învăța corect dicționarul ortogonal $\vU$, observați că 
+funcția de pierdere care a dat naștere la PCA, și anume \eqref{eq:pca_equals_denoising}, este
+complet invariantă la rotațiile rândurilor matricei $\vU$: adică, dacă
+$\vQ$ este orice matrice ortogonală $d \times d$, atunci $\vU$ și $\vU \vQ$ sunt ambele
+fezabile și au o pierdere identică pentru \eqref{eq:pca_equals_denoising}.
+Modelul de dicționar rar nu este în mod decisiv invariant la astfel de transformări: dacă
+am înlocui $\vU$ cu $\vU \vQ$ și am face o rotație corespunzătoare $\vQ^\top \vz$
+a coeficienților de reprezentare $\vz$, am distruge în general structura de raritate a $\vz$, încălcând ipoteza de modelare. Astfel, avem nevoie de noi algoritmi pentru învățarea dicționarelor ortogonale.
+
+\subsection{Învățarea Completă a Dicționarului}
+\label{sec:complete-dictionary}
+
+În această secțiune, vom deriva algoritmi pentru rezolvarea problemei de învățare a dicționarului ortogonal. Pentru a fi mai preciși, presupunem că vectorul observat $\vx \in \R^D$ urmează un model statistic
+\begin{equation}
+    \vx = \vU \vz + \veps, 
+    \label{eq:ica-model-ch2}
+\end{equation}
+unde $\vU \in \R^{D \times D}$ este un dicționar ortogonal necunoscut, $\vz$ este un vector aleator cu componente statistic independente $z_i$, fiecare cu medie zero, și $\veps \in \R^D$ este un vector aleator independent de zgomote (Gaussiene) mici. Scopul este să recuperăm $\vU$ (și prin urmare $\vz$) din eșantioane de $\vx$.
+
+Aici presupunem că fiecare componentă independentă $z_i$ este distribuită ca $$z_i \sim \mathrm{Bern}(\theta) \cdot \cN(0, 1/\theta).$$ Adică, este produsul unei variabile aleatoare Bernoulli cu probabilitate $\theta$ de a fi $1$ și $1-\theta$ de a fi $0$, și o variabilă aleatoare Gaussiană independentă cu varianță $1/\theta$. Această distribuție este cunoscută formal ca distribuția {\em Bernoulli-Gaussiană}. 
+Normalizarea este aleasă astfel încât $\Var(z_i) = 1$ și prin urmare $\bE[\norm{\vz}_2^2]=d$. 
+Această ipoteză de modelare implică că vectorul componentelor independente $\vz$ este de obicei foarte rar: 
+calculăm $\bE\left[\norm{\vz}_0\right] = d\theta$, care este mic când $\theta$ este invers proporțional cu $d$. 
+
+\begin{remark}[Ipoteza Ortogonală] 
+La prima vedere, ipoteza că dicționarul $\vU$ este ortogonal ar putea părea să fie oarecum restrictivă. Dar de fapt nu există pierdere de generalitate. Se poate considera un dicționar complet ca fiind orice matrice pătrată inversabilă $\vU$. Cu eșantioane generate din acest dicționar: $\vX = \vU \vZ \in \mathbb{R}^{D\times N}$, este ușor de arătat că cu o anumită precondiționare a matricei de date $\vX$: 
+\begin{equation}
+    \bar{\vX} = \Big(\frac{1}{N\theta} \vX\vX^\top\Big)^{-\frac{1}{2}}\vX,
+\end{equation}
+atunci există o matrice ortogonală $\vU_{o} \in \O(D)$ astfel încât
+\begin{equation}
+    \bar{\vX} = \vU_{o}\vZ.
+\end{equation}
+    Vezi \Cref{exercise:whitening} sau \cite{sun2017completeI} pentru mai multe detalii.
+\end{remark}
+
+
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.6\linewidth]{\toplevelprefix/chapters/chapter2/figs/2DL4Sphere.png}\vspace{-0.1in}
+    \caption{Maximizarea normei $\ell^4$ sau minimizarea normei $\ell^1$ promovează raritatea (pentru vectori pe sferă).}
+    \label{fig:L4-sphere}
+\end{figure}
+
+
+\paragraph{Învățarea dicționarului prin algoritmul MSP.}
+
+Acum să presupunem că avem un set de observații:
+\begin{equation}
+    \vx_i = \vU \vz_i + \veps_i,\ \forall i \in [N].
+\end{equation}
+Fie $\vX = [\vx_1, \dots, \vx_N]$ și $\vZ = [\vz_1, \dots, \vz_N]$. Scopul este să recuperăm $\vU$ din datele $\vX$. Prin urmare, având orice matrice ortogonală $\vA \in \O(D)$, 
+\begin{equation}
+    \vA\vx_i = \vA\vU \vz_i + \vA\veps_i
+\end{equation}
+ar fi aproape rară dacă $\vA = \vU^T$ (deoarece prin ipoteză zgomotul $\veps_i$ are magnitudine mică). 
+
+De asemenea, având $\vU$ ortogonal și faptul că $\veps$ este mic, vectorul $\vx$ are o normă așteptată previzibilă, adică $\bE[\norm{\vx}_2^2] \approx \bE[\norm{\vz}_2^2]=d$. Este un fapt cunoscut că pentru vectori pe o sferă, maximizarea normei $\ell^4$ este echivalentă cu minimizarea normei $\ell^0$ (pentru promovarea rarității),
+\begin{equation}
+    \argmax_{\vz \in \mathbb{S}^n}\|\vz\|_{4}\quad\Leftrightarrow\quad \argmin_{\vz \in \mathbb{S}^n}\|\vz\|_{0}.
+\end{equation}
+Aceasta este ilustrată în \Cref{fig:L4-sphere}.
+
+O matrice ortogonală $\vA$ păstrează norma Euclidiană (\(\ell^{2}\)): $\|\vA \vx\|_2^2 = \|\vx\|_2^2$. Prin urmare, pentru a găsi dicționarul ortogonal corect $\vU$ din $\vX$, putem încerca să rezolvăm următorul program de optimizare:
+\begin{equation}\label{eq0:orthogonal-dictionary-learning-l4}
+    \max_{\tilde{\vA} \in \O(D)}\,
+     \frac{1}{4} \norm*{
+    \tilde{\vA} \vX
+    }_4^4 =  \frac{1}{4} \sum_{i=1}^N \norm*{
+        \tilde{\vA} \vx_i
+    }_4^4
+\end{equation}
+Aceasta este cunoscută ca problema de maximizare $\ell^4$ \cite{Zhai-2020}. După ce
+găsim soluția \(\vA^{\star}\), putem lua transpusa \(\vU^{\star}
+= (\vA^{\star})^{\top}\).
+\begin{remark}
+    Este de asemenea cunoscut că pentru vectori pe o sferă, minimizarea normei $\ell^1$ este echivalentă cu minimizarea normei $\ell^0$ (pentru promovarea rarității),
+\begin{equation*}
+            \argmin_{\vz \in \mathbb{S}^n}\|\vz\|_{1}\quad\Leftrightarrow\quad \argmin_{\vz \in \mathbb{S}^n}\|\vz\|_{0},
+\end{equation*}
+care este de asemenea ilustrată în \Cref{fig:L4-sphere}. Acest fapt poate fi de asemenea exploatat pentru a învăța dicționarul $\vA$ eficient și eficace. Aceasta a fost de fapt explorată mai devreme decât norma $\ell^4$ folosită aici. Cititorii interesați pot consulta lucrarea \cite{qu2020findingsparsestvectorssubspace}.
+\end{remark}
+
+Observați că problema de mai sus este echivalentă cu următoarea problemă de optimizare constrânsă:
+\begin{equation}\label{eq:orthogonal-dictionary-learning-l4}
+    \min\,
+    -   \frac{1}{4} \norm*{
+    \tilde{\vA} \vX
+    }_4^4 \quad \mbox{cu condiția} \quad  \tilde{\vA}^\top\tilde{\vA} = \vI.
+\end{equation}
+După cum se arată în \cite{Wright-Ma-2022}, folosind metoda multiplicatorilor Lagrange, se poate deriva că soluția optimă la problemă ar trebui să satisfacă următoarea 
+condiție de „punct fix":
+\begin{equation}
+    \vA^{\star} = \mathcal{P}_{\mathrm O(D)}[( {\vA^{\star} \vX})^{\hada 3}\vX^\top],
+\end{equation}
+unde $\mathcal{P}_{\mathrm O(D)}[\,\cdot\,]$ este o proiecție pe spațiul
+matricelor ortogonale $\mathrm O(D)$.\footnote{Pentru orice matrice $\vM$ cu SVD $\vM = \vU\bm \Sigma \vV^\top$, $\mathcal{P}_{\mathrm O(D)}[\vM] = \vU \vV^\top$. Lăsăm aceasta ca exercițiu pentru cititor.} 
+
+Pentru a calcula punctul fix pentru ecuația de mai sus, similar cu modul în care am calculat
+vectorii proprii pentru PCA \eqref{eqn:PCA-fixed-point}, putem lua următoarea
+iterație a puterii:
+\begin{equation}\label{eq:msp_iteration}
+    \vA_{t+1} = \mathcal{P}_{\mathrm O(D)}[( {\vA_t \vX})^{\hada 3}\vX^\top].
+\end{equation}
+Aceasta este cunoscută ca algoritmul {\em potrivire, întindere și proiecție} (MSP) propus de \cite{Zhai-2020}. S-a demonstrat că în condiții largi un astfel de algoritm greedy converge într-adevăr la soluția corectă la o rată superliniară.
+
+\begin{remark}[Optimalitatea Globală a Maximizării $\ell^4$]\label{rem:L4-global}
+Problema de maximizare $\ell^4$ constrânsă este un program neconvex. În general nu ar trebui să ne \textit{așteptăm} ca algoritmi greedy (să zicem de tip gradient descent) să convergă la soluția global optimă. Surprinzător, se poate arăta că, spre deosebire de programele neconvexe generale, peisajul maximizării $\ell^4$ peste o sferă
+\begin{equation}\label{eq:l4-maximization-sphere}
+    \min\,
+    -   \frac{1}{4} \norm*{
+    \vq^\top \vX
+    }_4^4 \quad \mbox{cu condiția} \quad  \vq^\top\vq = 1.
+\end{equation}
+este foarte benign: Toate minimele locale sunt aproape de optimele globale și toate punctele critice sunt puncte șa cu o direcție de curbură negativă. Prin urmare, orice metodă de coborâre cu capacitatea de a scăpa de punctele șa stricte găsește demonstrabil soluții global optime. Pentru afirmații mai precise, cititorii interesați pot consulta \cite{Qu2020Geometric}. 
+\end{remark}
+
+\begin{remark}[Rețea Liniară Profundă Stabilă]
+Procesul iterativ de mai sus de calculare a dicționarului are o interpretare naturală incrementală de „învățare profundă". Să definim 
+$\delta \vA_{t+1} = \vA_{t+1}\vA_{t}^\top$ și $\vZ_t = \vA_t \vX$, atunci este ușor de arătat că
+$$\delta \vA_{t+1} = \mathcal{P}_{\mathrm O(D)}[(\vZ_t)^{\hada 3} \vZ_t^\top].$$ 
+Dacă $\vA_t$ converge la dicționarul corect $\vD_o$, atunci procesul de codificare iterativ de mai sus este în esență echivalent cu o „rețea liniară profundă": 
+$$\vZ \; \longleftarrow \; \vZ_{t+1} =  \underbrace{\delta \vA_{t+1} \delta \vA_{t} \ldots \delta \vA_{1}}_{\color{red} \text{straturi construite înainte}} \vX.$$
+Observați că calculul transformărilor incrementale $\delta \vA_{t+1}$ la fiecare strat depinde doar de ieșirea caracteristicilor din stratul anterior $\vZ_t$. Rețeaua este natural stabilă deoarece fiecare strat este o transformare ortogonală care păstrează norma. În ciuda asemănării sale cu o rețea liniară profundă, backpropagarea nu este necesară pentru a învăța fiecare strat. Toate straturile sunt învățate într-o singură trecere înainte!
+\end{remark}
+
+
+\subsection{Conexiunea cu ICA și Kurtosis}
+Cu modelul Bernoulli-Gaussian, variabilele $z_i$ sunt independente și non-Gaussiene. Atunci, există o corespondență clară între învățarea dicționarului și analiza clasică a componentelor independente (ICA), în măsura în care algoritmii pentru a rezolva o problemă pot fi folosiți pentru a rezolva cealaltă.\footnote{Explorăm această problemă mai în profunzime în \Cref{exercise:symmetry-identifiability}, unde se face o conexiune între non-Gaussianitatea componentelor independente și noțiunea pur geometrică de simetrie. Această problemă este legată de observația noastră de mai sus că PCA nu funcționează pentru recuperarea dicționarelor ortogonale folosite rar: în setarea statistică, poate fi legată de invarianța rotațională a distribuției Gaussiene (\Cref{exercise:gaussian-rot-invar}).} 
+
+
+Către derivarea unui algoritm bazat pe ICA, ne concentrăm pe o funcție obiectiv cunoscută ca \textit{kurtosis}, care este folosită în ICA ca o consecință directă a non-Gaussianității componentelor. \textit{Kurtosis}, sau cumulantul de ordinul patru, al unei variabile aleatoare $X$ cu medie zero este definit ca
+\begin{equation}\label{eq:kurtosis}
+\kurt(X) = \Ex{X^4} - 3 (\Ex{X^2})^2.
+\end{equation}
+Dacă avem doar eșantioane finite din variabila aleatoare $X$ aranjate într-un vector $\vx = [x_1, \dots, x_N]$, definim kurtosis prin media lor empirică, care dă
+\begin{equation}\label{eq:kurtosis-vector}
+\kurt(\vx) = \frac{1}{N} \norm{\vx}_4^4 - \frac{3}{N^2} \norm{\vx}_2^4.
+\end{equation}
+În final, pentru vectori aleatori, definim kurtosis-ul lor ca suma kurtosis-ului scalar al fiecărei componente.
+Kurtosis este o funcție de pierdere naturală pentru ICA deoarece pentru $X$ Gaussian, kurtosis este zero; cititorul poate verifica în plus că distribuția Bernoulli-Gaussiană are kurtosis pozitiv.
+Astfel o procedură naturală pentru căutarea componentelor independente non-Gaussiene este să căutăm un set de direcții mutual-ortogonale $\vV \in \R^{d \times k}$ astfel încât $\vV^\top \vX$ să aibă kurtosis maxim, unde $\vX = \vU \vZ \in \R^{D \times N}$ este matricea de date ICA Bernoulli-Gaussiană.
+Formal, căutăm să rezolvăm problema
+\begin{equation}
+    \max_{\vV^\top \vV = \vI} \kurt(\vV^\top \vX).
+\end{equation}
+La o extremă, putem seta $k = D$ și căutăm să recuperăm întregul dicționar
+$\vU$ dintr-o singură lovitură. Se poate arăta că această problemă poate fi rezolvată cu
+algoritmul MSP pe care l-am văzut anterior.
+La cealaltă extremă, putem seta $k=1$ și căutăm să recuperăm o singură direcție (coloană a $\vU$) la un moment dat, efectuând \textit{deflație}, adică, înlocuind matricea de date $\vX$ cu $(\vI - \vu\vu^\top) \vX$, după fiecare pas înainte de a găsi o altă direcție.
+Există un compromis natural între scalabilitatea abordării incrementale $k=1$ și eficiența și robustețea abordării $k=D$.
+
+\paragraph{ICA incrementală: corectitudine și algoritmul FastICA.}
+Algoritmul FastICA, avansat de Hyv\"{a}rinen și Oja \cite{hyvarinen-1997}, este un algoritm rapid cu punct fix pentru rezolvarea schemei de maximizare a kurtosis-ului $k=1$ pentru ICA.
+Problema în cauză este
+\begin{equation}\label{eq:kurtosis-maximization-sphere-finitesample}
+    \max_{\norm{\vv}_2^2 = 1}\, \kurt(\vX^\top \vv).
+\end{equation}
+În primul rând, vom efectua o analiză foarte de bază a acestui obiectiv pentru a verifica corectitudinea sa. Observați prin schimbarea de variabile $\vw = \vU^\top \vv$ că această problemă este echivalentă cu
+\begin{equation*}
+    \max_{\norm{\vw}_2^2 = 1}\, 
+    \mathrm{kurt}(\vZ^\top \vw).
+\end{equation*}
+Acest obiectiv este suficient de simplu încât putem face afirmații puternice despre corectitudinea sa ca formulare pentru recuperarea dicționarului $\vU$.
+De exemplu, în setarea populației unde $N \to \infty$, 
+putem folosi proprietățile de aditivitate ale kurtosis-ului (\Cref{exercise:kurtosis-linearity-properties}) și normalizarea noastră asumată asupra componentelor independente pentru a scrie problema anterioară echivalent ca
+\begin{equation}\label{eq:kurtosis-maximization-sphere-population-simple}
+    \max_{\norm{\vw}_2^2 = 1}\, 
+    \sum_{i=1}^d \mathrm{kurt}(z_i) w_i^4.
+\end{equation}
+Se poate arăta că sub ipoteza Bernoulli-Gaussiană, peisajul de optimizare al acestei probleme este „benign" (\Cref{exercise:kurtosis-sphere-landscape})---însemnând că toate maximele locale ale funcției obiectiv corespund recuperării uneia dintre componentele independente.
+O modalitate eficientă și scalabilă de a calcula unul dintre aceste maxime este prin algoritmi de optimizare de ordinul întâi, care urmează iterativ gradientul funcției obiectiv și proiectează pe setul de constrângeri $\set{\vw \given \norm{\vw}_2^2 = 1}$.
+Deoarece am presupus că fiecare $z_i$ satisface $\Var(z_i)=1$, avem 
+pentru $N$ mare
+\begin{equation}\label{eq:kurtosis-approximation-l4}
+    \kurt(\vX^\top \vu)
+    \approx
+    \tfrac{1}{N} \norm{\vX^\top \vu}_4^4 - 3 \norm{\vu}_2^4.
+\end{equation}
+Putem deriva apoi o aproximare corespunzătoare a gradientului:
+\begin{equation*}
+    \nabla_{\vu} \kurt(\vX^\top \vu)
+    \approx
+    \tfrac{4}{N} \vX (\vX^\top \vu)^{\hada 3}
+    - 12 \norm{\vu}_2^2 \vu.
+\end{equation*}
+Algoritmul FastICA folosește o metodă cu punct fix pentru a calcula direcțiile de kurtosis maxim. Începe de la condițiile de optimalitate de ordinul întâi pentru problema de maximizare a kurtosis-ului, având în vedere aproximarea gradientului precedent și setul de constrângeri, care citesc
+\begin{align}\label{eq:kurtosis-max-sphere-stationarity}
+   \vX (\vX^\top \vu)^{\hada 3} 
+   = 
+   \underbrace{
+   \ip*{\vu}{
+   \vX (\vX^\top \vu)^{\hada 3} 
+   }}_{\lambda} \vu,
+\end{align}
+unde valoarea specifică a $\lambda$ este determinată folosind constrângerea de normă unitară pe $\vu$.
+\Cref{exercise:sphere-calculus} descrie fundalul matematic necesar pentru a deriva aceste condiții de optimalitate din principii prime.
+Ecuația \eqref{eq:kurtosis-max-sphere-stationarity} este satisfăcută de \textit{orice} punct critic al problemei de maximizare a kurtosis-ului; vrem să derivăm o ecuație satisfăcută doar de maximizatori.
+După ce observăm că $\lambda = \norm{\vX^\top \vu}_4^4$, re-exprimăm echivalent \eqref{eq:kurtosis-max-sphere-stationarity} ca ecuația modificată
+\begin{align}\label{eq:kurtosis-max-sphere-stationarity-modified}
+   \frac{1}{N}\vX (\vX^\top \vu)^{\hada 3} 
+   - 
+   3 \vu
+   = 
+   \left(
+   \frac{\lambda}{N} - 3
+   \right)
+   \vu,
+\end{align}
+și realizăm că orice maximizator al \eqref{eq:kurtosis-maximization-sphere-finitesample} 
+trebuie să satisfacă $\lambda / N - 3 > 0$,
+presupunând că $N$ este suficient de mare.
+Prin urmare, putem \textit{normaliza} ambele părți ale \eqref{eq:kurtosis-max-sphere-stationarity-modified},
+dând următoarea ecuație cu punct fix satisfăcută de fiecare maximizator al \eqref{eq:kurtosis-maximization-sphere-finitesample}:
+\begin{align}\label{eq:kurtosis-max-sphere-fxp}
+\frac{
+   \frac{1}{N}\vX (\vX^\top \vu)^{\hada 3} 
+   - 
+   3 \vu
+   }{
+   \norm*{
+   \frac{1}{N}\vX (\vX^\top \vu)^{\hada 3} 
+   - 
+   3 \vu
+   }_2
+   }
+   =
+   \vu.
+\end{align}
+Iterând maparea definită de partea stângă a acestei expresii cu punct fix obținem apoi algoritmul FastICA al lui Hyv\"{a}rinen și Oja \cite{hyvarinen-1997}:
+\begin{equation}
+\begin{split}\label{eq:fast-ica}
+   \vv^+ &= \tfrac{1}{N}\vX (\vX^\top \vu)^{\hada 3}- 3 \vu
+   ,  \\
+   \vu^+ &= \vv^+ / \norm*{\vv^+}_2.
+   \end{split}
+\end{equation}
+Se dovedește că algoritmul FastICA converge extrem de rapid (de fapt la
+o rată \textit{cubică}) la coloanele dicționarului $\vU$; cititorii interesați
+pot consulta \cite{hyvarinen-1997} pentru detalii. 
+Comparând algoritmul FastICA \eqref{eq:fast-ica} cu metoda puterii studiată
+în \Cref{sub:pca} pentru problema PCA și algoritmul MSP
+\eqref{eq:msp_iteration}, observăm o similaritate izbitoare. Într-adevăr, FastICA este în esență o metodă a puterii modificată, implicând gradientul kurtosis-ului empiric mai degrabă decât gradientul liniar mai simplu al obiectivului PCA.
+
+
+\section{Un Amestec de Subspații Supracomplete cu Dimensiune Redusă}
+\label{sec:dictionary_learning}
+După cum am văzut, învățarea completă a dicționarului se bucură de o teorie computațională elegantă în care menținem o structură de autocodificare simetrică $\cE(\vx) = \vU^\top \vx$, $\cD(\vz) = \vU \vz$, cu un algoritm scalabil de tip metodă a puterii (algoritmul MSP) pentru învățarea unui dicționar/carte de coduri ortogonal $\vU$ din date. Cu toate acestea, pentru învățarea reprezentărilor distribuțiilor generale de date cu dimensiune mare, trebuie să extindem dimensiunea cărții de coduri dincolo de cerința ortogonalității---însemnând că trebuie să avem $\vA \in \R^{D \times m}$, cu $m \gg D$, corespunzând cazului unui dicționar/carte de coduri \textit{supracomplet},\footnote{Schimbăm notația aici de la $\vU$ la $\vA$ pentru a sublinia non-ortogonalitatea și forma non-pătrată a dicționarului supracomplet $\vA$.} și modelul de semnal
+\begin{equation}\label{eq:model-DL-overcomplete}
+    \vx =  \vA \vz + \veps,
+    \quad
+    \norm{\vz}_0 = d \ll m.
+\end{equation}
+Există atât motivații geometrice, cât și fizice/de modelare pentru trecerea la cazul supracomplet.
+Geometric, amintiți-vă că în reducerea noastră originală de la modelul de date cu amestec de subspații la modelul de dicționar rar, un amestec de $K$ subspații în $\R^D$, fiecare de dimensiune $d$, a dus la un dicționar de formă $\vA \in \R^{D \times Kd}$.
+Cu alte cuvinte, dicționarele supracomplete corespund amestecurilor \textit{mai bogate} de subspații, cu mai multe moduri distincte de variabilitate pentru modelarea distribuției de date cu dimensiune mare.
+Pe partea de modelare, putem rula un experiment computațional pe date din lumea reală care dezvăluie puterea suplimentară de modelare conferită de o reprezentare supracompletă.
+
+\begin{figure}[t]
+\centering
+    \begin{subfigure}{0.9\linewidth}
+        \centering
+        \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter2/figs/msp_atoms_patches_new.png}
+        \caption{}
+    \end{subfigure}
+    \begin{subfigure}{0.9\linewidth}
+        \centering
+        \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter2/figs/palm_atoms_patches_new.png}
+        \caption{}
+    \end{subfigure}
+    \caption{Comparație între atomii de dicționar învățați pentru dicționare complete (ortogonale)
+    și supracomplete, antrenate pentru a reconstrui patch-uri de $8$ pe $8$ luate din
+    cifre MNIST. Ambele dicționare sunt antrenate pentru $6000$ de epoci pe $10^4$ patch-uri aleatorii cu
+    conținut netrivial, iar codurile rare sunt calculate cu obiectivul LASSO
+    și $\lambda=0.1$ (vezi \eqref{eq:sparse_dl_lasso}). Hărțile de culori au negru pentru valori negative și alb pentru
+    valori pozitive. \textbf{Sus:} Un dicționar ortogonal învățat cu
+    algoritmul MSP \eqref{eq:msp_iteration} este constrâns să
+    aibă nu mai mult de $64$ de atomi; atomii învățați corespund aproximativ unui
+    dicționar de tip „spike and slab", și obțin niveluri de raritate de reconstrucție
+    relativ slabe pe datele de test nefolosite (codurile sunt aproximativ $17$-rare în
+    medie, în raport cu un prag de $10^{-1}$).
+    \textbf{Jos:} În contrast, un dicționar supracomplet (aici, cu $8^3$
+    atomi; vizualizăm un subset aleator de $64$) învață
+    atomi de dicționar semnificativi semantic corespunzând marginilor orientate
+    cu semn, care pot fi asamblate pentru a crea patch-uri de cifre și a obține
+    niveluri superioare de reconstrucție și raritate. Codurile sunt aproximativ
+    $20$-rare în
+    medie, fiind de $8$ ori mai mari decât cele ale dicționarului
+    ortogonal. Pentru a calcula
+    dicționarul, folosim un optimizator bazat pe minimizare alternată linearizată
+    proximală pe o versiune regularizată adecvat a
+    \eqref{eqn:DL-overcomplete}.}
+    \label{fig:ReconMNIST}
+\end{figure}
+
+\begin{example}
+Având imagini eșantionate de cifre scrise de mână, \Cref{fig:ReconMNIST}(a) arată rezultatul potrivirii unui dicționar ortogonal la setul de date.
+În contrast, \Cref{fig:ReconMNIST}(b) arată rezultatul rulării unui
+algoritm de optimizare pentru învățarea dicționarelor supracomplete (pe care îl vom
+prezenta în detaliu mai târziu în Capitol) pe aceste eșantioane.
+Observați că reprezentările devin mult mai rare și cărțile de coduri mult mai interpretabile---ele constau din primitive fundamentale pentru liniile care compun cifrele, adică margini orientate.
+\end{example}
+
+
+De fapt, învățarea dicționarului supracomplet a fost propusă inițial ca un algoritm biologic plauzibil pentru reprezentarea imaginilor bazat pe dovezi empirice despre modul în care etapele timpurii ale cortexului vizual reprezintă stimulii vizuali \cite{Olshausen1996-ap,Olshausen1997-yv}.
+
+În restul acestei secțiuni, vom prezenta fundamentele conceptuale și computaționale ale învățării dicționarului supracomplet.
+Presupunând că modelul \eqref{eq:model-DL-overcomplete} este satisfăcut cu
+coduri rare \(\vz\), dicționar supracomplet \(\vA\), și nivel de raritate \(d\),
+și având eșantioane \(\vX = [\vx_1, \dots, \vx_N]\) de \(\vx\), vrem să învățăm
+un encoder \(\cE : \R^D \to \R^m\) mapând fiecare \(\vx\) la {codul său rar}
+\(\vz\), și un decoder \(\cD(\vz) = \vA \vz\) reconstruind fiecare \(\vx\) din
+codul său rar. %
+În formă de diagramă:
+\begin{equation}
+\x \xrightarrow{\hspace{4mm} \mathcal{E} \hspace{4mm}}  \z \xrightarrow{\hspace{2mm} \mathcal{D} = \vA \hspace{2mm}}   \hat{\x}.  
+\label{eqn:autoencoding-DL-overcomplete}
+\end{equation}
+
+Vom începe de la construcția encoderului $\cE$.
+Vom lucra incremental: mai întâi, \textit{având dicționarul adevărat $\vA$}, vom arăta cum problema de \textit{codificare rară} oferă un algoritm elegant, scalabil și demonstrabil corect pentru recuperarea codului rar $\vz$ al lui $\vx$.
+Deși această problemă este NP-hard în cazul cel mai rău, poate fi rezolvată eficient și scalabil pentru dicționare $\vA$ care sunt \textit{incoerente}, adică având coloane care nu sunt prea corelate.
+Arhitectura encoderului cuprinsă de această soluție nu va mai fi simetrică: vom vedea că are forma unei rețele profunde primitive, care depinde de dicționarul $\vA$.
+
+Apoi vom proceda la sarcina de a învăța decodorul $\cD$, sau echivalent dicționarul supracomplet $\vA$.
+Vom deriva un algoritm pentru învățarea dicționarului supracomplet care ne permite 
+să învățăm simultan cartea de coduri $\vA$ și codurile rare $\vz$, folosind idei din codificarea rară.
+În final, vom discuta o perspectivă mai modernă asupra codificării rare învățabile care ne duce la o structură codor-decodor complet asimetrică, ca o alternativă la \eqref{eqn:autoencoding-DL-overcomplete}.
+Aici, decodorul va corespunde unei soluții incrementale la problema învățării dicționarului rar, și va produce o pereche de codori-decodori de tip rețea profundă pentru învățarea dicționarului rar.
+Această structură va prefigura multe dezvoltări viitoare în restul
+monografiei, pe măsură ce progresăm de la modele analitice la rețele neuronale moderne.
+
+
+
+\subsection{Codificare Rară cu un Dicționar Supracomplet} 
+
+În această secțiune, vom considera modelul de date
+\eqref{eq:model-DL-overcomplete}, care acomodează combinații liniare rare
+de multe motive, sau \textit{atomi}. Având date \(\{\vx_{i}\}_{i = 1}^{N} \subseteq
+\R^{D}\) care satisfac acest model, adică exprimabile ca
+\begin{equation}\label{eq:vectorized_sparse_dl_dgp}
+    \vx_{i} = \vA\vz_{i} + \veps_{i}, \qquad \forall i \in [N]
+\end{equation}
+pentru un anumit dicționar $\vA \in \bR^{D \times m}$ cu $m$ atomi, coduri rare
+$\vz_i$ astfel încât $\norm{\vz_i}_0 \leq d$, și erori mici $\veps_i$,
+problema de codificare rară este să recuperăm codurile $\vz_i$ cât mai precis
+posibil din datele $\vx_i$, având dicționarul $\vA$.
+Algoritmii eficienți pentru a rezolva această problemă reușesc când
+dicționarul \(\vA\) este \textit{incoerent} în sensul că produsele
+scalare \(\va_{i}^{\top}\va_{j}\) sunt uniform mici, prin urmare atomii sunt
+aproape ortogonali.\footnote{După cum se dovedește, într-un spațiu cu dimensiune mare, este
+destul de ușor să împachetezi un număr de vectori aproape ortogonali care este mult mai mare
+decât dimensiunea ambientală \cite{Wright-Ma-2022}. } 
+
+
+Observați că putem colecta \(\vx_{i}\) în \(\vX = \mat{\vx_{1}, \dots, \vx_{N}} \in \R^{D \times N}\), colecta \(\vz_{i}\) în \(\vZ = \mat{\vz_{1}, \dots, \vz_{N}} \in \R^{d  \times N}\), și colecta \(\veps_{i}\) în \(\vE = \mat{\veps_{1}, \dots, \veps_{N}} \in \R^{D \times N}\), pentru a rescrie \eqref{eq:vectorized_sparse_dl_dgp} ca 
+\begin{equation}\label{eq:sparse_dl_dgp}
+    \vX = \vA\vZ + \vE.
+\end{equation}
+O abordare naturală pentru rezolvarea problemei de codificare rară este să căutăm cele mai
+rare semnale care sunt consistente cu observațiile noastre, și aceasta duce în mod natural la
+următoarea problemă de optimizare:
+\begin{equation}\label{eq:sparse_dl_lasso}
+    \min_{\vZ \in \R^{d \times N}}\bc{\norm{\vX - \vA\vZ}_{F}^{2} + \lambda \norm{\vZ}_{1}},
+\end{equation}
+unde norma \(\ell^1\) \(\norm{\vZ}_{1}\), luată element cu element, este cunoscută pentru a promova raritatea soluției \cite{Wright-Ma-2022}. 
+Această problemă de optimizare este cunoscută ca problema LASSO. 
+
+Cu toate acestea, spre deosebire de PCA sau problema de
+învățare a dicționarului complet, nu există un algoritm clar de tip iterare a puterii
+pentru a recupera \(\vZ^{\star}\). O alternativă naturală este să considerăm
+rezolvarea problemei de optimizare de mai sus cu algoritmi de tip gradient descent.
+Fie \(f(\vZ) = \norm{\vX - \vA\vZ}_{2}^{2} + \lambda \norm{\vZ}_{1}\).
+Conceptual, am putea încerca să găsim \(\vZ^{\star}\) cu următoarele iterații:
+\begin{equation}
+    \vZ_{t+1} \leftarrow \vZ_t + \eta \nabla f(\vZ_t).
+\end{equation}
+Cu toate acestea, deoarece termenul asociat cu norma \(\ell^1\) \(\norm{\vZ}_{1}\)
+este ne-neted, nu putem rula pur și simplu gradient descent. Pentru acest tip de funcție,
+trebuie să înlocuim gradientul \(\nabla f(\vZ)\) cu ceva care
+generalizează noțiunea de gradient, cunoscut ca subgradient \(\partial
+f(\vZ)\):
+\begin{equation}
+    \vZ_{t+1} \leftarrow \vZ_t + \eta \partial f(\vZ_t).
+\end{equation}
+Cu toate acestea, se știe că convergența coborârii subgradientului este de obicei foarte
+lentă. Prin urmare, pentru acest tip de probleme de optimizare, este convențional să adoptăm
+un așa-numit algoritm de tip {\em gradient proximal descent}. Oferim o prezentare tehnică
+a acestei metode în \Cref{subsec:pgd}.
+
+Aplicarea gradientului proximal la funcția obiectiv LASSO
+\eqref{eq:sparse_dl_lasso} duce la clasicul \textit{algoritm iterativ
+de prag și micșorare} (ISTA), care implementează iterația
+\begin{eqnarray}
+    \vZ_{1} &\sim& \dNorm(\vzero, \vI), \\
+    \vZ_{t + 1} &=& S_{\eta\lambda}\rp{\vZ_{t} - 2\eta \vA^{\top}(\vA\vZ_{t} - \vX)}, \quad \forall t \geq 1,\label{eq:ista_update}
+\end{eqnarray}
+cu dimensiunea pasului \(\eta \geq 0\), și operatorul de prag moale \(S_{\alpha}\) definit pe scalari prin
+\begin{align}
+    S_{\alpha}(x) &
+    \doteq \begin{cases}x - \alpha, & x \geq \alpha, \\ 0,
+    & -\alpha < x < \alpha, \\ x + \alpha, & x \leq -\alpha\end{cases}
+    \\
+    &=
+    \sign(x) \max \set{\abs{x} - \alpha, 0},
+\end{align}
+și aplicat element cu element la matricea de intrare. Ca un algoritm de coborâre a gradientului
+proximal aplicat unei probleme convexe, convergența la un optim global este
+asigurată, și o rată precisă de convergență poate fi derivată direct
+\cite{Wright-Ma-2022}. 
+
+Acum luăm un moment pentru a remarca asupra formei funcționale a operatorului de actualizare în \eqref{eq:ista_update}. Ia forma 
+\begin{equation}
+    \vZ_{t + 1} = \texttt{neliniaritate}(\vZ_{t} + \texttt{liniar}^{\top}(\texttt{liniar}(\vZ_{t}) + \texttt{bias})).
+\end{equation}
+Această formă funcțională este foarte similară cu cea a unui strat de rețea reziduală, și anume,
+\begin{equation}
+    \vZ_{t + 1} = \vZ_{t} + \texttt{liniar}_{1}^{\top}(\texttt{neliniaritate}(\texttt{liniar}_{2}(\vZ_{t}) + \texttt{bias}_{1}) + \texttt{bias}_{2},
+\end{equation}
+doar decuplând mapările liniare (adică, înmulțirile matriceale), adăugând un bias, și mutând neliniaritatea. 
+Neliniaritatea în \eqref{eq:ista_update} este notabil similară cu
+funcția de activare ReLU folosită frecvent $x \mapsto \max\set{x, 0}$ în învățarea
+profundă---în particular, operatorul de prag moale este ca o activare
+ReLU „cu semn", care este de asemenea deplasată cu un bias.
+ISTA, atunci, poate fi văzut ca o trecere înainte a unei rețele neuronale primitive (recurente cu un strat). Argumentăm în \Cref{ch:representation} că astfel de operații sunt esențiale pentru învățarea profundă a reprezentărilor.
+
+
+
+
+\subsection{Învățarea Dicționarului Supracomplet} 
+
+Amintim că avem modelul de date 
+\begin{equation}\label{eq:overcomplete-dl-section-data-model}
+    \vX = \vA\vZ + \vE,
+\end{equation}
+unde \(\vZ\) este rar, și scopul nostru anterior era să estimăm \(\vZ\) având
+cunoștința datelor \(\vX\) și a atomilor dicționarului \(\vA\). Acum ne întoarcem la
+cazul mai practic și mai dificil în care nu cunoaștem
+nici \(\vA\) nici \(\vZ\) și căutăm să le învățăm dintr-un set mare de date. 
+
+O generalizare directă a \Cref{eq:sparse_dl_lasso} sugerează rezolvarea problemei
+\begin{equation}
+    \min_{\tilde{\vA}, \tilde{\vZ}}\bc{\norm{\vX - \tilde{\vA}\tilde{\vZ}}_{F}^{2} + \lambda \norm{\tilde{\vZ}}_{1}}.
+    \label{eqn:DL-overcomplete-try}
+\end{equation}
+Cu toate acestea, termenul biliniar în \Cref{eqn:DL-overcomplete-try} introduce o
+ambiguitate de scală care împiedică convergența: având orice punct $(\tilde{\vA},
+\tilde{\vZ})$ și orice constantă $c>0$, substituția
+$(c^{-1}\tilde{\vA}, c\tilde{\vZ})$ dă valoarea pierderii
+\begin{equation}
+    \norm{\vX - \tilde{\vA}\tilde{\vZ}}_{F}^{2} + c\lambda \norm{\tilde{\vZ}}_{1}.
+\end{equation}
+Această pierdere este evident minimizată peste $c$ luând $c \to 0$, ceea ce corespunde
+cu a face dicționarul rescalat $c^{-1} \tilde{\vA}$ să meargă „la infinit". În
+particular, iterațiile oricărui algoritm de optimizare care rezolvă
+\eqref{eqn:DL-overcomplete-try} nu vor converge.
+
+Această problemă cu \eqref{eqn:DL-overcomplete-try} este tratată prin adăugarea
+unei constrângeri asupra scalei coloanelor dicționarului $\tilde{\vA}$.
+De exemplu, este obișnuit să presupunem că fiecare coloană $\vA_j$ a dicționarului
+$\vA$ în \eqref{eq:overcomplete-dl-section-data-model} are normă $\ell^2$
+mărginită---să zicem, fără pierdere de generalitate, de $1$.
+Apoi impunem aceasta ca o constrângere, dând obiectivul
+\begin{equation}
+    \min_{\tilde{\vZ}, \tilde{\vA} \,:\, \norm{\tilde{\vA}_j}_2 \leq 1}
+    \bc{\norm{\vX - \tilde{\vA}\tilde{\vZ}}_{F}^{2} + \lambda \norm{\tilde{\vZ}}_{1}}.
+    \label{eqn:DL-overcomplete}
+\end{equation}
+Problemele de optimizare constrânsă precum \eqref{eqn:DL-overcomplete}
+pot fi rezolvate de o serie de algoritmi sofisticați
+\cite{nocedal2006numerical}. Cu toate acestea, unul simplu și scalabil este de fapt
+furnizat de același algoritm de coborâre a gradientului proximal pe care l-am folosit pentru a rezolva
+problema de codificare rară în secțiunea anterioară.
+Putem codifica fiecare constrângere ca termen suplimentar de regularizare, prin
+funcția caracteristică pentru setul de constrângeri---detaliile sunt date în
+\Cref{example:prox-of-characteristic-function}.
+Aplicarea coborârii gradientului proximal la problema regularizată rezultată este
+echivalentă cu \textit{coborârea gradientului proiectat}, în care, la fiecare iterație,
+iterațiile după efectuarea unui pas de coborâre a gradientului sunt proiectate pe
+setul de constrângeri.
+
+\begin{remark}[Maximizarea $\ell^4$ versus minimizarea $\ell^1$]
+Observați că formularea problemei de mai sus urmează în mod natural din
+    formularea LASSO \eqref{eq:sparse_dl_lasso} pentru codificarea rară. Promovăm
+    raritatea soluției prin norma \(\ell^1\). Cu toate acestea, dacă suntem interesați doar în recuperarea dicționarului supracomplet \(\vA\), schema de maximizare \(\ell^4\) introdusă în \Cref{sec:complete-dictionary} se generalizează de asemenea la cazul supracomplet, fără nicio modificare semnificativă. Cititorii interesați pot consulta lucrarea \cite{Qu2020Geometric}. 
+\end{remark}
+
+Problema de mai sus \eqref{eqn:DL-overcomplete}, pe care o numim
+\textit{învățare a dicționarului supracomplet}, este neconvexă deoarece aici atât \(\vA\) cât și
+\(\vZ\) sunt necunoscute. Nu poate fi rezolvată ușor cu setul de instrumente standard de optimizare
+convexă. Cu toate acestea, deoarece este interesantă, simplă de enunțat,
+și practic importantă, au existat multe lucrări importante dedicate
+diferitelor algoritmi și analize teoretice pentru această problemă. Aici, pentru
+interesul acestui manuscris, prezentăm o abordare idiomatică pentru a rezolva această problemă
+care este mai aproape de spiritul învățării profunde.
+
+Din experiența noastră cu problema LASSO de mai sus, este ușor de văzut că, pentru
+cele două necunoscute \(\vA\) și \(\vZ\), dacă fixăm una și optimizăm cealaltă, fiecare
+subproblemă este de fapt convexă și ușor de rezolvat. Aceasta sugerează în mod natural că am
+putea încerca să rezolvăm programul de mai sus \eqref{eqn:DL-overcomplete} prin
+minimizarea împotriva \(\vZ\) sau \(\vA\) alternativ, să zicem folosind gradient descent.
+Cuplat cu o alegere naturală de inițializare, aceasta duce la următoarea
+schemă iterativă:
+\begin{align}
+    &\vZ^{\ell + 1} = S_{\eta\lambda}\rp{\vZ^{\ell}
+    - 2\eta\vA_{+}^{\top}(\vA_{+}\vZ^{\ell} - \vX)},
+    \quad \vZ^1 = \Zero,
+    \quad \forall \ell \in [L] \label{eqn:ISTA-update}\\ 
+    &\vZ^+ = \vZ^L,\\
+    &\vA_{t + 1} = \proj_{\norm{(\,\cdot\,)_j}_2 \leq 1,\,\forall j}\left(
+    \vA_{t} - 2\nu (\vA_{t}\vZ^+ - \vX)(\vZ^+)^\top
+    \right), 
+    \quad (\vA_{1})_j \simiid \dNorm(\vzero, \tfrac{1}{D}\vI), \enspace \forall
+    j \in [m], 
+    \quad\;\; \forall t \in [T],\label{eqn:DL-update}\\
+    &\vA_+ = \vA_T,
+\end{align}
+unde operația de proiecție în actualizarea pentru $\vA$ asigură că fiecare coloană are
+cel mult normă $\ell^2$ unitară, prin $\vA_j \mapsto \vA_j / \max \set{\norm{\vA_j}_2,
+1}$, și unde $\vA_+$ este inițializat cu fiecare coloană i.i.d.\ $\cN(\Zero,
+\tfrac{1}{D} \vI)$.
+Cele de mai sus constau dintr-un „bloc" de minimizare alternată, și efectuăm în mod repetat
+astfel de blocuri, fiecare cu inițializări independente, până la convergență.
+Mai sus, am folosit doi indici separați $\{t\}$ și $\{\ell\}$ pentru a indica
+iterațiile. După cum vom vedea mai târziu, aceasta ne permite să interpretăm cele două actualizări
+separat în contextul învățării profunde.
+
+În ciuda faptului că problema învățării dicționarului este o problemă neconvexă, s-a
+demonstrat că algoritmii de tip minimizare alternantă converg într-adevăr către
+soluția corectă, cel puțin local. Vezi, de exemplu, \cite{alekh-2016}.
+Ca o demonstrație practică, algoritmul de mai sus (cu $L = T = 1$) a fost folosit pentru
+a genera rezultatele pentru învățarea dicționarului supracomplet din
+\Cref{fig:ReconMNIST}.
+
+\subsection{Codificare Rară Profundă Învățată}
+\label{sec:LISTA}
+Principala intuiție din algoritmul de minimizare alternantă pentru
+învățarea dicționarului supracomplet din secțiunea anterioară
+(\Cref{eqn:ISTA-update,eqn:DL-update}) este de a observa că \textit{când fixăm
+\(\vA\), actualizarea ISTA pentru $\vZ^\ell$ \eqref{eqn:ISTA-update} arată ca
+propagarea înainte a unei rețele neurale profunde cu ponderi date de \(\vA\) (și
+\(\vA^{\top}\))}. Dar în general, nu cunoaștem adevăratul $\vA$, iar estimarea
+curentă $\vA_+$ ar putea fi eronată. Prin urmare, trebuie actualizată în continuare folosind
+\eqref{eqn:DL-update} pe baza reziduului de utilizare a estimării curente a
+codurilor rare $\vZ^+$ pentru a reconstrui $\vX$. Algoritmul de minimizare
+alternantă iterează aceste două proceduri până la convergență. Dar putem în schimb
+extrapola și proiecta alte proceduri de învățare combinând aceste perspective
+cu tehnici din învățarea profundă. Aceasta duce la arhitecturi de rețea mai interpretabile,
+care vor fi o temă recurentă în acest manuscris.
+
+\paragraph{ISTA Învățat.} Interpretarea de mai sus a rețelei profunde a
+minimizării alternante este mai conceptuală decât practică, deoarece procesul ar putea
+fi destul de ineficient și ar putea lua multe straturi sau iterații pentru a converge.
+Dar aceasta
+se datorează în principal faptului că încercăm să inferăm atât \(\vZ\) cât și \(\vA\) din \(\vX\).
+Problema poate fi simplificată semnificativ și iterațiile de mai sus pot fi făcute
+mult mai eficiente în setarea \textit{supervizată}, unde avem un set de date de perechi
+de intrare și ieșire \((\vX, \vZ)\) distribuite conform
+\eqref{eq:overcomplete-dl-section-data-model} și căutăm doar să învățăm
+\(\vA^\ell\) pentru iterațiile de codificare rară învățabilă pe straturi
+\eqref{eq:ISTA-update-layerwise}:
+\begin{align}
+    & \vZ^{\ell + 1} = S_{\eta\lambda}\rp{\vZ^{\ell} - 2\eta(\vA^{\ell})^{\top}(\vA^\ell\vZ^{\ell} - \vX)}, \quad \forall \ell \in [L].
+\end{align}
+Dacă notăm operatorul pentru fiecare iterație ca $\vZ^{\ell + 1} = f(\vA^\ell, \vZ^\ell)$, iterația de mai sus poate fi ilustrată în termeni de diagramă:
+\begin{equation*}
+\vX, \vZ^1 \xrightarrow{\hspace{1mm} f(\vA^1,\,\cdot\,) \hspace{1mm}}  \vZ^2 \xrightarrow{\hspace{1mm} f(\vA^2,\,\cdot\,) \hspace{1mm}}  \vZ^3  \xrightarrow{\hspace{1mm} f(\vA^3,\,\cdot\,) \hspace{1mm}} \cdots \vZ^{L}  \xrightarrow{\hspace{1mm} f(\vA^{L},\,\cdot\,) \hspace{1mm}} \vZ^{L + 1} \approx \vZ.  
+\label{eqn:deep-sparse-encoding}
+\end{equation*}
+Astfel, dată fiind arhitectura secvențială, pentru a învăța operatorul \(\vA^\ell\) la
+fiecare strat, este complet natural să-l învățăm, să zicem prin propagare inversă
+(BP),\footnote{Vezi \Cref{sec:autodiff} pentru o scurtă descriere a BP.} prin minimizarea erorii între codul final $\vZ^L$ și adevărul de bază $\vZ$:
+\begin{equation}\label{eq:lista-training}
+    \min_{\{\vA^\ell\}} \big\|\vZ^L(\vA^1, \ldots, \vA^{L}) - \vZ\big\|_2^2.
+\end{equation}
+Aceasta este baza algoritmului ISTA Învățat (LISTA) \cite{gregor2010learning}, care poate fi privit ca algoritmul de învățare pentru o rețea neurală profundă, care încearcă să emuleze procesul de codificare rară de la $\vX$ la $\vZ$. În special, poate fi privit ca un \textit{algoritm simplu de învățare a reprezentărilor}.
+De fapt, aceeași metodologie poate fi folosită ca bază pentru a înțelege
+reprezentările calculate în arhitecturi de rețea mai puternice, cum ar fi
+transformatoarele. Dezvoltăm aceste implicații în detaliu în \Cref{ch:unrolling}.
+
+\paragraph{Autocodificatoare Rare.}
+Motivația originală pentru învățarea dicționarului supracomplet a fost de a oferi
+un model generativ simplu pentru date cu dimensiuni mari. Am văzut cu LISTA că, în
+plus, algoritmii iterativi pentru învățarea dicționarelor supracomplete folosite rar
+oferă o interpretare pentru rețelele profunde de tip ReLU, pe care le vom
+generaliza în capitolele ulterioare la distribuții de date mai complexe decât
+\eqref{eq:overcomplete-dl-section-data-model}.
+Dar merită menționat că chiar și în era modernă a modelelor mari, modelul
+de generare a datelor \eqref{eq:overcomplete-dl-section-data-model} oferă o bază
+practică utilă pentru
+\textit{interpretarea caracteristicilor în rețelele profunde la scară largă pre-antrenate}, cum ar fi
+transformatoarele, urmând ipoteza că caracteristicile (neinterpretabile, \textit{a
+priori}) din aceste rețele constau din „suprapuneri" rare de
+caracteristici subiacente, care sunt ele însele interpretabile
+\cite{elhage2022superposition}. Aceste paradigme de învățare \textit{nesupervizate}
+sunt în general mai prietenoase cu datele decât LISTA, de asemenea, care necesită cantități mari
+de perechi etichetate $(\vX, \vZ)$ pentru antrenament supervizat.
+
+Putem folosi dezvoltarea noastră a algoritmului LISTA de mai sus pentru a înțelege practicile
+comune în acest domeniu de cercetare.
+În cea mai directă instanțiere (vezi \citep{huben2024sparse,
+gao2025scaling}), un număr mare de caracteristici dintr-o rețea profundă pre-antrenată $h$
+sunt colectate din diferite intrări $\vx_i$, care sunt ele însele alese pe baza
+unei sarcini de interpretare dorite.\footnote{De exemplu, intrările $\vx_i$ ar putea
+corespunde textelor care conțin mostre de cod de calculator în diferite limbaje
+de programare, cu sarcina noastră fiind să încercăm să identificăm caracteristici interpretabile într-o
+hartă de caracteristici transformer $h$ corespunzând diferitelor aspecte saliente ale
+intrării, cum ar fi limbajul de programare specific (distinct între „clasele"
+de intrare) sau necesitatea de a insera o paranteză de potrivire la poziția
+curentă (comună între „clasele" de intrare). Discutăm utilizarea rețelelor profunde,
+și în special a transformatoarelor, pentru învățarea reprezentării
+textului în detaliu mai mare în \Cref{ch:applications}.} Pentru
+simplitate, vom folosi $h$ pentru a denota harta de caracteristici pre-selectată în cauză,
+cu caracteristici $D$-dimensionale; date $N$ intrări eșantion, fie $\vH \in \bR^{D
+\times N}$ să noteze matricea completă de caracteristici a lui $h$.
+Apoi un așa-numit autocodificator rar $f : \bR^D \to \bR^d$, cu decodor $g : \bR^d \to
+\bR^D$, este antrenat prin pierderea LASSO \eqref{eq:sparse_dl_lasso}:
+\begin{equation}\label{eq:sae-loss}
+  \min_{f, g} \| \vH - g(f(\vH))) \|_F^2 + \lambda \|f(\vH)\|_1 ,
+\end{equation}
+unde autocodificatorul rar $f$ ia forma unei rețele neurale cu un singur strat,
+i.e.\ $f(\vh_i) = \sigma(\vW_{\mathrm{enc}}(\vh_i - \vb)
++ \vb_{\mathrm{enc}})$, unde $\sigma(x) = \max \{x, 0\}$ este funcția de
+activare ReLU, iar decodorul $g$ este liniar, astfel încât $g(\vz_i)
+= \vW_{\mathrm{dec}}\vz + \vb$.
+
+Parametrizarea și procedura de antrenament \eqref{eq:sae-loss} pot părea inițial
+a fi o aplicație arbitrară a învățării profunde la problema codificării
+rare, dar este de fapt foarte aliniată cu algoritmii pe care i-am studiat
+mai sus pentru codificarea rară pe straturi cu un dicționar învățat.
+În special, reamintim arhitectura LISTA %
+$\vZ^{L} = f(\vA^L, f(\vA^{L-1}, \cdots, f(\vA^1, \vX) \cdots ))$.
+În cazul special $L=2$, avem
+\begin{equation}
+    \vZ^2 = f(\vA^1, \vX) 
+    =S_{\eta\lambda}\rp{\vZ^{1} - 2\eta(\vA^{1})^{\top}(\vA^1\vZ^{1} - \vX)}.
+\end{equation}
+Să presupunem că codurile rare $\vZ$ în cauză sunt nenegative, i.e.,
+că $\vZ \geq \Zero$.\footnote{În modelul de generare a datelor
+\eqref{eq:overcomplete-dl-section-data-model}, o pereche arbitrară
+dicționar-și-cod-rar $(\vA, \vZ)$ poate fi înlocuită cu una în care
+$\vZ \geq \Zero$ prin simpla dublare a numărului de coloane în $\vA$, deci dintr-o
+perspectivă de modelare, aceasta este o presupunere foarte blândă.}
+Atunci (vezi \Cref{example:prox-of-nonnegative-l1}), putem considera o arhitectură
+LISTA echivalentă obținută din obiectivul de codificare rară cu o constrângere
+suplimentară de nenegativitate pe $\vZ$ ca
+\begin{equation}
+    \vZ^2 = f(\vA^1, \vX) 
+    =\max \set*{\vZ^{1} - 2\eta(\vA^{1})^{\top}(\vA^1\vZ^{1} - \vX)
+    - \lambda\eta \mathbf{1}, 0},
+\end{equation}
+și după ceva algebră, putem exprima aceasta ca
+\begin{equation}
+    \vZ^2 = f(\vA^1, \vX) 
+    =\max \set*{
+        2\eta(\vA^{1})^{\top}
+        +
+        \left(
+        \vZ^{1} - 2\eta(\vA^{1})^{\top}\vA^1\vZ^{1} - \lambda\eta \mathbf{1}
+        \right), 0
+    }.
+\end{equation}
+Dată fiind capacitatea de a schimba inițializarea codului rar $\vZ^1$ ca
+un parametru învățabil (care, în cadrul curent, trebuie să aibă toate coloanele
+egale cu același vector învățabil), aceasta are forma unei rețele neurale ReLU
+cu bias învățabil---identică cu autocodificatorul rar $f$!
+Mai mult, pentru a \textit{decodifica} codurile rare învățate $\vZ^2$, este natural să
+aplicăm dicționarul învățat $\vZ^2 \mapsto \vA^1 \vZ^2$. Atunci singura
+diferență între aceasta și decodorul SAE $g$ este bias-ul suplimentar $\vb$,
+care poate fi tehnic absorbit în $\vH$ și $f$ în obiectivul de antrenament
+\eqref{eq:sae-loss}.
+
+Astfel, parametrizarea și procedura de antrenament SAE coincid cu
+antrenamentul LISTA cu $L=1$, și un obiectiv de antrenament modificat---folosind
+obiectivul LASSO \eqref{eq:sparse_dl_lasso}, care rămâne {\em nesupervizat}, în loc
+de pierderea de reconstrucție supervizată \eqref{eq:lista-training} folosită în LISTA
+vanilla. În special, putem înțelege arhitectura SAE în termenii interpretării
+noastre a arhitecturii LISTA în termenii codificării rare pe straturi din
+\eqref{eq:ISTA-update-layerwise}. Această conexiune sugerează o serie de noi
+strategii de proiectare pentru îmbunătățirea metodologiei practice de interpretabilitate, multe
+dintre ele rămânând neexplorate în mod tentant. Începem să expunem unele conexiuni cu
+metodologia mai largă de autocodificare în \Cref{ch:autoencoding}.
+
+\paragraph{Codificare rară învățată pe straturi?}
+
+În setarea supervizată, LISTA oferă un analog de rețea neurală profundă al
+iterației de codificare rară, cu dicționare învățate pe straturi, inspirat de
+minimizarea alternantă; chiar și în setarea nesupervizată, aceeași metodologie
+poate fi aplicată învățării, ca în cazul autocodificatoarelor rare.
+Dar conexiunea între algoritmii de optimizare care caută structuri cu dimensiuni reduse
+și arhitecturile de rețele profunde merge mult mai adânc decât aceasta și sugerează o gamă
+de arhitecturi neurale de învățare scalabile și naturale care pot fi chiar utilizabile
+fără propagare inversă.
+
+Ca o ilustrare simplă, revenim la iterațiile de minimizare alternantă
+\eqref{eqn:ISTA-update} și \eqref{eqn:DL-update}.
+Această schemă reinițializează aleatoriu dicționarul $\vA_1$ la fiecare astfel de actualizare.
+O îmbunătățire folosește în schimb \textit{pornirea caldă}, unde reziduul este
+generat folosind estimarea anterioară $\vA_+$ pentru dicționar.
+Dacă apoi vedem fiecare actualizare ISTA \eqref{eqn:ISTA-update} ca un strat și permitem
+dicționarului asociat, acum cuplat cu actualizările codului rar ca
+$\vA_\ell$, să se actualizeze în timp, aceasta duce la o schemă de
+codificare rară „învățabilă pe straturi":
+
+\begin{align}
+    & \vZ^{1}
+     = \Zero, \quad (\vA_{1})_j
+     \simiid \dNorm(\vzero, \tfrac{1}{D}\vI), \enspace \forall j \in [m], \\ 
+    & \vZ^{\ell + 1} = S_{\eta\lambda}\rp{\vZ^{\ell}
+    - 2\eta(\vA_{\ell})^\top(\vA_{\ell}\vZ^{\ell}
+    - \vX)},\label{eq:ISTA-update-layerwise}\\ 
+    & \vA_{\ell + 1} = \vA_{\ell}- 2\nu (\vA_{\ell}\vZ^{\ell + 1}
+    - \vX)(\vZ^{\ell + 1})^\top.
+\end{align}
+Observați că această iterație %
+corespunde unei re-etichetări a \eqref{eqn:ISTA-update} și \eqref{eqn:DL-update}
+pentru $T = L = 1$, pe un număr infinit de blocuri.
+Fiecare dintre pașii „interni" care actualizează $\vZ$ poate fi considerat ca o
+propagare înainte cu un singur strat, în timp ce fiecare dintre pașii „externi" care actualizează $\vA$ poate fi considerat
+ca o propagare înapoi cu un singur strat, a unei rețele neurale profunde primitive. În
+special, acesta este cel mai simplu caz în care se manifestă o diviziune clară între
+optimizarea înainte și învățarea înapoi. Această diviziune este încă
+observată în rețelele neurale și autocodificatoarele actuale---vom avea mult mai multe de spus despre aceasta în \Cref{ch:unrolling} și în
+\Cref{ch:autoencoding}.
+
+Observați că schema de mai sus pe straturi sugerează, de asemenea, o alternativă plauzibilă la strategia actuală de optimizare de la capăt la capăt care se bazează în principal pe propagarea inversă (BP) detaliată în \Cref{app:BP-section}. Eliberarea antrenării rețelelor mari de BP ar fi una dintre cele mai mari provocări și oportunități în viitor, așa cum vom discuta mai mult la sfârșitul cărții în \Cref{ch:future}.
+
+\section{Rezumat și Note}
+
+Modelele idealiste pe care le-am prezentat în acest capitol---PCA, ICA și
+învățarea dicționarului---au fost dezvoltate pe parcursul secolului XX.
+Multe cărți au fost scrise doar despre fiecare metodă, așa că vom încerca aici
+doar să oferim o imagine de ansamblu largă a lucrărilor cheie și a istoriei.
+
+Jolliffe \cite{Jolliffe1986} atribuie analiza componentelor principale lui Pearson
+\cite{Pearson1901}, și independent lui Hotelling \cite{Hotelling1933}. În
+matematică, rezultatul principal privind problema conexă a aproximării de rang redus în
+norme unitar invariante este atribuit lui Eckart și Young
+\cite{Eckart1936-ep}, și lui Mirsky pentru generalitate completă \cite{Mirsky1960-ek}.
+PCA continuă să joace un rol important în cercetare ca poate cea mai simplă
+problemă model pentru învățarea nesupervizată a reprezentărilor: încă din anii 1980,
+lucrări precum \textcite{Oja1982SimplifiedNM} și \textcite{Baldi89} au folosit
+problema pentru a înțelege învățarea în rețelele neurale primitive, iar mai recent,
+a servit ca un instrument pentru înțelegerea cadrelor de învățare a reprezentărilor mai complexe,
+cum ar fi modelele de difuzie \cite{wang2024diffusion}.
+
+Analiza componentelor independente a fost propusă de \textcite{Ans-1985} și pionierată de
+Aapo Hyv\"{a}rinen în anii 1990 și începutul anilor 2000 într-o serie de lucrări
+influente: vezi \textcite{Hyvrinen-2000} pentru un rezumat. Ca un model simplu pentru
+structura care apare în datele practice, inițial a avut o utilizare semnificativă în
+aplicații precum separarea surselor oarbe, unde fiecare componentă independentă
+$z_i$ reprezintă o sursă independentă (cum ar fi sunetul asociat cu un instrument
+distinct într-o înregistrare muzicală) care este suprapusă pentru a produce
+observația $\vx = \vU \vz$.
+
+Problema
+învățării dicționarului poate, în cazul complet sau ortogonal, să fie văzută ca una dintre
+problemele fundamentale ale procesării semnalului din secolul XX, în special
+în teoria sistemelor liniare, unde baza Fourier joacă rolul cheie; din
+anii 1980 încoace, domeniul analizei armonice computaționale s-a cristalizat în jurul
+studiului unor astfel de dicționare alternative pentru clase de semnale în care aproximarea
+optimă ar putea fi realizată doar într-o bază diferită de Fourier (de exemplu, wavelets)
+\cite{Donoho1998-zf}. Cu toate acestea, importanța cazului bazelor redundante, sau
+dicționarelor supracomplete, a fost evidențiată doar în urma lucrării pioniere a lui
+Olshausen și Field \cite{Olshausen1996-ap,Olshausen1997-yv}. Lucrările ulterioare timpurii au
+stabilit fundamentele conceptuale și algoritmice pentru învățarea
+dicționarelor supracomplete folosite rar, adesea destinate reprezentării imaginilor
+naturale
+\cite{Donoho2001-tl,DonohoD2003-PNAS,Elad2006-yi,Murray2007-cw,aharon2006k,Mairal2014-nq,Gribonval2015-fy}.
+Mai târziu, o cantitate semnificativă de interes teoretic în problemă, ca o problemă
+model importantă și netrivială pentru învățarea nesupervizată a reprezentărilor,
+a dus la studiul ei de către comunitățile de procesare a semnalului, învățare automată teoretică și
+informatică teoretică, în special axată pe condițiile
+în care problema ar putea fi rezolvată demonstrabil și eficient.
+O listă neexhaustivă de lucrări notabile în această linie include cele ale lui
+\textcite{Spielman2012-tl} și \textcite{sun2017complete_a} pe cazul complet;
+\textcite{pmlr-v40-Arora15}; \textcite{Barak2015-uu}; și
+\textcite{Qu2020Geometric}. Multe întrebări teoretice profunde despre această
+problemă simplă de enunțat rămân deschise, poate în parte din cauza unei tensiuni cu
+duritatea NP în cel mai rău caz a problemei (de exemplu, vezi \textcite{Tillmann2015-up}).
+
+\begin{table}[tb]
+\centering
+    \caption{Rezumatul metodelor puterii (generalizate) prezentate în Capitol}
+    \label{tab:power-method-summary}
+\begin{tabular}{llll}
+\toprule
+Problemă & Algoritm & Iterație & Tip de Structură Impusă \\
+\midrule
+PCA & Metoda Puterii & $\vu_{t} = \frac{\vX\vX^\top
+    \vu_{t}}{\norm{\vX\vX^\top \vu_{t}}_2}$ & subspațiu 1-dim.\ (vector unitar) \\
+    \addlinespace
+    ICA & FastICA &
+    $\vu_{t+1} = \frac{\tfrac{1}{N}\vX (\vX^\top \vu_{t})^{\hada 3}-
+    3 \vu_{t}}{\norm*{\tfrac{1}{N}\vX (\vX^\top \vu_{t})^{\hada 3}-
+    3 \vu_{t}}_2}$
+    & subspațiu 1-dim.\ (vector unitar) \\
+    \addlinespace
+    DL Complet & Algoritmul MSP &
+    $\vU_{t+1} = \mathcal{P}_{\mathrm O(D)}[( {\vU_t \vX})^{\hada 3}\vX^\top]$
+    & subspațiu $D$-dim.\ (matrice ortogonală) \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Un punct pe care dorim să-l evidențiem din studiul acestor modele
+analitice clasice pentru structura cu dimensiuni reduse este rolul comun jucat de
+diverse \textit{metode generalizate ale puterii}---algoritmi care converg foarte rapid,
+cel puțin local, către diverse tipuri de structuri cu dimensiuni reduse. Terminologia
+pentru această clasă de algoritmi urmează lucrarea lui \textcite{JourneeM2010}.
+La un nivel înalt, modelat pe iterația clasică a puterii pentru calculul
+vectorului propriu de top al unei matrice semidefinite $\vA \in \bR^{n \times n}$, adică
+\begin{equation}
+    \vu_{t+1} = \frac{\vA \vu_{t}}{\norm{\vA \vu_{t}}_2},
+\end{equation}
+această clasă de algoritmi constă dintr-o operație de „ridicare la putere" care implică o matrice
+$\vA$ asociată datelor, împreună cu o operație de „proiecție" care
+impune un tip dorit de structură. \Cref{tab:power-method-summary} prezintă
+un rezumat al algoritmilor pe care i-am studiat în acest capitol care urmează această
+structură. Cititorul poate aprecia aplicabilitatea acestei metodologii la
+diferite tipuri de structură cu dimensiuni reduse și pierderi diferite (i.e., atât
+pierderea pătratică din PCA, cât și pierderile de tip kurtosis din ICA), precum și
+lipsa unui astfel de algoritm pentru învățarea dicționarului supracomplet, în ciuda
+amplitudinii literaturii despre acești algoritmi. Vedem dezvoltarea metodelor
+puterii pentru familii suplimentare de structuri cu dimensiuni reduse, în special cele
+relevante pentru aplicațiile în care învățarea profundă este prevalentă, ca una dintre
+întrebările de cercetare mai importante (și deschise) sugerate de acest capitol.
+
+Conexiunea pe care o facem în \Cref{sec:mixture-and-dict} între ipoteza
+distribuțională geometrică de amestec de subspații și ipoteza mai convenabilă
+analitic a dicționarului rar a fost menționată în lucrări anterioare,
+în special de cei concentrați pe analiza generalizată a componentelor principale
+și aplicații precum gruparea subspațiilor, de exemplu, lucrarea lui \textcite{GPCA}.
+Ipoteza amestecului de subspații va continua să joace un rol semnificativ
+pe parcursul acestui manuscris, atât ca un caz de test analitic pentru diferite
+paradigme algoritmice, cât și ca o fundație pentru derivarea diferitelor arhitecturi
+de rețea profundă, ca în cazul LISTA în \Cref{sec:LISTA}, dar care pot scala la
+distribuții de date mai complexe.
+
+\section{Exerciții și Extensii}
+
+\begin{exercise}\label{exercise:principal-components-derivation}
+    Demonstrați că, pentru orice matrice simetrică \(\vA\), soluția la problema
+    \(\max_{\vU \in \O(D, d)}\tr\left(\vU^{\top}\vA\vU\right)\) este matricea
+    \(\vU^{\star}\) ale cărei coloane sunt cei \(d\) vectori proprii unitari de top ai lui \(\vA\).
+\end{exercise}
+
+\begin{exercise}\label{exercise:gaussian-rot-invar}
+    Fie $\vz \sim \cN(\Zero, \sigma^2 \vI)$ o variabilă aleatoare gaussiană cu componente independente, fiecare cu varianță $\sigma^2$.
+    Demonstrați că pentru orice matrice ortogonală $\vQ$ (i.e., $\vQ^\top \vQ = \vI$), variabila aleatoare $\vQ \vz$ este distribuită identic cu $\vz$.
+    \textit{(Sugestie: amintiți-vă formula pentru funcția de densitate de probabilitate gaussiană și formula pentru densitatea unei funcții liniare a unei variabile aleatoare.)}
+\end{exercise}
+
+\begin{exercise}\label{exercise:symmetry-identifiability}
+    Noțiunea de identificabilitate statistică discutată mai sus poate fi legată de \textit{simetriile} clasei de model, permițând înțelegerea estimării într-un mod pur determinist fără ipoteze statistice.
+
+    Considerați modelul $\vX = \vU \vZ$ pentru matricele $\vX, \vU, \vZ$ de dimensiuni compatibile.
+    \begin{enumerate}
+        \item Arătați că dacă $\vA$ este orice matrice pătrată inversabilă de dimensiune compatibilă, atunci perechea
+        $(\vU \vA, \vA^{-1} \vZ)$ este de asemenea egală cu $\vX$ sub model. Numim aceasta o \textit{simetrie $\GL(d)$}.
+        \item Presupuneți că fiecare coloană a lui $\vZ$ este o observație independentă și identic distribuită dintr-un model statistic comun $\vz$, care mai mult are medie zero și componente independente $z_i$ cu varianță pozitivă.
+        Arătați că pentru orice matrice pătrată inversabilă $\vA$, dacă $\vA \vz$ are componente necorelate, atunci $\vA$ poate fi scrisă ca $\vD_1 \vQ \vD_2$, unde $\vQ$ este o matrice ortogonală și $\vD_1$, $\vD_2$ sunt matrice diagonale.
+        \textit{Aceasta leagă ipoteza de „independență" din ICA de un efect de „rupere a simetriei", care permite doar simetrii de scală și rotaționale.}
+    \end{enumerate}
+\end{exercise}
+
+\begin{exercise}\label{exercise:whitening}
+    Considerați modelul $\vx = \vU \vz$, unde $\vU \in \R^{D \times d}$ cu $D \geq d$ este fixat și are rang $d$, iar $\vz$ este o variabilă aleatoare cu medie zero. Fie $\vx_1, \dots, \vx_N$ să noteze observații i.i.d.\ din acest model.
+    \begin{enumerate}
+        \item Arătați că matricea $\vX = [\vx_1, \dots, \vx_N]$ are rang nu mai mare de $d$, și prin urmare există o matrice ortonormală $\vV \in \R^{D \times d}$ astfel încât $\vX = \vV \vY$, unde $\vY \in \R^{d \times N}$. (\textit{Sugestie: folosiți PCA.})
+        \item Arătați că \textit{matricea albită} $(\vY \vY^\top)^{-1/2}\vY$ există în așteptare ori de câte ori $\Cov(\vz)$ este nesingulară și că are covarianță empirică identitate.\footnote{În special, se poate demonstra matematic că aceasta este suficientă pentru a garanta că matricea albită există cu probabilitate mare ori de câte ori $\vz$ satisface o inegalitate de concentrare adecvată și $N$ este suficient de mare.}
+        \item Arătați, folosind descompunerea în valori singulare a lui $\vU$, că matricea $\vV$ poate fi aleasă astfel încât matricea albită să satisfacă $(\vY \vY^\top)^{-1/2} \vY = \vW [\vz_1, \dots, \vz_N]$, unde $\vW$ este o matrice ortonormală.
+    \end{enumerate}
+\end{exercise}
+
+\begin{exercise}\label{exercise:kurtosis-linearity-properties}
+    Fie $X$ și $Y$ variabile aleatoare independente cu medie zero.
+    \begin{enumerate}
+        \item Arătați că $\kurt(X + Y) = \kurt(X) + \kurt(Y)$.
+        \item Pentru orice $\alpha \in \R$, arătați că $\kurt(\alpha X) = \alpha^4 \kurt(X)$.
+    \end{enumerate}
+\end{exercise}
+
+\begin{exercise}\label{exercise:sphere-calculus}
+    Fie $f : \R^d \to \R$ o funcție obiectiv dată de două ori continuu diferențiabilă. Considerați problema de optimizare constrânsă sferic
+    \begin{equation}\label{eq:exercise-sphere-constrained-max}
+        \max_{\norm{\vu}_2^2 = 1}\, f(\vu). 
+    \end{equation}
+    În acest exercițiu, vom deriva expresiile pe care le-am dat în derivarea FastICA pentru maximizarea kurtosis-ului pe sferă prin intermediul unui algoritm de urcare a gradientului.
+    Aceste expresii sunt cazuri speciale ale unei teorii bogate de calcul și optimizare pe varietăți, dintre care sfera este un exemplu particular. Un studiu tehnic profund al acestui domeniu este în afara scopului nostru, așa că menționăm doar două referințe cheie pentru cititorul interesat: manualul pionier al lui Absil, Mahony și Sepulchre
+    \cite{Absil2009-nc}, și un tratat introductiv mai recent de Boumal \cite{Boumal2023-rj}.
+    \begin{enumerate}
+        \item Pentru orice set de constrângeri $\cM$ care este o subvarietate diferențiabilă a lui $\R^d$,
+        \textit{spațiul tangent} la un punct $\vu \in \cM$ este, informal, cea mai bună aproximare liniară locală la varietatea $\cM$ la punctul $\vu$.
+        În cazul special important unde $\cM$ este definit local la $\vu$ ca un set de nivel al unei funcții $F : \R^d \to \R$,
+        adică
+        \begin{equation*}
+            \cM \cap U = \set{\vu \in U \given F(\vu) = 0}
+        \end{equation*}
+        pentru un anumit set deschis $U \subset \cM$ cu $\vu \in U$,
+        spațiul tangent la $\cM$ la $\vu$ poate fi calculat
+        prin diferențiere:
+        \begin{equation*}
+            T_{\vu} \cM = \Ker(DF_{\vu}).
+        \end{equation*}
+        Se vede cu ușurință că sfera are ecuația definitorie $F(\vu) = \norm{\vu}_2^2 - 1$.
+        Arătați, folosind aceste fapte, că spațiul tangent la sferă la $\vu$ este dat de
+        \begin{equation*}
+            T_{\vu} \bS^{d-1} = \set{\vv \in \R^d \given \ip{\vv}{\vu} = 0},
+        \end{equation*}
+        și că proiecția ortogonală pe acest subspațiu este $\vP_{\vu}^\perp = \vI - \vu\vu^\top$.
+        \item Câmpul vectorial
+        \begin{equation}\label{eq:exercise-riemann-grad-sphere}
+        \mathrm{grad}\, f(\vu) = \vP_{\vu}^\perp \nabla f
+        \end{equation}
+        este cunoscut ca \textit{gradientul Riemannian} al funcției $f$ restricționată la sferă.
+        \textit{Condițiile de optimalitate de ordinul întâi} pentru problema de optimizare \eqref{eq:exercise-sphere-constrained-max} pot fi exprimate în termenii gradientului Riemann:
+        \begin{equation*}
+            \mathrm{grad}\, f(\vu) = \mathbf{0}.
+        \end{equation*}
+        Geometric, aceasta spune că gradientul euclidian al lui $f$ la $\vu$ trebuie să fie ortogonal pe spațiul tangent la sferă la $\vu$.
+        Acum presupuneți că $\vv \in \R^d$ este nenul. Arătați că
+        \begin{equation*}
+            \mathrm{proj}_{\bS^{d-1}}(\vv) \doteq
+            \min_{\norm{\vu}_2^2 = 1}\, \norm{\vu - \vv}_2 
+            =
+            \frac{\vv}{\norm{\vv}_2},
+        \end{equation*}
+        folosind condițiile de optimalitate de ordinul întâi.
+        \item În optimizarea pe $\R^d$, se verifică condițiile de optimalitate de ordinul al doilea (pentru a determina dacă un punct critic este un maximizator, un minimizator sau un punct de șa) folosind \textit{matricea Hessiană} $\nabla^2 f(\vu)$.
+        Arătați, prin diferențierea gradientului Riemann $\mathrm{grad}\, f(\vu)$ pentru sferă în raport cu $\vu$ ca în prima parte a acestui exercițiu, că obiectul corespunzător pentru determinarea condițiilor de optimalitate de ordinul al doilea pentru optimizarea constrânsă sferic este \textit{Hessiana Riemanniană}, definită ca
+        \begin{equation}\label{eq:exercise-riemann-hess-sphere}
+            \mathrm{Hess}\, f(\vu) = \vP_{\vu}^\perp \left( 
+            \nabla^2 f(\vu) - \ip{\nabla f(\vu)}{\vu} \vI
+            \right) \vP_{\vu}^\perp.
+        \end{equation}
+    \end{enumerate}
+\end{exercise}
+
+\begin{exercise}\label{exercise:kurtosis-sphere-landscape}
+    În acest exercițiu, schițăm un argument numit în literatură \textit{analiză de peisaj} pentru problema de maximizare a kurtosis-ului populației constrânsă sferic \eqref{eq:kurtosis-maximization-sphere-population-simple}. Vom arăta că atunci când există cel puțin o componentă independentă cu kurtosis pozitiv,
+    maximizatorii săi globali duc într-adevăr la recuperarea unei coloane a dicționarului $\vU$.
+    Pentru simplitate, vom presupune că $\kurt(z_i) \neq 0$ pentru fiecare $i = 1, \dots, d$.
+    \begin{enumerate}
+        \item Folosind rezultatele din Partea 1 a \Cref{exercise:sphere-calculus},
+        arătați că condiția de optimalitate de ordinul întâi pentru \eqref{eq:kurtosis-maximization-sphere-population-simple} este
+        \begin{equation}\label{eq:kurtosis-sphere-landscape-stationarity}
+            \left(\sum_{i=1}^d \kurt(z_i) w_i^4 \right) 
+            \vw = \kurt(\vz) \hada \vw^{\hada 3}, 
+        \end{equation}
+        unde kurtosis-ul este calculat element cu element, $\hada$ denotă înmulțirea element cu element a vectorilor și $\vw^{\hada 3}$ denotă cubul element cu element al argumentului său.
+        \item Arătați că vectorii $\vw$ cu normă unitară care satisfac de asemenea \eqref{eq:kurtosis-sphere-landscape-stationarity}
+        iau toți următoarea formă.
+        Fie $S^+ = \set{i \in [d] \given \kurt(z_i) > 0}$, și
+        $S^- = \set{i \in [d] \given \kurt(z_i) < 0}$.
+        Fie $S$ o submulțime fie a lui $S^+$ sau a lui $S^-$.
+        Atunci
+        \begin{equation}\label{eq:kurtosis-sphere-landscape-cps}
+            \vw_S = \sum_{i \in S} \pm \sqrt{\frac{1}{\kurt(z_i) \sum_{j \in S} \frac{1}{\kurt(z_j)}}} \ve_i
+        \end{equation}
+        satisface \eqref{eq:kurtosis-sphere-landscape-stationarity},
+        unde $\ve_i$ este vectorul cu un $1$ în poziția $i$-a și $0$-uri în altă parte, iar semnul $\pm$ denotă alegerea fie a unui semn pozitiv, fie negativ.
+        \item Presupuneți că există cel puțin un $i$ astfel încât $\kurt(z_i) > 0$. Folosind rezultatele din Partea 2 a \Cref{exercise:sphere-calculus}, arătați că singurele maxime locale ale obiectivului din \eqref{eq:kurtosis-maximization-sphere-population-simple} sunt vectorii cu semn unu-rar $\pm \ve_i$ cu $i \in S^+$. Concluzionați că maximizatorii globali ai \eqref{eq:kurtosis-maximization-sphere-population-simple} sunt vectorii cu semn unu-rar corespunzători componentelor cu kurtosis maxim. %
+        (\textit{Sugestie: numărați numărul de valori proprii pozitive și negative ale Hessianei Riemanniene \eqref{eq:exercise-riemann-hess-sphere} la fiecare punct critic.})
+        \item Acum presupuneți că $\kurt(z_j) < 0$ pentru fiecare $j =1, \dots, d$. Aceasta corespunde unei instanțieri „prea deflată" a problemei de maximizare a kurtosis-ului. Folosind din nou rezultatele din Partea 2 a \Cref{exercise:sphere-calculus}, arătați că singurele maxime locale ale obiectivului din \eqref{eq:kurtosis-maximization-sphere-population-simple} sunt vectorii cu semn dens $\sum_{i=1}^d \pm \ve_i$.
+        Aceasta arată că formularea de optimizare \eqref{eq:kurtosis-maximization-sphere-population-simple} nu poate fi aplicată naiv.
+    \end{enumerate}
+\end{exercise}
+
+\begin{exercise}\label{exercise:orthogonal-group-calculus}
+    Acest exercițiu urmează structura și formalismul introdus în \Cref{exercise:sphere-calculus}, dar îl aplică în schimb la grupul ortogonal $\O(d) = \set{\vU \in \R^{d \times d} \given \vU^\top \vU = \vI}$.
+    Consultați descrierea din \Cref{exercise:sphere-calculus} pentru fundalul conceptual necesar; formalismul se aplică identic cazului în care spațiul ambiental este setul de matrice $d \times d$ atâta timp cât ne amintim că produsul interior relevant pe matrice este $\ip{\vX}{\vY} = \tr(\vX^\top \vY)$.
+    O referință generală excelentă pentru fapte despre optimizarea pe grupul ortogonal este Edelman, Arias și Smith \cite{Edelman1998-lg}.
+    
+    Fie $f : \R^{d\times d} \to \R$ o funcție obiectiv dată de două ori continuu diferențiabilă. Considerați problema de optimizare constrânsă ortogonal
+    \begin{equation}\label{eq:exercise-orthogonal-group-constrained-max}
+        \max_{\vQ^\top \vQ = \vI}\, f(\vQ). 
+    \end{equation}
+    \begin{enumerate}
+        \item Se vede cu ușurință că grupul ortogonal are ecuația definitorie $F(\vQ) = \vQ^\top \vQ = \vI$.
+        Arătați, folosind acest fapt, că spațiul tangent la grupul ortogonal la $\vQ$ este dat de
+        \begin{equation*}
+            T_{\vQ} \O(d) = \set{\vQ \vOmega \in \R^{d\times d} \given \vOmega^\top = - \vOmega},
+        \end{equation*}
+        și că proiecția ortogonală pe acest subspațiu este
+        \begin{equation*}
+        \cP_{T_{\vQ}\O(d)}(\vDelta) =  \vQ \Skew(\vQ^\top \vDelta),
+        \end{equation*}
+        unde $\Skew(\vDelta) = \tfrac{1}{2} ( \vDelta - \vDelta^\top)$ este proiecția ortogonală pe setul de matrice antisimetrice.
+        Câmpul vectorial
+        \begin{equation}\label{eq:exercise-riemann-grad-orthogonal-group}
+        \mathrm{grad}\, f(\vQ) = \cP_{T_{\vQ} \O(d)} \left( \nabla f(\vQ) \right)
+        \end{equation}
+        este cunoscut ca \textit{gradientul Riemannian} al funcției $f$ restricționată la grupul ortogonal.
+        \textit{Condițiile de optimalitate de ordinul întâi} pentru problema de optimizare \eqref{eq:exercise-orthogonal-group-constrained-max} pot fi exprimate în termenii gradientului Riemann:
+        \begin{equation*}
+            \mathrm{grad}\, f(\vQ) = \mathbf{0}.
+        \end{equation*}
+        \item Arătați, prin diferențierea gradientului Riemann $\mathrm{grad}\, f(\vQ)$ pentru grupul ortogonal în raport cu $\vQ$ ca în prima parte a acestui exercițiu, că \textit{Hessiana Riemanniană} este dată de
+        \begin{equation}\label{eq:exercise-riemann-hess-orthogonal-group}
+            \mathrm{Hess}\, f(\vQ) = \cP_{T_{\vQ}\O(d)} \left( 
+            \nabla^2 f(\vQ) - \Symm(\vQ^\top \nabla f(\vQ)) \kron \vI
+            \right) \cP_{T_{\vQ}\O(d)},
+        \end{equation}
+        unde $\Symm(\vDelta) = \tfrac{1}{2}(\vDelta + \vDelta^\top)$ denotă proiecția ortogonală pe setul de matrice simetrice, iar $\kron$ denotă produsul Kronecker al matricelor.
+        Aveți grijă să interpretați operatorii care apar în expresia anterioară ca \textit{transformări liniare pe matrice ${d \times d}$}, \textbf{nu} ca matrice $d \times d$ ele însele.
+        \textit{Condițiile de optimalitate de ordinul al doilea} pentru problema de optimizare \eqref{eq:exercise-orthogonal-group-constrained-max} pot fi exprimate în termenii Hessianei Riemann:
+        \begin{equation*}
+            \mathrm{Hess}\, f(\vQ) \preceq \mathbf{0}.
+        \end{equation*}
+        Pentru o problemă de minimizare, semnul este inversat.
+
+        (\textit{Sugestie: Cheia este să manipulați calculele pentru a obține forma \eqref{eq:exercise-riemann-hess-orthogonal-group}, care este cât mai compactă posibil. În acest scop, folosiți următorul izomorfism al produsului Kronecker: dacă $\vA$, $\vX$ și $\vB$ sunt matrice de dimensiuni compatibile, atunci avem
+        \begin{equation*}
+            (\vB^\top \kron \vA) \Vec(\vX) = \Vec(\vA \vX \vB),
+        \end{equation*}
+        unde $\Vec(\vX)$ denotă stivuirea „de la stânga la dreapta" a coloanelor argumentului matrice într-un vector. Folosim acest izomorfism în \eqref{eq:exercise-riemann-hess-orthogonal-group} pentru a defini produsul Kronecker a două matrice ca un operator pe matrice într-un mod canonic.})
+        
+        \item Acum presupuneți că $\vX \in \R^{d\times d}$ are rang complet. În aceasta și în următoarea parte a exercițiului, considerăm proiecția pe grupul ortogonal a lui $\vX$:
+        \begin{equation}\label{eq:projection-onto-ogrp-defn}
+            \mathrm{proj}_{\O(d)}(\vX) \doteq
+            \min_{\vQ \in \O(d)
+            }\, \norm{\vQ - \vX}_F^2.
+        \end{equation}
+        Vom demonstra că soluția acestei probleme este dată de
+        \begin{equation*}
+            \mathrm{proj}_{\O(d)}(\vX)
+            =
+            \vU \vV^\top,
+        \end{equation*}
+        unde $\vX = \vU \vS \vV^\top$ este o descompunere în valori singulare a lui $\vX$.
+
+        \begin{enumerate}
+            \item Folosind condițiile de optimalitate de ordinul întâi și al doilea, arătați că fiecare minimizator local $\vQ$ al \eqref{eq:projection-onto-ogrp-defn} satisface
+            \begin{align*}
+                \left( \vQ^\top \vX \right)^\top &= \vQ^\top \vX, \\
+                \vQ^\top \vX &\succeq \mathbf{0}.
+            \end{align*}
+            (\textit{Sugestie: folosiți liniaritatea produsului Kronecker în oricare dintre cei doi argumente când celălalt este fixat.})
+            \item Folosind aceste condiții, argumentați că la fiecare minimizator local $\vQ$ al \eqref{eq:projection-onto-ogrp-defn}, avem $\vQ^\top \vX = (\vX^\top \vX)^{1/2}$.
+            (\textit{Sugestie: Folosiți %
+            faptul din algebra liniară că dacă $\vS \succeq \mathbf{0}$ este o matrice simetrică pozitiv semidefinită, atunci $(\vS^\top\vS)^{1/2} = \vS$.})
+            \item Folosind descompunerea în valori singulare $\vX = \vU \vS \vV^\top$, concluzionați că
+            \begin{equation*}
+                \vU \vV^\top
+                =
+                \mathrm{proj}_{\O(d)}(\vX).
+            \end{equation*}
+        \end{enumerate}
+    \end{enumerate}
+\end{exercise}
+
+\end{document}

--- a/chapters/chapter3/compression-principle_ro.tex
+++ b/chapters/chapter3/compression-principle_ro.tex
@@ -1,0 +1,1430 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Urmărirea Dimensionalității Reduse prin Compresie cu Pierderi}
+\label{ch:compression}\label{ch:general-distribution}
+
+\begin{quote}
+	\hfill    ``{\em Comprimăm pentru a învăța, și învățăm pentru a comprima}.''\\
+	$~$ \hfill --- Analiza Datelor cu Dimensiuni Mari, Wright și Ma, 2022
+\end{quote}
+\vspace{5mm}
+
+În \Cref{ch:linear-independent}, am arătat cum să învățăm clase simple de distribuții ale căror suporturi sunt presupuse a fi fie un singur subspațiu sau un amestec de subspații cu dimensiuni reduse sau Gaussiene de rang redus. Pentru simplitate suplimentară, diferitele moduri liniare sau Gaussiene (ascunse) sunt presupuse a fi ortogonale sau independente\footnote{Sau pot fi reduse cu ușurință la astfel de cazuri idealiste.}, așa cum este ilustrat în \Cref{fig:subspaces}. După cum am arătat, pentru astfel de distribuții speciale, se pot deriva algoritmi de învățare destul de simpli și eficienți cu garanții de corectitudine și eficiență. Interpretarea geometrică și statistică a operațiilor din algoritmii asociați este, de asemenea, foarte clară.
+
+În practică, atât liniaritatea cât și independența sunt ipoteze destul de idealiste pe care distribuțiile datelor din lumea reală cu dimensiuni mari le satisfac rar. Singurul lucru pe care îl putem presupune este că dimensiunea intrinsecă a distribuției este foarte mică în comparație cu dimensiunea spațiului ambiental în care sunt înglobate datele. Prin urmare, în acest capitol, arătăm cum să învățăm o clasă mai generală de distribuții cu dimensiuni reduse într-un spațiu cu dimensiuni mari care nu este neapărat (pe bucăți) liniară.
+
+Este tipic ca distribuția datelor reale să conțină adesea componente multiple sau moduri, să zicem corespunzând diferitelor clase de obiecte în cazul imaginilor. Aceste moduri s-ar putea să nu fie statistic independente și pot avea chiar dimensiuni intrinseci diferite. Este, de asemenea, tipic că avem acces doar la un număr finit de eșantioane ale distribuției. Prin urmare, în general, putem presupune că datele noastre sunt distribuite pe un amestec de subvarietăți (neliniare) cu dimensiuni reduse într-un spațiu cu dimensiuni mari. \Cref{fig:mixture-manifolds} ilustrează un exemplu al unei astfel de distribuții.
+
+Pentru a învăța o astfel de distribuție în astfel de condiții, există câteva întrebări fundamentale pe care trebuie să le abordăm:
+\begin{itemize}
+	\item Care este o abordare generală pentru a învăța o distribuție generală cu dimensiuni reduse într-un spațiu cu dimensiuni mari și pentru a reprezenta distribuția învățată?
+	\item Cum măsurăm complexitatea reprezentării rezultate astfel încât să putem exploata efectiv dimensionalitatea redusă pentru a învăța?
+	\item Cum facem procesul de învățare tractabil computațional și chiar scalabil, deoarece dimensiunea ambientală este de obicei mare și numărul de eșantioane de obicei mare?
+\end{itemize}
+După cum vom vedea, ideea fundamentală a {\em compresiei}, sau {\em reducerii dimensiunii}, care s-a dovedit a fi foarte eficientă pentru cazul liniar/independent, servește încă ca un principiu general pentru dezvoltarea modelelor și metodelor computaționale eficiente pentru învățarea distribuțiilor generale cu dimensiuni reduse.
+
+Datorită semnificației sale teoretice și practice, vom studia în profunzime mai mare cum acest cadru general de învățare a distribuțiilor cu dimensiuni reduse prin compresie se concretizează atunci când distribuția de interes poate fi bine modelată sau aproximată printr-un amestec de subspații cu dimensiuni reduse sau Gaussiene de rang redus.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter3/figs/mixed-manifolds.png}
+    \caption{Date distribuite pe un amestec de subvarietăți cu dimensiuni reduse $\cup_j \mathcal{M}_j$ într-un spațiu ambiental cu dimensiuni foarte mari, să zicem $\mathbb{R}^D$.}
+    \label{fig:mixture-manifolds}
+\end{figure}
+
+
+\section{Minimizarea Entropiei și Compresie}
+
+\subsection{Entropie și Rata de Codificare}
+În \Cref{ch:intro}, am menționat că scopul învățării este de a găsi cel mai simplu mod de a genera un set dat de date. Conceptual, complexitatea Kolmogorov a fost destinată să ofere o astfel de măsură a complexității, dar nu este calculabilă și nu este asociată cu nicio schemă implementabilă care să poată reproduce efectiv datele. Prin urmare, avem nevoie de o măsură alternativă, calculabilă și realizabilă a complexității. Aceasta ne conduce la noțiunea de {\em entropie}, introdusă de Shannon în 1948 \cite{Shannon-1948}.
+
+Pentru a ilustra natura constructivă a entropiei, să începem cu cel mai simplu caz. Să presupunem că avem o variabilă aleatoare discretă care ia $N$ valori distincte, sau \textit{jetoane}, $\{\x_1, \ldots, \x_N\}$ cu probabilitate egală $1/N$. Atunci am putea codifica fiecare jeton \(\vx_{i}\) folosind reprezentarea binară pe \(\log_2 N\)-biți a lui \(i\). Această schemă de codificare ar putea fi generalizată la codificarea distribuțiilor discrete arbitrare \cite{Cover-Thomas}: Dată o distribuție \(p\) astfel încât $\sum_{i=1}^N p(\x_i) = 1$, am putea atribui fiecărui jeton $\x_i$ cu probabilitate $p(\x_i)$ un cod binar de dimensiune $\log_2 [1/p(\x_i)] = - \log_2 p(\x_i)$ biți. Prin urmare, numărul mediu de biți, sau {\em rata de codificare}, necesară pentru a codifica orice eșantion din distribuția $p(\cdot)$ este dată de expresia:\footnote{Prin convenția Teoriei Informației \cite{Cover-Thomas}, $\log$ aici este în baza $2$. Prin urmare, entropia este măsurată în biți (binari).}
+\begin{equation}
+	H(\x) \doteq \mathbb{E}[\log 1/p(\x)]  = - \sum_{i=1}^N p(\x_i) \log  p(\x_i).
+	\label{eqn:entropy-discrete}
+\end{equation}
+Aceasta este cunoscută ca {\em entropia} distribuției (discrete) $p(\cdot)$. Observați că această entropie este întotdeauna nenegativă și este zero dacă și numai dacă $p(\x_i) = 1$ pentru un anumit $\x_i$ cu $i \in [N]$.\footnote{Aici observăm că folosim faptul $\lim_{p\rightarrow 0} p \log p = 0$.}
+
+
+\subsection{Entropie Diferențială}
+
+Când variabila aleatoare $\x \in \R^{D}$ este continuă și are o densitate de probabilitate $p$, se poate considera că limita sumei de mai sus \eqref{eqn:entropy-discrete} este legată de o integrală:
+\begin{equation}
+	h(\vx) \doteq \Ex[\log 1/p(\vx)] = - \int_{\R^{D}} p(\vxi) \log p(\vxi) \odif{\vxi}.
+	\label{eqn:entropy-differential}
+\end{equation}
+{Mai precis, dată o variabilă continuă $\x$, o putem cuantiza cu o dimensiune de cuantizare $\epsilon > 0$. Notând variabila discretă rezultată ca $\x^\epsilon$. Atunci se poate arăta că $H(\vx^\epsilon) + \log(\epsilon) \approx h(\vx)$. Prin urmare, când $\epsilon$ este mic, entropia diferențială $h(\x)$ poate fi negativă. Cititorii interesați pot consulta \cite{Cover-Thomas} pentru o explicație mai detaliată.}
+
+\begin{example}[Entropia Distribuțiilor Gaussiene]
+	Prin calcul direct, este posibil să arătăm că entropia unei distribuții Gaussiene $x \sim \mathcal{N}(\mu, \sigma^2)$ este dată de:
+	\begin{equation}
+		h(x) = \frac{1}{2}\log (2\pi \sigma^2) + \frac{1}{2}.
+		\label{eqn:entropy-Gaussian}
+	\end{equation}
+	Se știe, de asemenea, că distribuția Gaussiană atinge entropia maximă
+	pentru toate distribuțiile cu aceeași varianță $\sigma^2$. Entropia unei distribuții Gaussiene multivariate $\x \sim \mathcal{N}(\boldsymbol{\mu}, \boldsymbol{\Sigma})$ în $\mathbb{R}^D$ este dată de:
+	\begin{equation}
+		h(\x) = \frac{D}{2}(1 + \log(2\pi)) + \frac{1}{2}\log\det(\boldsymbol{\Sigma}).
+		\label{eqn:entropy-Gaussian-multi}
+	\end{equation}
+\end{example}
+
+Similar cu entropia pentru o distribuție discretă, am dori ca entropia
+diferențială să fie asociată cu rata de codificare a unei scheme de codificare realizabile. De exemplu, ca mai sus, putem discretiza domeniul distribuției cu o grilă de dimensiune $\epsilon >0$. Rata de codificare a distribuției discrete rezultate poate fi văzută ca o aproximare a entropiei diferențiale \cite{Cover-Thomas}.
+
+Fiți conștienți că există unele avertismente asociate cu definiția entropiei
+diferențiale. Pentru o distribuție într-un spațiu cu dimensiuni mari, când suportul său devine degenerat (cu dimensiuni reduse), entropia sa diferențială diverge la \(-\infty\). Acest fapt este demonstrat în
+\Cref{thm:max_entropy} (reamintim și caracterizarea entropiei maxime a distribuției Gaussiene menționată mai sus în \Cref{thm:max_entropy}) dar chiar și în cazul explicit simplu al distribuțiilor Gaussiene \eqref{eqn:entropy-Gaussian-multi}, când covarianța \(\vSigma\) este singulară, putem vedea că \(\log\det(\vSigma) = -\infty\) deci avem $h(\x) = -\infty$. Într-o astfel de situație, nu este evident cum să cuantizăm sau să codificăm în mod adecvat o astfel de distribuție. Cu toate acestea, distribuțiile degenerate (Gaussiene) sunt tocmai cele mai simple posibile, și fără îndoială cele mai importante, instanțe ale distribuțiilor cu dimensiuni reduse într-un spațiu cu dimensiuni mari. În acest capitol, vom discuta o rezolvare completă a acestei dificultăți aparente cu degenerarea.
+
+\subsection{Minimizarea Ratei de Codificare}\label{sub:min_entropy}
+Amintiți-vă că problema învățării implică recuperarea unei distribuții (potențial continue) $p(\x)$ dintr-un set de eșantioane $\{\x_1, \ldots, \x_N\}$ extrase din distribuție. Pentru ușurința expunerii, scriem $\X = [\x_1, \ldots, \x_N] \in \mathbb{R}^{D\times N}$. Având în vedere că distribuțiile de interes aici sunt (aproape) cu dimensiuni reduse, ar trebui să ne așteptăm ca entropia lor (diferențială) să fie foarte mică. Dar, spre deosebire de situațiile pe care le-am studiat în capitolul anterior, în general nu cunoaștem familia de modele (analitice) cu dimensiuni reduse căreia îi aparține distribuția $p(\x)$. Deci verificarea dacă entropia este mică pare să fie singura orientare pe care ne putem baza pentru a identifica și modela distribuția.
+
+Acum, având doar eșantioanele fără a ști ce este $p(\x)$, în teorie ele ar putea fi interpretate ca eșantioane din orice distribuție generică. În special, ele ar putea fi interpretate ca oricare dintre următoarele cazuri:
+\begin{enumerate}
+	\item ca eșantioane din distribuția empirică $p^{\vX}$ însăși, care atribuie probabilitate $1/N$ fiecăruia dintre cele $N$ eșantioane $\x_i, i=1, \ldots, N$.
+	\item ca eșantioane dintr-o distribuție normală standard $\x^n \sim p^{n} \doteq \mathcal{N}(\boldsymbol{0}, \sigma^2 \boldsymbol{I})$ cu o varianță $\sigma^2$ suficient de mare (să zicem mai mare decât normele eșantionului);
+	\item ca eșantioane dintr-o distribuție normală $\x^e \sim p^{e} \doteq \mathcal{N}(\boldsymbol{0}, \hat{\vSigma})$ cu o covarianță $\hat{\vSigma} = \frac{1}{N} \X \X^T$ fiind covarianța empirică a eșantioanelor;
+	\item ca eșantioane dintr-o distribuție $\hat \x \sim \hat{q}(\vx)$ care aproximează îndeaproape distribuția adevărată $p$.
+\end{enumerate}
+Acum întrebarea este: care este mai bună și în ce sens? Să presupunem că credeți că aceste date $\X$ sunt extrase dintr-o distribuție particulară $q(\x)$, care poate fi una dintre distribuțiile considerate mai sus. Atunci am putea codifica punctele de date cu cartea de coduri optimă pentru distribuția $q(\x)$. Lungimea medie de codificare necesară (sau rata de codificare) este dată de:
+\begin{equation}
+	\frac{1}{N}\sum_{i=1}^N -\log q(\x_i) \quad \approx \quad - \int_{\R^{D}} p(\vxi) \log q(\vxi)\odif{\vxi}
+\end{equation}
+pe măsură ce numărul de eșantioane $N$ devine mare. Dacă am identificat distribuția corectă $p(\x)$, rata de codificare este dată de entropia $- \int p(\vxi) \log p(\vxi) \odif{\vxi}$. Se dovedește că lungimea de codificare de mai sus $- \int p(\vxi) \log q(\vxi) \odif{\vxi}$ este întotdeauna mai mare sau egală cu entropia, cu excepția cazului în care $q(\x) = p(\x)$. Diferența lor, notată ca
+\begin{eqnarray}
+	\KL(p \mmid q) &\doteq& - \int_{\R^{D}} p(\vxi) \log q(\vxi) \odif{\vxi}  - \Big(- \int_{\R^{D}} p(\vxi) \log p(\vxi) \odif{\vxi} \Big)\\
+	&=& \int_{\R^{D}} p(\vxi) \log \frac{p(\vxi)}{q(\vxi)} \odif{\vxi}
+\end{eqnarray}
+este cunoscută ca divergența {\em Kullback-Leibler} (KL), sau entropie relativă. Această cantitate este întotdeauna nenegativă.
+\begin{theorem}[Inegalitatea Informației]\label{thm:information-inequality}
+	Fie $p(\x), q(\x)$ două funcții de densitate de probabilitate (care au același
+	suport). Atunci $\KL(p\mmid q) \ge 0$, unde inegalitatea devine egalitate dacă și numai dacă $p = q$.\footnote{Tehnic, această egalitate ar trebui să fie interpretată ca „aproape peste tot", i.e., cu excepția posibilă a unui set de măsură zero (volum), deoarece acest set nu ar afecta valoarea oricărei integrale.}
+\end{theorem}
+\begin{proof}
+	\begin{eqnarray*}
+		- \KL(p\mmid q)
+		&=& - \int_{\R^{D}} p(\vxi) \log \frac{p(\vxi)}{q(\vxi)} \odif{\vxi}
+		=  \int_{\R^{D}} p(\vxi) \log \frac{q(\vxi)}{p(\vxi)} \odif{\vxi} \\
+		&\le& \log \int_{\R^{D}} p(\vxi)  \frac{q(\vxi)}{p(\vxi)} \odif{\vxi} \label{eqn:jensen-KL}
+		= \log \int_{\R^{D}} q(\vxi) \odif{\vxi} = \log 1 = 0,
+	\end{eqnarray*}
+	unde prima inegalitate urmează din {\em inegalitatea lui Jensen} și
+	faptul că funcția $\log(\cdot)$ este strict concavă. Egalitatea este valabilă
+	dacă și numai dacă $p = q$ .
+\end{proof}
+
+Prin urmare, dat un set de date eșantionate $\X$, pentru a determina care caz este mai bun dintre $p^{n}$, $p^{e}$ și $\hat{q}$, putem compara ratele lor de codificare pentru $\X$ și putem vedea care oferă cea mai mică rată. Știm din cele de mai sus că rata de codificare (teoretic realizabilă) pentru o distribuție este strâns legată de entropia sa. În general, avem:
+\begin{equation}
+	h(\x^n) > h(\x^e) > h(\hat \x).
+\end{equation}
+Prin urmare, dacă datele $\X$ ar fi codificate de cartea de coduri asociată cu fiecare dintre aceste distribuții, rata de codificare pentru $\X$ ar scădea în general în aceeași ordine:
+\begin{equation}
+	p(\x^n) \rightarrow p(\x^e) \rightarrow p(\hat \x).
+\end{equation}
+
+Această observație ne oferă o orientare generală despre cum am putea fi capabili să urmărim o distribuție $p(\x)$ care are o structură cu dimensiuni reduse. Ea sugerează două abordări posibile:
+\begin{enumerate}
+	\item Pornind de la o distribuție generală (să zicem o distribuție normală) cu entropie mare, transformând treptat distribuția către distribuția (empirică) a datelor prin reducerea entropiei.
+	\item Dintre o familie mare de distribuții (parametrice sau neparametrice) cu scheme de codificare explicite care codifică datele date, căutând progresiv scheme de codificare mai bune care dau rate de codificare mai mici.
+\end{enumerate}
+Conceptual, ambele abordări încearcă în esență să facă același lucru. Pentru prima abordare, trebuie să ne asigurăm că o astfel de cale de transformare există și este calculabilă. Pentru a doua abordare, este necesar ca familia aleasă să fie suficient de bogată și să poată aproxima îndeaproape (sau să conțină) distribuția adevărată. Pentru oricare dintre abordări, trebuie să ne asigurăm că soluțiile cu entropie mai mică sau rate de codificare mai bune pot fi calculate eficient și converg rapid către distribuția dorită.\footnote{Să zicem distribuția datelor din lumea reală, cum ar fi imagini și texte.} Vom explora ambele abordări în cele două secțiuni rămase ale acestui capitol.  %
+
+\section{Compresie prin Îndepărtarea Zgomotului}\label{sub:compression_denoising}
+
+În această secțiune, vom descrie o modalitate \textit{naturală} și \textit{tractabilă computațional} de a învăța o distribuție \(p(\vx)\) prin învățarea unei codificări parametrice a distribuției noastre astfel încât reprezentarea să aibă entropia sau rata de codificare minimă, apoi folosind această codificare pentru a transforma eșantioane cu entropie mare dintr-o distribuție Gaussiană standard în eșantioane cu entropie mică din distribuția țintă, așa cum este ilustrat în \Cref{fig:diffusion-chapter3}. Aceasta prezintă o metodologie care utilizează ambele abordări de mai sus pentru a învăța și eșantiona din distribuție.
+
+\begin{figure}[t]
+	\centering
+	\includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter3/figs/diffusion_pipeline.png}
+	\caption{Ilustrarea unui proces iterativ de îndepărtare a zgomotului care, pornind de la o distribuție Gaussiană izotropă, converge către o distribuție arbitrară de date.}
+	\label{fig:diffusion-chapter3}
+\end{figure}
+
+\subsection{Procese de Difuzie și Îndepărtarea Zgomotului} \label{sub:intro_diffusion_denoising}
+
+Mai întâi vrem să găsim o procedură pentru a scădea entropia unui eșantion foarte zgomotos dat într-un eșantion cu entropie mai mică din distribuția datelor. Aici, descriem o abordare potențială—una dintre multe, dar poate cel mai natural mod de a ataca această problemă. Mai întâi, găsim o modalitate de a \textit{crește treptat} entropia eșantioanelor existente din distribuția datelor. Apoi, găsim un \textit{invers aproximativ} al acestui proces. Dar în general, operația de creștere a entropiei nu are invers, deoarece informațiile din distribuția originală pot fi distruse. Vom aborda astfel un caz special în care (1) operația de adăugare a entropiei ia o formă simplă, calculabilă și reversibilă; (2) putem obține o codificare (parametrică) a distribuției datelor, așa cum am aluzionat în perechea de abordări de mai sus. După cum vom vedea, cei doi factori de mai sus vor asigura că abordarea noastră este posibilă.
+
+Vom crește entropia în modul probabil cel mai simplu posibil, i.e., \textit{adăugând zgomot Gaussian izotrop}. Mai precis, dată variabila aleatoare \(\vx\), putem considera \textit{procesul stocastic} \((\vx_{t})_{t \in [0, T]}\) care adaugă zgomot treptat la aceasta, i.e.,
+\begin{equation}\label{eq:additive_gaussian_noise_model}
+	\vx_{t} \doteq \vx + t\vg, \qquad \forall t \in [0, T],
+\end{equation}
+unde \(T \in [0, \infty)\) este un orizont de timp și \(\vg \sim \dNorm(\vzero, \vI)\) este extras independent de \(\vx\). Acest proces este un exemplu de \textit{proces de difuzie}, numit astfel deoarece împrăștie masa de probabilitate pe tot \(\R^{D}\) pe măsură ce timpul trece, crescând entropia în timp. Această intuiție este confirmată grafic de \Cref{fig:ve_forward_density} și riguros prin următoarea teoremă.
+\begin{theorem}[Versiune Simplificată a \Cref{thm:diffusion_entropy_increases}]
+	Să presupunem că \((\vx_{t})_{t \in [0, T]}\) urmează modelul \eqref{eq:additive_gaussian_noise_model}. Pentru orice \(t \in (0, T]\), variabila aleatoare \(\vx_{t}\) are entropie diferențială \(h(\vx_{t}) > -\infty\). Mai mult, în anumite condiții tehnice pe \(\vx\), 
+	\begin{equation}
+		\odv*{h(\vx_{t})}{t} > 0, \qquad \forall t \in (0, T],
+	\end{equation}
+	arătând că entropia lui \(\vx\) cu zgomot crește în timp \(t\).
+\end{theorem}
+Demonstrația este elementară, dar este destul de lungă, așa că o amânăm pentru \Cref{sub:diffusion_entropy_increases}. Principala implicație încă nenunțată a acestui rezultat este că \(h(\vx_{t}) > h(\vx)\) pentru fiecare \(t > 0\). Pentru a vedea aceasta, observați că dacă \(h(\vx) = -\infty\) atunci \(h(\vx_{t}) > -\infty\) pentru toți \(t > 0\), și dacă \(h(\vx) > -\infty\) atunci \(h(\vx_{t}) = h(\vx) + \int_{0}^{t}[\odv*{h(\vx_{s})}{s}]\odif{s} > h(\vx)\) prin teorema fundamentală a calculului, deci în ambele cazuri \(h(\vx_{t}) > h(\vx)\) pentru fiecare \(t > 0\).
+
+\begin{figure}
+	\includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter3/figs/ve_forward_diffusion_density.png}
+	\caption{\small\textbf{Difuzarea unui amestec de Gaussiene.} De la stânga la dreapta, observăm evoluția densității pe măsură ce \(t\) crește de la \(0\) la \(10\), împreună cu câteva eșantioane reprezentative. Fiecare regiune este colorată în funcție de densitatea sa (\(0.0\) este complet alb, \(> 0.01\) este albastru foarte închis, orice altă valoare se mapează la o nuanță de albastru între acestea.) Observăm că masa de probabilitate devine mai puțin concentrată pe măsură ce \(t\) crește, semnalând că entropia crește.}
+	\label{fig:ve_forward_density}
+\end{figure}
+
+Operația inversă adăugării de zgomot este cunoscută ca \textit{îndepărtarea zgomotului}. Este un subiect clasic și bine studiat în procesarea semnalului și teoria sistemelor, cum ar fi filtrul Wiener și filtrul Kalman. Câteva probleme discutate în \Cref{ch:classic}, cum ar fi PCA, ICA și Învățarea Dicționarului, sunt instanțe specifice ale problemei de îndepărtare a zgomotului. Pentru un \(t\) fix și modelul de zgomot Gaussian aditiv \eqref{eq:additive_gaussian_noise_model}, problema de îndepărtare a zgomotului poate fi formulată ca încercarea de a învăța o funcție \(\bar{\vx}^{\ast}(t, \cdot)\) care formează cea mai bună aproximare posibilă (în așteptare) a variabilei aleatoare adevărate \(\vx\), date fiind atât \(t\) cât și \(\vx_{t}\):
+\begin{equation}\label{eq:denoising_loss}
+	\bar{\vx}^{\ast}(t, \cdot) \in \argmin_{\bar{\vx}(t, \cdot)}\Ex_{\vx, \vx_{t}}\norm{\vx - \bar{\vx}(t, \vx_{t})}_{2}^{2}.
+\end{equation}
+Soluția acestei probleme, când optimizăm \(\bar{\vx}(t, \cdot)\) peste toate funcțiile posibile (integrabile pătratic), este așa-numitul \textit{denoiser optim Bayes}: 
+\begin{equation}\label{eq:optimal_denoiser}
+	\bar{\vx}^{\ast}(t, \vxi) \doteq \Ex[\vx \mid \vx_{t} = \vxi].
+\end{equation}
+
+Această expresie justifică notația \(\bar{\vx}\), care este menită să calculeze o așteptare condiționată (i.e., medie condiționată sau medie condiționată). Pe scurt, încearcă să elimine zgomotul din intrarea zgomotoasă, producând cea mai bună estimare posibilă (în așteptare și în raport cu distanța \(\ell^{2}\)) a variabilei aleatoare originale (fără zgomot).
+
+\begin{example}[Îndepărtarea Zgomotului Gaussian dintr-un Amestec de Gaussiene]\label{example:denoising_gaussian_mixture}
+	În acest exemplu calculăm denoiser-ul optim Bayes pentru o clasă incredibil de importantă de distribuții, modelul de amestec Gaussian. Pentru a începe, să fixăm parametrii pentru distribuție: ponderile amestecului \(\vpi \in \R^{K}\), mediile componentelor \(\{\vmu_{k}\}_{k = 1}^{K} \subseteq \R^{D}\), și covarianțele componentelor \(\{\vSigma_{k}\}_{k = 1}^{K} \subseteq \PSD(D)\), unde \(\PSD(D)\) este mulțimea matricelor simetrice pozitiv semidefinite de \(D \times D\). Acum, să presupunem că \(\vx\) este generat prin următoarea procedură în doi pași:
+	\begin{itemize}
+		\item Mai întâi, un index (sau \textit{etichetă}) \(y \in [K]\) este eșantionat astfel încât \(y = k\) cu probabilitate \(\pi_{k}\).
+		\item În al doilea rând, \(\vx\) este eșantionat din distribuția normală \(\dNorm(\vmu_{y}, \vSigma_{y})\).
+	\end{itemize}
+	Atunci \(\vx\) are distribuția
+	\begin{equation}
+		\vx \sim \sum_{k = 1}^{K}\pi_{k}\dNorm(\vmu_{k}, \vSigma_{k}),
+	\end{equation}
+	și astfel
+	\begin{equation}
+		\vx_{t} = \vx + t\vg \sim \sum_{k = 1}^{K}\pi_{k}\dNorm(\vmu_{k}, \vSigma_{k} + t^{2}\vI).
+	\end{equation}
+	Să definim \(\phi(\vx ; \vmu, \vSigma)\) ca densitatea de probabilitate a \(\dNorm(\vmu, \vSigma)\) evaluată la \(\vx\). În această notație, densitatea lui \(\vx_{t}\) este
+	\begin{equation}
+		p_{t}(\vx_{t}) = \sum_{k = 1}^{K}\pi_{k}\phi(\vx_{t} ; \vmu_{k}, \vSigma_{k} + t^{2}\vI).
+	\end{equation}
+
+	Condiționat pe \(y\), variabilele sunt în comun Gaussiene: dacă spunem că \(\vx = \vmu_{y} + \vSigma_{y}^{1/2}\vu\) unde \((\cdot)^{1/2}\) este rădăcina pătrată a matricei și \(\vu \sim \dNorm(\vzero, \vI)\) independent de \(y\) (și \(\vg\)), atunci avem
+	\begin{equation}
+		\mat{\vx \\ \vx_{t}} = \mat{\vmu_{y} \\ \vmu_{y}} + \mat{\vSigma_{y}^{1/2} & \vzero \\ \vSigma_{y}^{1/2} & t\vI}\mat{\vu \\ \vg}.
+	\end{equation}
+	Aceasta arată că \(\vx\) și \(\vx_{t}\) sunt în comun Gaussiene (condiționate pe \(y\)) așa cum am afirmat. Astfel putem scrie
+	\begin{equation}
+		\mat{\vx \\ \vx_{t}} \sim \dNorm\rp{\mat{\vmu_{y} \\ \vmu_{y}}, \mat{\vSigma_{y} & \vSigma_{y} \\ \vSigma_{y} & \vSigma_{y} + t^{2}\vI}}.
+	\end{equation}
+	Astfel așteptarea condiționată a lui \(\vx\) dată \(\vx_{t}\) (i.e., denoiser-ul
+	optim Bayes condiționat pe \(y\)) este faimos
+	(\Cref{exercise:conditional_gaussian})
+	\begin{equation}
+		\Ex[\vx \mid \vx_{t}, y] = \vmu_{y} + \vSigma_{y}(\vSigma_{y} + t^{2}\vI)^{-1}(\vx_{t} - \vmu_{y}).
+	\end{equation}
+	Pentru a găsi denoiser-ul optim Bayes general, folosim legea așteptării iterate, obținând
+	\begin{align}
+		\bar{\vx}^{\ast}(t, \vx_{t})
+		&= \Ex[\vx \mid \vx_{t}] \\ 
+		&= \Ex[\Ex[\vx \mid \vx_{t}, y] \mid \vx_{t}] \\ 
+		&= \sum_{k = 1}^{K}\Pr[y = k \mid \vx_{t}]\Ex[\vx \mid \vx_{t}, y = k].
+	\end{align}
+	Probabilitatea poate fi tratată după cum urmează. Fie \(p_{t \mid y}\) densitatea de probabilitate a lui \(\vx_{t}\) condiționată pe valoarea lui \(y\). Atunci
+	\begin{align}
+		\Pr[y = k \mid \vx_{t}]
+		&= \frac{p_{t \mid y}(\vx_{t} \mid k)\pi_{k}}{p_{t}(\vx_{t})} \\ 
+		&= \frac{\pi_{k}\phi(\vx_{t} ; \vmu_{k}, \vSigma_{k}
+		+ t^{2}\vI)}{\sum_{i = 1}^{K}\pi_{i}\phi(\vx_{t} ; \vmu_{i}, \vSigma_{i} + t^{2}\vI)}.
+	\end{align}
+	Pe de altă parte, așteptarea condiționată este așa cum am descris înainte:
+	\begin{equation}
+		\Ex[\vx \mid \vx_{t}, y = k] = \vmu_{k} + \vSigma_{k}(\vSigma_{k} + t^{2}\vI)^{-1}(\vx_{t} - \vmu_{k}).
+	\end{equation}
+	Deci punând toate acestea împreună, adevăratul denoiser optim Bayes este
+	\begin{equation}\label{eq:gmm_bayes_optimal_denoiser}
+		\bar{\vx}^{\ast}(t, \vx_{t}) = \sum_{k = 1}^{K}\frac{\pi_{k}\phi(\vx_{t}
+		;\vmu_{k}, \vSigma_{k} + t^{2}\vI)}{\sum_{i = 1}^{K}\pi_{i}\phi(\vx_{t}
+		;\vmu_{i}, \vSigma_{i} + t^{2}\vI)}\cdot\bp{\vmu_{k} + \vSigma_{k}(\vSigma_{k} + t^{2}\vI)^{-1}(\vx_{t} - \vmu_{k})}.
+	\end{equation}
+	Acest exemplu este deosebit de important, și câteva cazuri speciale ne vor oferi o mare intuiție conceptuală mai târziu. Pentru moment, să încercăm să extragem o anumită intuiție geometrică din forma funcțională a denoiser-ului optim \eqref{eq:gmm_bayes_optimal_denoiser}.
+
+	Pentru a încerca să înțelegem \eqref{eq:gmm_bayes_optimal_denoiser} intuitiv, să setăm mai întâi \(K = 1\) (i.e., o Gaussiană) astfel încât \(\vx \sim \dNorm(\vmu, \vSigma)\). Să diagonalizăm apoi \(\vSigma = \vV\vLambda \vV^{\top}\). Atunci denoiser-ul optim Bayes este
+	\begin{equation}
+		\bar{\vx}^{\ast}(t, \vx_{t}) = \vmu + \vSigma(\vSigma + t^{2}\vI)^{-1}(\vx_{t} - \vmu) = \vmu + \vV\mat{\lambda_{1}/(\lambda_{1} + t^{2}) & & \\ & \ddots & \\ & & \lambda_{D}/(\lambda_{D} + t^{2})}\vV^{\top}(\vx_{t} - \vmu),
+	\end{equation}
+	unde \(\lambda_{1}, \dots, \lambda_{D}\) sunt valorile proprii ale lui \(\vSigma\). Putem observa că acest denoiser are trei pași:
+	\begin{itemize}
+		\item Translatează intrarea \(\vx_{t}\) cu \(\vmu\).
+		\item Contractă intrarea (translată) \(\vx_{t} - \vmu\) în fiecare direcție a vectorului propriu cu o cantitate \(\lambda_{i}/(\lambda_{i} + t^{2})\). Dacă intrarea translată este de rang redus și unele valori proprii ale lui \(\vSigma\) sunt zero, aceste direcții sunt imediat contractate la \(0\) de către denoiser, asigurând că ieșirea contracției este similar de rang redus.
+		\item Translatează ieșirea înapoi cu \(\vmu\).
+	\end{itemize}
+	Este ușor de arătat că contractă actualul \(\vx_{t}\) către media \(\vmu\):
+	\begin{equation}\label{eq:contraction}
+		\norm{\bar{\vx}^{\ast}(t, \vx_{t}) - \vmu}_{2} \leq \norm{\vx_{t} - \vmu}_{2}.
+	\end{equation}
+
+	Aceasta este interpretarea geometrică a denoiser-ului unei \textit{singure} Gaussiene. Denoiser-ul general al modelului de amestec Gaussian \eqref{eq:gmm_bayes_optimal_denoiser} folosește \(K\) astfel de denoisere, ponderând ieșirea lor cu probabilitățile posterioare \(\Pr[y = k \mid \vx_{t}]\). Dacă mediile Gaussienelor sunt bine separate, aceste probabilități posterioare sunt foarte aproape de \(0\) sau \(1\) în apropierea fiecărei medii sau cluster. În acest regim, denoiser-ul general \eqref{eq:gmm_bayes_optimal_denoiser} are aceeași interpretare geometrică ca denoiser-ul cu o singură Gaussiană de mai sus.
+
+	La prima vedere, o astfel de mapare de contracție \eqref{eq:contraction} poate părea similară cu iterațiile puterii (vezi \Cref{subsec:power iterations}). Cu toate acestea, cele două sunt fundamental diferite. Iterația puterii implementează o mapare de contracție către un subspațiu---și anume subspațiul întins de prima componentă principală. În contrast, iterațiile din \eqref{eq:contraction} converg către media \(\vmu\) a distribuției subiacente, care este un singur punct.
+\end{example}
+
+\begin{figure}
+	\centering 
+	\includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter3/figs/ve_forward_diffusion_denoising.png}\vspace{-0.15in}
+	\caption{\small \textbf{Denoiser-ul optim Bayes și scorul unui model de amestec Gaussian.} În aceeași setare ca \Cref{fig:ve_forward_density}, demonstrăm efectul denoiser-ului optim Bayes \(\bar{\vx}^{\ast}\) prin trasarea \(\vx_{t}\) (roșu) și \(\bar{\vx}^{\ast}(t, \vx_{t})\) (verde) pentru o anumită alegere \(t\) și \(\vx_{t}\). Prin formula lui Tweedie \Cref{thm:tweedie}, reziduul dintre ele este proporțional cu așa-numitul scor (Hyv\"arinen) \(\nabla_{\vx_{t}}\log p_{t}(\vx_{t})\). Putem vedea că scorul indică către modurile distribuției lui \(\vx_{t}\).}
+	\label{fig:ve_forward_denoising}
+\end{figure}
+
+Intuitiv, și așa cum putem vedea din \Cref{example:denoising_gaussian_mixture}, denoiser-ul optim Bayes \(\bar{\vx}^{\ast}(t, \cdot)\) ar trebui să-și mute intrarea \(\vx_{t}\) către modurile distribuției lui \(\vx\). Se dovedește că, de fapt, putem cuantifica aceasta arătând că denoiser-ul optim Bayes \textit{face un pas de urcare a gradientului} pe densitatea (log-)densității lui \(\vx_{t}\), pe care (reamintim) am notat-o \(p_{t}\). Adică, urmând denoiser-ul înseamnă a te deplasa de la iterația de intrare într-o regiune cu probabilitate mai mare în cadrul acestei distribuții (perturbate). Pentru \(t\) mic, perturbarea este mică, deci intuiția noastră inițială este (aproape) exact corectă. Imaginea este vizualizată în \Cref{fig:ve_forward_denoising} și formulată riguros ca formula lui Tweedie \cite{Robbins1956AnEB}.
+\begin{theorem}[Formula lui Tweedie]\label{thm:tweedie}
+	Să presupunem că \((\vx_{t})_{t \in [0, T]}\) respectă \eqref{eq:additive_gaussian_noise_model}. Fie \(p_{t}\) densitatea lui \(\vx_{t}\) (așa cum a fost declarată anterior). Atunci
+	\begin{equation}\label{eq:tweedie}
+		\Ex[\vx \mid \vx_{t}] = \vx_{t} + t^{2}\nabla_{\vx_{t}} \log p_{t}(\vx_{t}).
+	\end{equation}
+\end{theorem}
+\begin{proof}
+	Pentru demonstrație să presupunem că \(\vx\) are o densitate (deși teorema
+	este adevărată fără această presupunere), și să numim această densitate \(p\). Fie
+	\(p_{0 \mid t}\) și \(p_{t \mid 0}\) densitățile condiționate ale lui \(\vx
+	= \vx_{0}\) date \(\vx_{t}\) și \(\vx_{t}\) date \(\vx\) respectiv.
+	Fie \(\phi(\vx ; \vmu, \vSigma)\) densitatea lui \(\dNorm(\vmu,
+	\vSigma)\) evaluată la \(\vx\), astfel încât \(p_{t \mid 0}(\vx_{t} \mid \vx)
+	= \phi(\vx_{t} ; \vx, t^{2}\vI)\). Atunci un calcul simplu dă
+	\begin{align}
+		\nabla_{\vx_{t}} \log p_{t}(\vx_{t})
+		&= \frac{\nabla_{\vx_{t}}p_{t}(\vx_{t})}{p_{t}(\vx_{t})} \\
+		&= \frac{1}{p_{t}(\vx_{t})}\nabla_{\vx_{t}}\int_{\R^{D}}p(\vx)p_{t \mid 0}(\vx_{t} \mid \vx)\odif{\vx} \\
+		&=
+		\frac{1}{p_{t}(\vx_{t})}\nabla_{\vx_{t}}\int_{\R^{D}}p(\vx)\phi(\vx_{t}
+		;\vx, t^{2}\vI)\odif{\vx} \\
+		&=
+		\frac{1}{p_{t}(\vx_{t})}\int_{\R^{D}}p(\vx)[\nabla_{\vx_{t}}\phi(\vx_{t}
+		;\vx, t^{2}\vI)]\odif{\vx} \\
+		&= \frac{1}{p_{t}(\vx_{t})}\int_{\R^{D}}p(\vx)\phi(\vx_{t} ; \vx, t^{2}\vI)\bs{-\frac{\vx_{t} - \vx}{t^{2}}}\odif{\vx} \\
+		&= \frac{1}{t^{2}p_{t}(\vx_{t})}\int_{\R^{D}}p(\vx)\phi(\vx_{t} ; \vx, t^{2}\vI)[\vx - \vx_{t}]\odif{\vx} \\
+		&= \frac{1}{t^{2}p_{t}(\vx_{t})}\int_{\R^{D}}p(\vx)\phi(\vx_{t} ; \vx,
+		t^{2}\vI)\vx \odif{\vx}
+		- \frac{\vx_{t}}{t^{2}p_{t}(\vx_{t})}\int_{\R^{D}}p(\vx)\phi(\vx_{t} ; \vx, t^{2}\vI)\odif{\vx} \\
+		&= \frac{1}{t^{2}p_{t}(\vx_{t})}\int_{\R^{D}}p(\vx)p_{t \mid 0}(\vx_{t} \mid \vx)\vx \odif{\vx} - \frac{\vx_{t}}{t^{2}p_{t}(\vx_{t})}p_{t}(\vx_{t}) \\
+		&= \frac{1}{t^{2}p_{t}(\vx_{t})}\int_{\R^{D}}p_{t}(\vx_{t})p_{0 \mid t}(\vx \mid \vx_{t})\vx \odif{\vx} - \frac{\vx_{t}}{t^{2}p_{t}(\vx_{t})}p_{t}(\vx_{t}) \\
+		&= \frac{1}{t^{2}}\int_{\R^{D}}p_{0 \mid t}(\vx \mid \vx_{t})\vx \odif{\vx} - \frac{\vx_{t}}{t^{2}} \\
+		&= \frac{1}{t^{2}}\Ex[\vx \mid \vx_{t}] - \frac{\vx_{t}}{t^{2}} \\
+		&= \frac{\Ex[\vx \mid \vx_{t}] - \vx_{t}}{t^{2}}.
+	\end{align}
+	Rearanjarea simplă a egalității de mai sus demonstrează teorema.
+\end{proof}
+Acest rezultat dezvoltă o conexiune între îndepărtarea zgomotului și optimizare: denoiser-ul optim Bayes face un singur pas de urcare a gradientului pe densitatea datelor perturbate \(p_{t}\), iar dimensiunea pasului devine adaptiv mai mică (i.e., făcând pași mai preciși) pe măsură ce perturbarea distribuției datelor devine mai mică. Cantitatea \(\nabla_{\vx_{t}}\log p_{t}(\vx_{t})\) este numită \textit{scorul (Hyv\"arinen)} și apare frecvent în discuții despre îndepărtarea zgomotului etc.; a apărut pentru prima dată într-o lucrare a lui Aapo Hyv\"arinen în contextul ICA \cite{hyvarinen05a}.
+
+Similar cu modul în care un pas de coborâre a gradientului nu este aproape niciodată suficient pentru a minimiza un obiectiv în practică atunci când se inițializează departe de optim, ieșirea denoiser-ului optim Bayes \(\bar{\vx}^{\ast}(t, \cdot)\) nu este aproape niciodată conținută într-o regiune cu probabilitate mare a distribuției datelor când \(t\) este mare, \textit{în special} când datele au structuri cu dimensiuni reduse. Ilustrăm acest punct explicit în următorul exemplu.
+\begin{example}[Îndepărtarea zgomotului dintr-un Amestec cu Două Puncte]\label{example:denoising_twopoints}
+	Fie \(x\) uniformă pe mulțimea cu două puncte \(\{-1, +1\}\) și fie \((\vx_{t})_{t \in [0, T]}\) să urmeze \eqref{eq:additive_gaussian_noise_model}. Aceasta este tocmai un model de amestec Gaussian degenerat cu prioruri egale cu \(\frac{1}{2}\), medii \(\{-1, +1\}\) și covarianțe ambele egale cu \(0\). Pentru un \(t > 0\) fix putem folosi calculul denoiser-ului optim Bayes din \eqref{eq:gmm_bayes_optimal_denoiser} pentru a obține (demonstrație ca exercițiu)
+	\begin{equation}
+		\bar{x}^{\ast}(t, x_{t}) = \frac{\phi(x_{t} ; +1, t^{2}) - \phi(x_{t}
+		; -1, t^{2})}{\phi(x_{t} ; 1, t^{2}) + \phi(x_{t} ; -1, t^{2})} = \tanh\rp{-\frac{x_{t}}{t^{2}}}.
+	\end{equation}
+	Pentru \(t\) aproape de \(0\), această cantitate este aproape de \(\{-1, +1\}\) pentru aproape toate intrările \(\bar{x}^{\ast}(t, x_{t})\). Cu toate acestea, pentru \(t\) mare, această cantitate nu este neapărat nici măcar aproximativ în suportul original al lui \(x\), care, amintim, este \(\{-1, +1\}\). În special, pentru \(x_{t} \approx 0\) avem \(\bar{x}^{\ast}(t, x_{t}) \approx 0\) care se află complet între cele două puncte posibile. Astfel \(\bar{x}^{\ast}\) \textit{nu va produce ``realist'' \(x\)}. Sau mai matematic, distribuția lui \(\bar{x}(t, x_{t})\) este foarte diferită de distribuția lui \(x\).
+\end{example}
+
+Prin urmare, dacă vrem să îndepărtăm zgomotul din eșantionul foarte zgomotos \(\vx_{T}\) (unde—reamintim—\(T\) este timpul maxim), nu putem folosi doar denoiser-ul \textit{o dată}. În schimb, trebuie să folosim denoiser-ul de multe ori, analog cu coborârea gradientului cu \textit{dimensiuni descrescătoare ale pasului}, pentru a converge la un punct staționar \(\hat{\vx}\). Și anume, vom folosi denoiser-ul pentru a merge de la \(\vx_{T}\) la \(\hat{\vx}_{T - \delta}\) care aproximează \(\vx_{T - \delta}\), apoi de la \(\hat{\vx}_{T - \delta}\) la \(\hat{\vx}_{T - 2\delta}\), etc., până de la \(\hat{\vx}_{\delta}\) la \(\hat{\vx} = \hat{\vx}_{0}\). De fiecare dată când facem un pas de îndepărtare a zgomotului, acțiunea denoiser-ului devine mai mult ca un pas de gradient pe (log-)densitatea originală.
+
+Mai formal, discretizăm uniform \([0, T]\) în \(L + 1\) pași de timp \(0 = t_{0} < t_{1} < \cdots < t_{L} = T\), i.e.,
+\begin{equation}
+	t_{\ell} = \frac{\ell}{L}T, \qquad \ell \in \{0, 1, \dots, L\}.
+\end{equation}
+Apoi pentru fiecare \(\ell \in [L] = \{1, 2, \dots, L\}\), mergând de la \(\ell = L\) la \(\ell = 1\), putem rula iterația
+\begin{align}
+	\hat{\vx}_{t_{\ell - 1}}
+	&= \Ex[\vx_{t_{\ell - 1}} \mid \vx_{t_{\ell}} = \hat{\vx}_{t_{\ell}}] \\
+	&= \Ex[\vx + t_{\ell - 1}\vg \mid \vx_{t_{\ell}} = \hat{\vx}_{t_{\ell}}] \\
+	&= \Ex\rs{\vx + t_{\ell - 1}\cdot\frac{\vx_{t_{\ell}} - \vx}{t_{\ell}} \given \vx_{t_{\ell}} = \hat{\vx}_{t_{\ell}}} \\
+	&= \frac{t_{\ell - 1}}{t_{\ell}}\hat{\vx}_{t_{\ell}} + \bp{1 - \frac{t_{\ell - 1}}{t_{\ell}}}\Ex[\vx \mid \vx_{t_{\ell}} = \hat{\vx}_{t_{\ell}}] \\
+	&= \bp{1 - \frac{1}{\ell}}\cdot\hat{\vx}_{t_{\ell}} + \frac{1}{\ell}\cdot\bar{\vx}^{\ast}(t_{\ell}, \hat{\vx}_{t_{\ell}}).
+\end{align}
+Efectul acestei iterații este următorul. La începutul iterației, unde \(\ell\) este mare, abia avem încredere în ieșirea denoiser-ului și păstrăm în mare parte iterația curentă. Aceasta are sens, deoarece denoiser-ul poate avea varianță uriașă (cf \Cref{example:denoising_twopoints}). Când \(\ell\) este mic, denoiser-ul va ``se fixa'' pe modurile distribuției datelor, deoarece un pas de îndepărtare a zgomotului face practic un pas de gradient pe log-densitatea distribuției adevărate, și putem avea încredere că nu va produce eșantioane nerezonabile, astfel încât pasul de îndepărtare a zgomotului implică în mare parte ieșirea denoiser-ului. La \(\ell = 1\) chiar aruncăm iterația curentă și păstrăm doar ieșirea denoiser-ului.
+
+\begin{figure}[t]
+	\centering
+	\includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter3/figs/ve_gmm_denoising.png}
+	\caption{\small\textbf{Îndepărtarea zgomotului dintr-un amestec de Gaussiene de rang redus.} Fiecare figură reprezintă eșantioane din distribuția adevărată a datelor (gri, portocaliu, roșu) și eșantioane care trec prin procesul de îndepărtare a zgomotului \eqref{eq:denoising-iteration-basic} (albastru deschis). În stânga sus, procesul tocmai a început și zgomotul este foarte mare. Pe măsură ce procesul continuă, zgomotul este împins mai departe către suportul distribuției datelor de rang redus. În final, în dreapta jos, eșantioanele generate sunt perfect aliniate cu suportul datelor și arată foarte mult ca eșantioane extrase din modelul de amestec Gaussian de rang redus.}
+	\label{fig:ve_gmm_denoising}
+\end{figure}
+
+Cele de mai sus sunt intuiția pentru care ne așteptăm ca procesul de îndepărtare a zgomotului să convergă. Vizualizăm procesul de convergență în \(\R^{3}\) în \Cref{fig:ve_gmm_denoising}. Vom dezvolta mai târziu câteva rezultate riguroase despre convergență. Pentru moment, amintiți-vă că am vrut să construim un proces pentru a reduce entropia. Deși am făcut acest lucru într-un mod indirect inversând un proces care adaugă entropie, acum este timpul să confirmăm că procesul nostru iterativ de îndepărtare a zgomotului reduce entropia.
+
+\begin{theorem}[Versiune Simplificată a \Cref{thm:conditioning_reduces_entropy}]
+	Să presupunem că \((\vx_{t})_{t \in [0, T]}\) respectă \eqref{eq:additive_gaussian_noise_model}. Atunci, în anumite condiții tehnice pe \(\vx\), pentru fiecare \(s < t\) cu \(s, t \in (0, T]\),
+	\begin{equation}
+		h(\Ex[\vx_{s} \mid \vx_{t}]) < h(\vx_{t}).
+	\end{equation}
+\end{theorem}
+Enunțul complet al teoremei și demonstrația în sine necesită unele tehnicități, așa că este amânată pentru \Cref{sub:denoising_entropy_decreases}.
+
+Ultimul lucru pe care îl discutăm aici este că de multe ori \textit{nu vom putea calcula} \(\bar{\vx}^{\ast}(t, \cdot)\) pentru niciun \(t\), deoarece nu avem distribuția \(p_{t}\). Dar putem încerca să \textit{învățăm una din date}. Amintiți-vă că denoiser-ul \(\bar{\vx}^{\ast}\) este definit în \eqref{eq:denoising_loss} ca minimizând eroarea pătratică medie \(\Ex\norm{\bar{\vx}(t, \vx_{t}) - \vx}_{2}^{2}\). Putem folosi această eroare pătratică medie ca o pierdere sau funcție obiectiv pentru a învăța denoiser-ul. De exemplu, putem parametriza \(\bar{\vx}(t, \cdot)\) printr-o rețea neurală, scriind-o ca \(\bar{\vx}_{\theta}(t, \cdot)\), și optimizăm pierderea peste spațiul parametrilor \(\Theta\):
+\begin{equation}
+	\min_{\theta \in \Theta}\Ex_{\vx, \vx_{t}}\norm{\bar{\vx}_{\theta}(t, \vx_{t}) - \vx}_{2}^{2}.
+\end{equation}
+Soluția acestei probleme de optimizare, implementată prin coborârea gradientului sau un algoritm similar, ne va da un \(\bar{\vx}_{\theta^{\ast}}(t, \cdot)\) care este o bună aproximare a lui \(\bar{\vx}^{\ast}(t, \cdot)\) (cel puțin dacă antrenamentul funcționează) și pe care îl vom folosi ca denoiser.
+
+Ce este o arhitectură bună pentru această rețea neurală \(\bar{\vx}_{\theta^{\ast}}(t, \cdot)\)? Pentru a răspunde la această întrebare, vom examina cazul omniprezent al unui \textit{model de amestec Gaussian}, al cărui denoiser l-am calculat în \Cref{example:denoising_gaussian_mixture}. Acest model este relevant deoarece poate aproxima multe tipuri de distribuții: în particular, dată o distribuție pentru \(\vx\), există un model de amestec Gaussian care o poate aproxima arbitrar de bine. Deci optimizarea în clasa de denoisere pentru modele de amestec Gaussian ne poate da ceva apropiat de denoiser-ul optim pentru distribuția reală a datelor.
+
+În cazul nostru, presupunem că \(\vx\) este cu dimensiuni reduse, ceea ce se traduce vag în cerința că \(\vx\) este \textit{aproximativ} distribuit conform unui \textit{amestec de Gaussiene de rang redus}. Formal, scriem
+\begin{equation}\label{eq:MoG1}
+	\vx \sim \frac{1}{K}\sum_{k = 1}^{K}\dNorm(\vzero, \vU_{k}\vU_{k}^{\top})
+\end{equation}
+unde \(\vU_{k} \in \O(D, P) \subseteq \R^{D \times P}\) este o matrice ortogonală. Atunci denoiser-ul optim sub \eqref{eq:additive_gaussian_noise_model} este (din \Cref{example:denoising_gaussian_mixture})
+\begin{equation}
+	\bar{\vx}^{\ast}(t, \vx_{t}) = \sum_{k = 1}^{K}\frac{\phi(\vx_{t} ; \vzero,
+	\vU_{k}\vU_{k}^{\top} + t^{2}\vI)}{\sum_{i = 1}^{K}\phi(\vx_{t} ; \vzero, \vU_{i}\vU_{i}^{\top} + t^{2}\vI)}\cdot\bp{\vU_{k}\vU_{k}^{\top}(\vU_{k}\vU_{k}^{\top} + t^{2}\vI)^{-1}\vx_{t}}.
+\end{equation}
+
+[Continuarea traducerii calculelor matematice complexe cu identitatea Sherman-Morrison-Woodbury și forma finală a denoiser-ului...]
+
+\begin{equation}\label{eq:gmm_lowrank_denoiser}
+	\bar{\vx}^{\ast}(t, \vx_{t}) = \frac{1}{1 + t^{2}}\sum_{k = 1}^{K}\frac{\exp\rp{\frac{1}{2t^{2}(1 + t^{2})}\norm{\vU_{k}^{\top}\vx_{t}}_{2}^{2}}}{\sum_{i = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1 + t^{2})}\norm{\vU_{i}^{\top}\vx_{t}}_{2}^{2}}}\vU_{k}\vU_{k}^{\top}\vx_{t},
+\end{equation}
+i.e., o proiecție a lui \(\vx_{t}\) pe fiecare din cele \(K\) subspații, ponderată printr-o operație soft-max a unei funcții pătratice de \(\vx_{t}\). Această formă funcțională este similară cu un \textit{mecanism de atenție} într-o arhitectură transformer! După cum vom vedea în \Cref{ch:representation}, aceasta nu este deloc o coincidență; legătura profundă între îndepărtarea zgomotului și compresia cu pierderi (care va fi acoperită în \Cref{sec:lossy_compression}) face ca denoiserii transformer să fie atât de eficienți în practică. Și astfel, în ansamblu, teoria noastră a modelului de amestec Gaussian motivează utilizarea rețelelor neurale de tip transformer pentru îndepărtarea zgomotului.
+
+\subsection{Învățarea și Eșantionarea unei Distribuții prin Îndepărtarea Iterativă a Zgomotului}\label{sub:sampling_denoising}
+
+Amintiți-vă că la sfârșitul \Cref{sub:min_entropy}, am discutat o pereche de deziderate pentru urmărirea unei distribuții cu structură cu dimensiuni reduse. Primul astfel de deziderat este să pornim cu o distribuție normală, să zicem cu entropie mare, și să-i reducem treptat entropia până când ajunge la distribuția datelor. Vom numi această procedură \textit{eșantionare} deoarece generăm noi eșantioane. Acum este timpul să discutăm cum să facem acest lucru cu setul de instrumente pe care l-am construit.
+
+Știm cum să îndepărtăm zgomotul din eșantioane foarte zgomotoase \(\vx_{T}\) pentru a obține aproximări \(\hat{\vx}\) care au distribuții similare cu variabila aleatoare țintă \(\vx\). Dar dezideratul spune că, pentru a eșantiona, vrem să pornim cu o distribuție șablon \textit{fără} influență din distribuția lui \(\vx\) și să folosim denoiser-ul pentru a ghida iterațiile către distribuția lui \(\vx\). Cum putem face acest lucru? O modalitate este motivată după cum urmează:
+\begin{equation}\label{eq:ve_converge_to_large_gaussian}
+	\frac{\vx_{T}}{T} = \frac{\vx + T\vg}{T} = \frac{\vx}{T} + \vg \to \vg \sim \dNorm(\vzero, \vI).
+\end{equation}
+Astfel, \(\vx_{T} \approx \dNorm(\vzero, T^{2}\vI)\). Această aproximare este destul de bună pentru aproape toate distribuțiile practice și este vizualizată în \Cref{fig:xT_vs_noise}.
+
+\begin{figure}[!htbp]
+	\centering 
+	\includegraphics[width=0.75\textwidth]{\toplevelprefix/chapters/chapter3/figs/xT_vs_noise.png}
+	\caption{\small\textbf{Vizualizarea \(\vx_{T}\) versus \(\dNorm(\vzero, T^{2}\vI)\).} \textit{Stânga:} O reprezentare grafică a datelor modelului de amestec Gaussian \(\vx\). \textit{Dreapta:} O reprezentare grafică a lui \(\vx\) precum și \(\vx_{T}\) și un eșantion independent de \(\dNorm(\vzero, T^{2}\vI)\), pentru \(T = 10\). Pe graficul din dreapta, \(\vx\) este reprezentat în aceleași culori ca în stânga: cu toate acestea, eșantioanele din \(\vx_{T}\) și \(\dNorm(\vzero, T^{2}\vI)\) sunt ambele mult mai mari, în medie, decât eșantioanele din \(\vx\), și astfel apare mult mai mic din cauza scalării. În ciuda acestei măriri mari, observăm clar similaritățile în distribuțiile lui \(\vx_{T}\) și \(\dNorm(\vzero, T^{2}\vI)\).}
+	\label{fig:xT_vs_noise}
+\end{figure}
+
+Deci, discretizând \([0, T]\) în \(0 = t_{0} < t_{1} < \cdots < t_{L} = T\) uniform folosind \(t_{\ell} = T\ell / L\) (ca în secțiunea anterioară), o modalitate posibilă de a eșantiona din zgomot pur este:
+\begin{itemize}
+	\item Eșantionează \(\hat{\vx}_{T} \sim \dNorm(\vzero, T^{2}\vI)\) (i.i.d.~de orice altceva) 
+	\item Rulează iterația de îndepărtare a zgomotului ca în \Cref{sub:intro_diffusion_denoising}, adică,
+		\begin{equation}\label{eq:denoising-iteration-basic}
+		\hat{\vx}_{t_{\ell - 1}} = \bp{1 - \frac{1}{\ell}}\cdot\hat{\vx}_{t_{\ell}} + \frac{1}{\ell}\cdot\bar{\vx}^{\ast}(t_{\ell}, \hat{\vx}_{t_{\ell}}).
+	\end{equation}
+	\item Returnează \(\hat{\vx} = \hat{\vx}_{0}\).
+\end{itemize}
+Aceasta este conceptual tot ce stă în spatele \textit{modelelor de difuzie}, care transformă zgomotul în eșantioane de date în conformitate cu primul deziderat. Cu toate acestea, mai sunt câțiva pași de făcut înainte de a obține modele care pot efectiv eșantiona din distribuții de date reale precum imagini, date constrângerile practice de resurse. În continuare, vom introduce și motiva câțiva astfel de pași.
+
+\paragraph{Pasul 1: discretizări diferite.} Primul pas pe care îl facem este motivat de următorul punct: \textit{nu trebuie să cheltuim atât de multe iterații de îndepărtare a zgomotului} la \(t\) mare. Dacă ne uităm la \Cref{fig:ve_gmm_denoising}, observăm că primele \(200\) sau \(300\) de iterații din cele \(500\) de iterații ale procesului de eșantionare sunt cheltuite doar contractând zgomotul către distribuția datelor ca întreg, înainte ca iterațiile rămase să împingă eșantioanele către un subspațiu. Dat un număr fix de iterații \(L\), aceasta semnalează că ar trebui să cheltuim mai mulți pași de timp \(t_{\ell}\) aproape de \(t = 0\) comparativ cu \(t = T\). În timpul eșantionării (și antrenării), putem folosi prin urmare o altă discretizare a \([0, T]\) în \(0 \leq t_{0} < t_{1} < \cdots < t_{L} \leq T\), cum ar fi o \textit{discretizare exponențială}:
+\begin{equation}\label{eq:denoising_exponential_discretization}
+	t_{\ell} = C_{1}(e^{C_{2}\ell} - 1), \qquad \forall \ell \in \{0, 1, \dots, L\}
+\end{equation}
+unde \(C_{1}, C_{2} > 0\) sunt constante care pot fi ajustate pentru performanță optimă în practică; analiza teoretică va specifica adesea astfel de constante optime de asemenea. Atunci iterația de îndepărtare a zgomotului/eșantionare devine 
+\begin{equation}\label{eq:denoising_iteration}
+	\hat{\vx}_{t_{\ell - 1}} \doteq \frac{t_{\ell - 1}}{t_{\ell}}\hat{\vx}_{t_{\ell}} + \bp{1 - \frac{t_{\ell - 1}}{t_{\ell}}}\bar{\vx}^{\ast}(t_{\ell}, \hat{\vx}_{t_{\ell}}),
+\end{equation}
+cu, din nou, \(\hat{\vx}_{t_{L}} \sim \dNorm(\vzero, t_{L}^{2}\vI)\).
+
+\paragraph{Pasul 2: modele de zgomot diferite.} Al doilea pas este să considerăm modele ușor diferite comparativ cu \eqref{eq:additive_gaussian_noise_model}. Motivația de bază pentru aceasta este următoarea. În practică, distribuția zgomotului \(\dNorm(\vzero, t_{L}^{2}\vI)\) devine o estimare din ce în ce mai slabă a covarianței adevărate în dimensiuni înalte, adică, \eqref{eq:ve_converge_to_large_gaussian} devine o aproximare din ce în ce mai proastă, în special cu date anizotrope cu dimensiuni înalte. Distanța crescută dintre \(\dNorm(\vzero, t_{L}^{2}\vI)\) și distribuția adevărată a lui \(\vx_{t_{L}}\) poate face ca denoiser-ul să funcționeze mai prost în astfel de circumstanțe. Teoretic, \(\vx_{t_{L}}\) nu converge niciodată la nicio distribuție pe măsură ce \(t_{L}\) crește, deci această configurare este dificil de analizat de la cap la coadă. În acest caz, remediul nostru este să \textit{adăugăm simultan zgomot și să micșorăm contribuția lui \(\vx\), astfel încât \(\vx_{T}\) să convergă pe măsură ce \(T \to \infty\)}. Rata de zgomot adăugat este notată \(\sigma \colon [0, T] \to \R_{\geq 0}\), iar rata de micșorare este notată \(\alpha \colon [0, T] \to \R_{\geq 0}\), astfel încât \(\sigma\) este \textit{crescătoare} și \(\alpha\) este (nu strict) \textit{descrescătoare}, și 
+\begin{equation}\label{eq:gen_additive_gaussian_noise_model}
+	\vx_{t} \doteq \alpha_{t}\vx + \sigma_{t}\vg, \qquad \forall t \in [0, T].
+\end{equation}
+Configurarea anterioară are \(\alpha_{t} = 1\) și \(\sigma_{t} = t\), și aceasta se numește \textit{procesul cu varianță explozivă (VE)}. O alegere populară care scade contribuția lui \(\vx\), așa cum am descris inițial, are \(T = 1\) (astfel încât \(t \in [0, 1]\)), \(\alpha_{t} = \sqrt{1 - t^{2}}\) și \(\sigma_{t} = t\); acesta este \textit{procesul cu păstrarea varianței (VP)}. Notați că sub procesul VP, \(\vx_{1} \sim \dNorm(\vzero, \vI)\) exact, astfel încât putem eșantiona pur și simplu din această distribuție standard și să îndepărtăm zgomotul iterativ. Ca rezultat, procesul VP este mult mai ușor de analizat teoretic și mai stabil empiric.\footnote{De ce să folosim întreaga configurare \(\alpha, \sigma\)? După cum vom vedea în \Cref{exercise:implement_denoising_processes}, aceasta încapsulează și unifică multe procese propuse, inclusiv procesul recent popular așa-numit \textit{potrivire de flux}. În ciuda acestui fapt, procesele VE și VP sunt încă cele mai populare empiric și teoretic (până acum), și astfel le vom considera în această secțiune.} 
+
+Cu această configurare mai generală, formula lui Tweedie \eqref{eq:tweedie} devine 
+\begin{equation}\label{eq:gen_tweedie}
+	\Ex[\vx \mid \vx_{t}] = \frac{1}{\alpha_{t}}\bp{\vx_{t} + \sigma_{t}^{2}\nabla \log p_{t}(\vx)}.
+\end{equation}
+Iterația de îndepărtare a zgomotului \eqref{eq:denoising_iteration} devine
+\begin{equation}\label{eq:gen_denoising_iteration}
+	\hat{\vx}_{t_{\ell - 1}} = \frac{\sigma_{t_{\ell - 1}}}{\sigma_{t_{\ell}}}\hat{\vx}_{t_{\ell}} + \bp{\alpha_{t_{\ell - 1}} - \frac{\sigma_{t_{\ell - 1}}}{\sigma_{t_{\ell}}}\alpha_{t_{\ell}}}\bar{\vx}^{\ast}(t_{\ell}, \hat{\vx}_{t_{\ell}}).
+\end{equation}
+În final, denoiser-ul modelului de amestec Gaussian \eqref{eq:gmm_bayes_optimal_denoiser} devine 
+\begin{equation}\label{eq:gen_gmm_bayes_optimal_denoiser}
+	\bar{\vx}^{\ast}(t, \vx_{t}) = \sum_{k = 1}^{K}\frac{\pi_{k}\phi(\vx_{t} ; \alpha_{t}\boldsymbol{\mu}_{k}, \alpha_{t}^{2}\boldsymbol{\Sigma}_{k} + \sigma_{t}^{2}\vI)}{\sum_{j = 1}^{K}\pi_{j}\phi(\vx_{t} ; \alpha_{t}\boldsymbol{\mu}_{j}, \alpha_{t}^{2}\boldsymbol{\Sigma}_{j} + \sigma_{t}^{2}\vI)}\bp{\boldsymbol{\mu}_{k} + \boldsymbol{\Sigma}_{k}(\alpha_{t}^{2}\boldsymbol{\Sigma}_{k} + \sigma_{t}^{2}\vI)^{-1}(\vx_{t} - \alpha_{t}\boldsymbol{\mu}_{k})}.
+\end{equation}
+
+\begin{figure}[!htbp]
+	\centering 
+	\includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter3/figs/vp_gmm_denoising.png}
+	\caption{\small\textbf{Îndepărtarea zgomotului dintr-un amestec de Gaussiene folosind procesul de difuzie VP.} Folosim aceeași configurare grafică și distribuție de date ca în \Cref{fig:ve_gmm_denoising}. Notați că, comparativ cu \Cref{fig:ve_gmm_denoising}, distribuția zgomotului este mult mai concentrată în jurul originii.}
+	\label{fig:vp_gmm_denoising}
+\end{figure}
+
+\paragraph{Pasul 3: învățarea unui singur denoiser parametric.} Până acum am presupus că avem denoiser-ul Bayes-optim \(\bar{\vx}^{\ast}(t, \cdot)\) pentru toți \(t\). Dar în practică nu cunoaștem distribuția \(p(\vx)\), deci nu putem calcula \(\bar{\vx}^{\ast}(t, \cdot)\). În schimb, va trebui să \textit{învățăm} denoiser-ul din date. Acest lucru duce la două probleme: (1) cum să învățăm un denoiser și (2) cum să învățăm un denoiser pentru fiecare \(t\). În general, există două abordări. Prima este să antrenăm \(L\) denoisere, unul pentru fiecare pas de timp discret, dar aceasta necesită o cantitate substanțială de memorie și nu generalizează la pași de timp nevăzuți anterior. A doua este să antrenăm un singur denoiser \textit{parametric} (rețea neurală) \(\bar{\vx}_{\theta}(t, \cdot)\) prin optimizare pe spațiul de parametri \(\Theta\) pentru a minimiza eroarea pătratică medie pe toți pașii de timp:
+\begin{equation}
+	\min_{\theta}\Ex_{t, \vx, \vx_{t}}\norm{\bar{\vx}_{\theta}(t, \vx_{t}) - \vx}_{2}^{2}.
+\end{equation}
+Similar cu Pasul 1, unde am folosit mai mulți pași de timp aproape de \(t = 0\) pentru a asigura un proces de eșantionare mai bun, am putea dori să ne asigurăm că denoiser-ul este de calitate mai înaltă aproape de \(t = 0\), și astfel să \textit{ponderăm pierderea} astfel încât \(t\) aproape de \(0\) să aibă o pondere mai mare. Fie \(w_{t}\) ponderea la timpul \(t\), pierderea ponderată ar arăta astfel:
+\begin{equation}\label{eq:parametric_denoising_loss}
+	\min_{\theta}\Ex_{t}w_{t}\Ex_{\vx, \vx_{t}}\norm{\bar{\vx}_{\theta}(t, \vx_{t}) - \vx}_{2}^{2}.
+\end{equation}
+O alegere rezonabilă de pondere în practică este \(w_{t} = \alpha_{t}/\sigma_{t}\). Motivul precis va fi acoperit în paragraful următor, dar în general servește la creșterea ponderilor pierderilor corespunzătoare lui \(t\) aproape de \(0\), rămânând în același timp rezonabil stabil numeric. De asemenea, desigur, nu putem calcula așteptarea în practică, așa că folosim cea mai simplă medie Monte-Carlo pentru a o estima. Seria de schimbări făcute aici au mai multe beneficii conceptuale și computaționale: nu trebuie să antrenăm mai mulți denoisere, putem antrena pe un set de pași de timp și eșantiona folosind un subset (sau altele complet diferite), etc. Pipeline-ul complet este discutat în \Cref{alg:learning_denoiser}.
+
+\begin{algorithm}
+	\begin{algorithmic}[1]
+		\Require{Set de date \(\cD \subseteq \R^{D}\).}
+		\Require{O listă ordonată de pași de timp \(0 \leq t_{0} < \cdots < t_{L} \leq T\) de folosit pentru eșantionare.}
+		\Require{O funcție de ponderare \(w \colon \{t_{\ell}\}_{\ell = 1}^{L} \to \R_{\geq 0}\).}
+		\Require{Funcții de scală și nivel de zgomot \(\alpha, \sigma \colon \{t_{\ell}\}_{\ell = 0}^{L} \to \R_{\geq 0}\).}
+		\Require{Un spațiu de parametri \(\Theta\) și o arhitectură de denoiser \(\bar{\vx}_{\theta}\).}
+		\Require{Un algoritm de optimizare pentru parametri.}
+		\Require{Numărul de iterații de optimizare \(M\).}
+		\Require{Numărul de extrageri Monte-Carlo \(N\) pe iterație (pentru a aproxima așteptarea în \eqref{eq:parametric_denoising_loss}).}
+		\Ensure{Un denoiser antrenat \(\bar{\vx}_{\theta^{\ast}}\).}
+
+		\Function{AntreneazăDenoiser}{$\cD, \Theta$}
+		\State{Inițializează \(\theta^{(1)} \in \Theta\)}
+		\For{\(i \in [M]\)}
+		\For{\(n \in [N]\)}
+		\State{\(\vx_{n}^{(i)} \sim \cD\)} \Comment{Extrage un eșantion din setul de date.}
+		\State{\(t_{n}^{(i)} \simiid \dUnif(\{t_{\ell}\}_{\ell = 1}^{L})\)} \Comment{Eșantionează un pas de timp.}
+		\State{\(\vg_{n}^{(i)} \simiid \dNorm(\vzero, \vI)\)} \Comment{Eșantionează un vector de zgomot.}
+		\State{\(\vx_{t, n}^{(i)} \doteq \alpha_{t_{n}^{(i)}}\vx_{n}^{(i)} + \sigma_{t_{n}^{(i)}}\vg_{n}^{(i)}\)} \Comment{Calculează eșantionul cu zgomot.}
+		\State{\(w_{n}^{(i)} \doteq w_{t_{n}^{(i)}}\)} \Comment{Calculează ponderea pierderii.}
+		\EndFor
+		\State{\(\hat{\cL}^{(i)} \doteq \displaystyle \frac{1}{N}\sum_{n = 1}^{N}w_{n}^{(i)}\norm{\vx_{n}^{(i)} - \bar{\vx}_{\theta^{(i)}}(t_{n}^{(i)}, \vx_{t, n}^{(i)})}_{2}^{2}\)} \Comment{Calculează estimarea pierderii.}
+		\State{\(\theta^{(i + 1)} \doteq \texttt{ActualizareOptimizare}^{(i)}(\theta^{(i)}, \nabla_{\theta^{(i)}}\hat{\cL}^{(i)})\)} \Comment{Actualizează parametrii.}
+		\EndFor
+		\State{\Return{\(\bar{\vx}_{\theta^{(K + 1)}}\)}}
+		\EndFunction
+	\end{algorithmic}
+	\caption{Învățarea unui denoiser din date.}
+	\label{alg:learning_denoiser}
+\end{algorithm}
+
+\begin{algorithm}
+	\caption{Eșantionare folosind un denoiser.}
+	\label{alg:iterative_denoising}
+	\begin{algorithmic}[1]
+		\Require{O listă ordonată de pași de timp \(0 \leq t_{0} < \cdots < t_{L} \leq T\) de utilizat pentru eșantionare.}
+		\Require{Un denoiser \(\bar{\vx} \colon \{t_{\ell}\}_{\ell = 1}^{L} \times \R^{D} \to \R^{D}\).}
+		\Require{Funcții de scală și nivel de zgomot \(\alpha, \sigma \colon \{t_{\ell}\}_{\ell = 0}^{L} \to \R_{\geq 0}\).}
+		\Ensure{Un eșantion \(\hat{\vx}\), aproximativ din distribuția lui \(\vx\).}
+		\Function{DDIMSampler}{$\bar{\vx}, (t_{\ell})_{\ell = 0}^{L}$}
+		\State{Inițializează \(\tilde{\vx}_{t_{L}} \sim\) distribuția aproximativă a lui \(\vx_{t_{L}}\)} \Comment{VP \(\implies \dNorm(\vzero, \vI)\), VE \(\implies \dNorm(\vzero, t_{L}^{2}\vI)\).}
+		\For{\(\ell = L, L - 1, \dots, 1\)}
+		\State{Calculează
+			\begin{equation*}
+				\hat{\vx}_{t_{\ell - 1}} \doteq \frac{\sigma_{t_{\ell - 1}}}{\sigma_{t_{\ell}}}\hat{\vx}_{t_{\ell}} + \bp{\alpha_{t_{\ell - 1}} - \frac{\sigma_{t_{\ell - 1}}}{\sigma_{t_{\ell}}}\alpha_{t_{\ell}}}\bar{\vx}(t_{\ell}, \hat{\vx}_{t_{\ell}})
+			\end{equation*}
+		}
+		\EndFor
+		\State{\Return{\(\hat{\vx}_{t_{0}}\)}}
+		\EndFunction
+	\end{algorithmic}
+\end{algorithm}
+
+\paragraph{(Opțional) Pasul 4: schimbarea țintei de estimare.} Notați că este comun să reorientăm întreaga conductă de îndepărtare a zgomotului în jurul \textit{predictorilor de zgomot}, adică, estimări ale \(\Ex[\vg \mid \vx_{t}]\). În practică, predictorii de zgomot sunt ușor mai ușor de antrenat deoarece ieșirea lor este (aproape) întotdeauna de dimensiune comparabilă cu o variabilă aleatoare Gaussiană, astfel încât antrenarea este mai stabilă numeric. Notați că prin \eqref{eq:gen_additive_gaussian_noise_model} avem 
+\begin{equation}
+	\vx_{t} = \alpha_{t}\Ex[\vx \mid \vx_{t}] + \sigma_{t}\Ex[\vg \mid \vx_{t}] \implies \Ex[\vg \mid \vx_{t}] = \frac{1}{\sigma_{t}}\bp{\vx_{t} - \alpha_{t}\Ex[\vx \mid \vx_{t}]},
+\end{equation}
+Prin urmare, orice predictor pentru \(\vx\) poate fi transformat într-un predictor pentru \(\vg\) folosind relația de mai sus, adică,
+\begin{equation}
+	\bar{\vg}(t, \vx_{t}) = \frac{1}{\sigma_{t}}\vx_{t} - \frac{\alpha_{t}}{\sigma_{t}}\bar{\vx}(t, \vx_{t}),
+\end{equation}
+și vice-versa. Astfel, o rețea bună pentru estimarea \(\bar{\vg}\) este aceeași cu o rețea bună pentru estimarea \(\bar{\vx}\) \textit{plus o conexiune reziduală} (așa cum se vede în, de exemplu, transformatoare). Pierderile lor sunt de asemenea aceleași ca denoiser-ul, până la factorul de \(\alpha_{t}/\sigma_{t}\).
+
+\paragraph{Convergența procesului de eșantionare.} Acum că am dezvoltat procesul de eșantionare prin difuzie, este natural să ne întrebăm cât de bine funcționează. Pentru a măsura acuratețea eșantionării, folosim \textit{distanța de variație totală} (TV) între distribuția adevărată \(\vx\) și distribuția eșantionată \(\hat{\vx}\):
+\begin{equation}
+	\TV(\vx, \vy) \doteq \sup_{A \subseteq \R^{d}}\abs*{\Pr[\vx \in A] - \Pr[\vy \in A]}.
+\end{equation}
+Dacă \(\vx\) și \(\vy\) sunt foarte aproape (uniform), atunci supremumul va fi mic. Deci distanța TV măsoară apropierea variabilelor aleatoare. (Este într-adevăr o metrică, după cum sugerează numele; demonstrația este un exercițiu.)
+
+\begin{theorem}[\citep{li2024d} Teorema 1, Simplificată]\label{thm:diffusion_sampler_convergence}
+	Să presupunem că \(\Ex\norm{\vx}_{2} < \infty\). Dacă \(\vx\) este denoised conform procesului VP cu o discretizare exponențială\footnote{Definiția precisă este destul de lungă în notația noastră și definită doar până la diverse constante absolute, așa că o omitem aici pentru concizie. Desigur, este în lucrarea originală \citep{li2024d}.} ca în \eqref{eq:denoising_exponential_discretization}, ieșirea \(\hat{\vx}\) a \Cref{alg:iterative_denoising} satisface limita de variație totală
+	\begin{equation}\label{eq:diffusion_sampling_error}
+		\TV(\vx, \hat{\vx}) = \tilde{\cO}\rp{\underbrace{\frac{D}{L}}_{\text{eroare de discretizare}} + \underbrace{\sqrt{\frac{1}{L}\sum_{\ell = 1}^{L}\frac{\alpha_{t_{\ell}}}{\sigma_{t_{\ell}}^{2}}\Ex_{\vx, \vx_{t_{\ell}}}\norm{\bar{\vx}^{\ast}(t_{\ell}, \vx_{t_{\ell}}) - \bar{\vx}(t_{\ell}, \vx_{t_{\ell}})}_{2}^{2}}}_{\text{eroare medie în exces a denoiser-ului}}}
+	\end{equation}
+	unde \(\bar{\vx}^{\ast}\) este denoiser-ul Bayes optimal pentru \(\vx\), și \(\tilde{\cO}\) este o versiune a notației big-\(\cO\) care ignoră factorii logaritmici în \(L\).
+\end{theorem}
+Tehnica de demonstrație la nivel foarte înalt este, așa cum s-a discutat mai devreme, să limităm eroarea la fiecare pas, să distingem sursele de eroare (între discretizare și eroarea denoiser-ului) și să ne asigurăm cu grijă că erorile nu se acumulează prea mult (sau chiar se anulează).
+
+Notați că dacă \(L \to \infty\) și învățăm corect denoiser-ul Bayes optimal \(\bar{\vx} = \bar{\vx}^{\ast}\) (astfel încât eroarea în exces să fie \(0\)), atunci procesul de eșantionare din \Cref{alg:iterative_denoising} produce o \textit{inversă perfectă (în distribuție)} a procesului de adăugare a zgomotului, deoarece rata de eroare din \Cref{thm:diffusion_sampler_convergence} merge la \(0\),\footnote{Există rezultate similare pentru procesele VE, deși niciunul nu este la fel de precis ca acesta după cunoștințele noastre.} așa cum s-a argumentat euristic anterior.
+
+\begin{remark}
+	Ce se întâmplă dacă datele sunt cu dimensiuni reduse, să zicem susținute pe un \textit{subspațiu de rang redus} al spațiului cu dimensiuni înalte \(\R^{D}\)? Dacă distribuția datelor are suport compact---să zicem dacă datele sunt normalizate la hipercubul unitar, ceea ce este adesea asigurat ca un pas de pre-procesare pentru date reale precum imagini---este posibil să obținem rezultate mai bune. Mai exact, autorii \cite{li2024d} definesc de asemenea o măsură de \textit{dimensiune intrinsecă aproximativă} folosind asimptoticele așa-numitului număr de acoperire, care este extrem de similar în intuiție (dacă nu în implementare) cu funcția ratei distorsiunii prezentată în următoarea Secțiune. Apoi ei arată că folosind o modificare mică particulară a eșantionatorului DDIM din \Cref{alg:iterative_denoising} (i.e., perturbând ușor coeficienții de actualizare), eroarea de discretizare devine
+	\begin{equation}
+		\tilde{\cO}\rp{\frac{\text{dimensiune intrinsecă aproximativă}}{L}}
+	\end{equation}
+	în loc de \(\frac{D}{L}\) cum era în \Cref{thm:diffusion_sampler_convergence}. Prin urmare, folosind acest algoritm modificat, \(L\) nu trebuie să fie prea mare chiar și când \(D\) ajunge la mii sau milioane, deoarece datele reale au structură cu dimensiuni reduse. Cu toate acestea, în practică folosim eșantionatorul DDIM în schimb, așa că \(L\) ar trebui să aibă o dependență ușoară de \(D\) pentru a obține rate de eroare consistente. Alegerea exactă a lui \(L\) face un compromis între complexitatea computațională (de exemplu, timpul de execuție sau consumul de memorie) al eșantionării și complexitatea statistică a învățării unui denoiser pentru structuri cu dimensiuni reduse. Valoarea lui \(L\) este adesea diferită la timpul de antrenare (unde un \(L\) mai mare permite o acoperire mai bună a intervalului \([0, T]\), ceea ce ajută rețeaua să învețe o relație care generalizează peste \(t\)) și timpul de eșantionare (unde \(L\) fiind mai mic înseamnă eșantionare mai eficientă). Se pot chiar alege pașii de timp adaptiv la timpul de eșantionare pentru a optimiza aceste compromisuri \cite{bao2022analytic}.
+\end{remark}
+
+\begin{remark}
+	Diverse alte lucrări definesc procesul invers ca mișcându-se înapoi în indexul de timp \(t\) folosind o ecuație cu diferențe explicită, sau ecuație diferențială în limita \(L \to \infty\), sau înainte în timp folosind transformarea \(\vy_{t} = \vx_{T - t}\), astfel încât dacă \(t\) crește atunci \(\vy_{t}\) devine mai aproape de \(\vx_{0}\). În această lucrare ne străduim să păstrăm consistența: ne mișcăm înainte în timp pentru a adăuga zgomot și înapoi în timp pentru a îndepărta zgomotul. Dacă citiți o altă lucrare care nu este clară cu privire la indexul de timp, sau încercați să implementați un algoritm care este similar neclar, există o modalitate de a face acest lucru corect de fiecare dată: procesul de eșantionare ar trebui să aibă întotdeauna un coeficient \textit{pozitiv} atât pe termenul denoiser-ului, cât și pe iterația curentă când se trece de la pas la pas. Dar în general multe lucrări își definesc propria notație și nu este prietenoasă cu utilizatorul.
+\end{remark}
+
+\begin{remark}
+	Teoria prezentată la sfârșitul ultimei \Cref{sub:intro_diffusion_denoising} pare să sugereze (vorbind liber) că în practică, folosirea unei rețele de tip transformer este o alegere bună pentru învățarea sau aproximarea unui denoiser. Acest lucru este rezonabil, dar care este problema cu utilizarea oricărei rețele neuronale vechi (cum ar fi un perceptron multistrat (MLP)) și doar încercarea de a o scala la infinit? Pentru a observa problema cu aceasta, să ne uităm la un alt caz special al modelului de amestec gaussian studiat în \Cref{example:denoising_gaussian_mixture}. Mai exact, \textit{distribuția empirică} este o instanță a unui model de amestec gaussian degenerat, cu \(K = N\) componente \(\dNorm(\vx_{i}, \vzero)\) eșantionate cu probabilitate egală \(\pi_{i} = \frac{1}{N}\). În acest caz, denoiser-ul Bayes optimal este
+	\begin{equation}\label{eq:memorizing_denoiser}
+		\bar{\vx}^{\star}(t, \vx_{t}) = \sum_{i = 1}^{N}\frac{e^{-\|\vx_{t} - \alpha_{t}\vx_{i}\|_{2}^{2}/(2\sigma_{t}^{2})}}{\sum_{j = 1}^{N}e^{-\|\vx_{t} - \alpha_{t}\vx_{j}\|_{2}^{2}/(2\sigma_{t}^{2})}}\vx_{i}.
+	\end{equation}
+	Aceasta este o combinație convexă a datelor \(\vx_{i}\), și coeficienții devin „mai ascuțiți" (i.e., mai aproape de \(0\) sau \(1\)) pe măsură ce \(t \to 0\). Observați că acest denoiser \textit{rezolvă optimal} problema de optimizare a îndepărtării zgomotului \eqref{eq:parametric_denoising_loss} când calculăm pierderea pe baza extragerii lui \(\vx\) uniform aleator dintr-un set de date finit fix \(\vX = \{\vx_{i}\}_{i = 1}^{N}\), care este o setare foarte realistă. Astfel, dacă arhitectura noastră de rețea \(\bar{\vx}_{\theta}\) este suficient de expresivă astfel încât denoiserii optimi de forma de mai sus \eqref{eq:memorizing_denoiser} pot fi bine aproximați, atunci denoiser-ul învățat poate face exact asta. Apoi, îndepărtarea noastră iterativă a zgomotului \Cref{alg:iterative_denoising} va eșantiona exact din distribuția empirică, re-generând eșantioane din datele de antrenare, așa cum este certificat de \Cref{thm:diffusion_sampler_convergence}. Acesta este un eșantionator prost, nu cu adevărat mai interesant decât o bază de date cu toate eșantioanele, și astfel este important să înțelegem cum să evităm acest lucru în practică. Cheia este să venim cu o arhitectură de rețea care poate aproxima bine denoiser-ul adevărat (să zicem corespunzător unei distribuții de rang redus ca în \eqref{eq:gmm_lowrank_denoiser}) dar nu denoiser-ul bayesian empiric ca în \eqref{eq:memorizing_denoiser}. Unele lucrări au explorat această linie fină și de ce modelele de difuzie moderne, care folosesc arhitecturi de rețea bazate pe transformatoare și convoluționale, pot memoriza și generaliza în regimuri diferite \citep{kamb2024analytic,niedoba2024towards}.
+
+	La un nivel înalt, un denoiser care memorează toate punctele de antrenare, ca în \eqref{eq:memorizing_denoiser}, corespunde unui model parametric al distribuției care are rata de codificare minimă și obține aceasta prin codificarea fiecărui eșantion separat. Vom discuta această problemă (și paradoxul aparent cu dezideratele noastre inițiale la sfârșitul \Cref{sub:min_entropy}) din perspectiva teoriei informației în următoarea secțiune.
+\end{remark}
+
+Am făcut multe modificări procesului nostru platonic original de adăugare/îndepărtare a zgomotului. Pentru a ne asigura că noul proces funcționează încă în practică, putem calcula exemple numerice (cum ar fi \Cref{fig:vp_gmm_denoising}). Pentru a ne asigura că este solid din punct de vedere teoretic, putem demonstra o \textit{limită a ratei de eroare} pentru algoritmul de eșantionare, care arată că rata de eroare este mică. Vom furniza acum o astfel de rată din literatură, care arată că distribuția de ieșire a eșantionatorului converge în așa-numita \textit{distanță de variație totală (TV)} către distribuția adevărată. Distanța TV este definită între două variabile aleatoare \(\vx\) și \(\vy\) ca:
+\begin{equation}
+	\TV(\vx, \vy) \doteq \sup_{A \subseteq \R^{d}}\abs*{\Pr[\vx \in A] - \Pr[\vy \in A]}.
+\end{equation}
+Dacă \(\vx\) și \(\vy\) sunt foarte aproape (uniform), atunci supremumul va fi mic. Deci distanța TV măsoară apropierea variabilelor aleatoare. (Este într-adevăr o metrică, după cum sugerează numele; demonstrația este un exercițiu.)
+
+\section{Compresie prin Codificare cu Pierderi} \label{sec:lossy_compression}
+
+Să recapitulăm ce am acoperit până acum. Am discutat cum să potrivim un \textit{denoiser} \(\bar{\vx}_{\theta}\) folosind eșantioane finite. Am arătat că acest denoiser codifică o distribuție prin faptul că este direct conectat la log-densitatea sa prin formula lui Tweedie \eqref{eq:tweedie}. Apoi, l-am folosit pentru a transforma treptat o distribuție de zgomot pur (entropie mare) către distribuția învățată prin \textit{îndepărtarea iterativă a zgomotului}. Astfel, am dezvoltat primul mod de a învăța sau urmări o distribuție prezentat la sfârșitul \Cref{sub:min_entropy}.
+
+Cu toate acestea, în această metodologie, codificarea distribuției este implicită în forma funcțională a denoiser-ului și parametrii săi, dacă există. De fapt, cititorii atenți ar fi observat că pentru o distribuție generală, nu am specificat niciodată explicit care este forma funcțională pentru denoiser. În practică, oamenii îl modelează de obicei printr-o rețea neurală profundă cu o arhitectură proiectată empiric. În plus, deși știm că procesul de îndepărtare a zgomotului de mai sus reduce entropia, nu știm cu cât, nici nu știm entropia distribuțiilor intermediare și rezultate.
+
+Amintiți-vă că scopul nostru general este să modelăm date dintr-o distribuție (continuă) cu un suport cu dimensiuni reduse. Dacă scopul nostru este să identificăm cel mai „simplu" model care generează datele, s-ar putea considera trei măsuri tipice de parcimonitate: dimensiunea, volumul sau entropia (diferențială). Ei bine, dacă cineva folosește dimensiunea, atunci în mod evident cel mai bun model pentru un set de date dat este distribuția empirică însăși, care este zero-dimensională. Pentru toate distribuțiile cu suporturi cu dimensiuni reduse, entropia diferențială este întotdeauna minus infinit; volumul suporturilor lor este întotdeauna zero. Deci, printre toate distribuțiile cu suporturi cu dimensiuni reduse care ar fi putut genera aceleași eșantioane de date, cum putem decide care este mai bună pe baza acestor măsuri de parcimonitate care nu pot distinge deloc între modelele cu dimensiuni reduse? Această secțiune își propune să abordeze această situație aparent derutantă.
+
+În restul acestui capitol, discutăm un cadru care ne permite să atenuăm dificultatea tehnică de mai sus asociind distribuția învățată cu o schemă explicită calculabilă de codificare și decodificare, urmând a doua abordare sugerată la sfârșitul \Cref{sub:min_entropy}. După cum vom vedea, o astfel de abordare ne permite în esență să aproximăm cu precizie entropia distribuțiilor învățate în termeni de lungime (cu pierderi) de codificare sau rata de codificare asociată cu schema de codificare. Cu o astfel de măsură, nu numai că putem măsura cu precizie cu cât este redusă entropia, prin urmare informația câștigată, prin orice procesare (inclusiv îndepărtarea zgomotului) a distribuției, dar putem deriva și o formă explicită a operatorului optim care poate conduce astfel de operații în modul cel mai eficient. După cum vom vedea în următorul \Cref{ch:representation}, aceasta va duce la o explicație principială pentru arhitectura rețelelor profunde, precum și la proiectări mai eficiente de arhitecturi profunde.
+
+\subsection{Necesitatea Codificării cu Pierderi}
+
+Am discutat anterior, de mai multe ori, o dificultate: dacă învățăm distribuția din eșantioane finite în final, și clasa noastră de funcții de denoisere conține suficiente funcții, cum ne asigurăm că eșantionăm din distribuția \textit{adevărată} (cu suporturi cu dimensiuni reduse), în loc de orice altă distribuție care ar putea produce acele eșantioane finite cu probabilitate mare? Să dezvăluim câteva dintre dificultățile conceptuale și tehnice cu câteva exemple concrete.
+
+\begin{example}[Volum, Dimensiune și Entropie]\label{eg:measures-of-complexity}
+Pentru exemplul prezentat în partea de sus a \Cref{fig:1d-line}, să presupunem că am luat câteva eșantioane dintr-o distribuție uniformă pe o linie (să zicem într-un plan 2D). Volumul liniei sau al seturilor de eșantioane este zero.
+Geometric, distribuția empirică pe setul finit de eșantioane produs este {\em cea cu dimensiune minimă} care poate produce setul finit de eșantioane.\footnote{Un set de eșantioane discrete sunt toate de dimensiune zero, în timp ce linia de suport este de dimensiune unu.} Dar aceasta pare în contrast cu încă o altă măsură a complexității: entropia. Entropia (diferențială) a liniei este minus infinit, dar entropia (discretă) a acestui set de eșantioane este finită și pozitivă. Deci pare să avem o situație paradoxală conform acestor măsuri comune de parcimonitate sau complexitate: ele nu pot diferenția corect între (modele pentru) distribuții cu suporturi cu dimensiuni reduse deloc, iar unele par să le diferențieze chiar în moduri exact opuse.\footnote{Desigur, strict vorbind, entropia diferențială și entropia discretă nu sunt direct comparabile.}
+\end{example}
+
+\begin{example}[Densitate]\label{eg:density} Considerați cele două seturi de puncte de date eșantionate prezentate în \Cref{fig:1d-line}. Geometric, ele sunt în esență aceleași: fiecare set constă din opt puncte și fiecare punct a apărut cu frecvență egală $1/8$. Singura diferență este că pentru al doilea set de date, unele puncte sunt suficient de „apropiate" pentru a fi văzute ca având o densitate mai mare în jurul „clusterului" lor respectiv. Care este mai relevant pentru distribuția adevărată care ar fi putut genera eșantioanele? Cum putem reconcilia o astfel de ambiguitate în interpretarea acestui tip de distribuții (empirice)?
+\begin{figure}[t]
+	\centering
+	\includegraphics[width=0.7\linewidth]{\toplevelprefix/chapters/chapter3/figs/one-dim-distribution.png}
+	\caption{Opt puncte observate pe o linie.}
+	\label{fig:1d-line}
+\end{figure}
+\end{example}
+
+Există încă o altă dificultate tehnică asociată cu construirea unei scheme explicite de codificare și decodificare pentru un set de date. Dat un set de date eșantionate în $\X = [\vx_1, \ldots, \vx_N]$, cum să proiectăm o schemă de codificare care este implementabilă pe mașini cu memorie și resurse de calcul finite? Observați că până și reprezentarea unui număr real general necesită un număr infinit de cifre sau biți. Prin urmare, cineva s-ar putea întreba dacă entropia unei distribuții este o măsură directă pentru complexitatea schemei sale (optime) de codificare. Examinăm această chestiune cu un alt exemplu simplu.
+
+\begin{example}[Precizie] \label{eg:two-inrational}
+	Considerați o distribuție discretă $\X = [e, \pi]$ cu probabilitate egală $1/2$ luând valorile numărului lui Euler $e \approx 2.71828$ sau numărul $\pi \approx 3.14159$. Entropia acestei distribuții este $H =1$, ceea ce sugerează că cineva ar putea codifica cele două numere printr-o cifră de un bit $0$ sau $1$, respectiv. Dar puteți realiza o schemă de decodificare pentru acest cod pe o mașină cu stări finite? Răspunsul este de fapt nu, deoarece sunt necesari infinit de mulți biți pentru a descrie oricare dintre numere cu precizie.
+\end{example}
+
+Prin urmare, este în general imposibil să avem o schemă de codificare și decodificare care poate reproduce cu precizie eșantioane dintr-o distribuție cu valori reale arbitrare.\footnote{Adică, dacă cineva vrea să codifice astfel de eșantioane cu precizie, singura modalitate este să memoreze fiecare eșantion individual.} Dar ar fi de puțină valoare practică să codificăm o distribuție fără a putea decodifica pentru eșantioane extrase din aceeași distribuție.
+
+Deci pentru a ne asigura că orice schemă de codificare/decodificare este calculabilă și implementabilă cu memorie și resurse computaționale finite, trebuie să cuantificăm eșantionul $\x$ și să-l codificăm doar până la o anumită precizie, să zicem $\epsilon > 0$. {\em Făcând acest lucru, în esență, tratăm orice două puncte de date ca echivalente dacă distanța lor este mai mică de $\epsilon$.} Mai precis, am dori să considerăm scheme de codificare
+\begin{equation}
+	\x \mapsto \hat \x
+\end{equation}
+astfel încât eroarea așteptată cauzată de cuantizare să fie mărginită de $\epsilon$. Este matematic mai convenabil și conceptual aproape identic să mărginim eroarea \textit{pătrată} așteptată cu \(\epsilon^{2}\), i.e.,
+\begin{equation}
+	\Ex[d(\vx, \hat \vx)^{2}] \le \epsilon^{2}.
+\end{equation}
+De obicei, distanța \(d\) este aleasă să fie distanța euclidiană, sau norma 2.\footnote{Mai general, putem înlocui \(d^{2}\) cu orice așa-numită \textit{divergență}.} Vom adopta această alegere în continuare.
+
+\subsection{Rata Distorsiunii și Geometria Datelor}
+Desigur, dintre toate schemele de codificare care satisfac constrângerea de mai sus, am dori să alegem pe cea care minimizează rata de codificare rezultată. Pentru o variabilă aleatoare dată $\x$ și o precizie $\epsilon$, această rată este cunoscută ca {\em rata distorsiunii}, notată ca $\cR_{\epsilon}(\x)$.
+O teoremă profundă în teoria informației, demonstrată inițial de \textcite{shannon1959coding}, stabilește că această rată poate fi exprimată echivalent în termeni pur probabilistici ca
+\begin{equation}
+	\cR_{\epsilon}(\x) 
+	= \min_{p(\hat \x \mid \x): \Ex[\norm{\x -\hat \x}_2^{2}] \le \epsilon^{2}} 
+	I(\vx; \hat{\vx}),
+    \label{eqn:rate-distortion-general}
+\end{equation}
+unde cantitatea $I(\vx; \hat{\vx})$ este cunoscută ca \textit{informația mutuală}, definită de
+\begin{equation}\label{eq:mutual-information}
+	I(\vx; \hat{\vx})
+	= \KL(p(\vx, \hat{\vx}) \mmid p(\vx) p(\hat{\vx})).
+\end{equation}
+Observați că minimizarea în \eqref{eqn:rate-distortion-general} este peste toate distribuțiile condiționate $p(\hat \x \mid \x)$ care satisfac constrângerea de distorsiune $\Ex_{\x, \hat \x}[\norm{\x- \hat \x}_2^{2}] \le \epsilon^{2}$.
+Fiecare astfel de distribuție condiționată induce o distribuție comună $p(\vx, \hat{\vx}) = p(\hat\x \mid \x) p(\x)$, care determină informația mutuală \eqref{eq:mutual-information}.
+Multe proprietăți convenabile ale informației mutuale (și prin urmare rata distorsiunii) sunt implicate de proprietățile corespunzătoare ale divergenței KL (amintiți-vă \Cref{thm:information-inequality}).
+Din definiție, știm că $\cR_{\epsilon}(\x)$ este o funcție {\em nedescrescătoare} în $\epsilon$.
+
+\begin{remark}
+	În timp ce este posibil să ne așteptăm că rata distorsiunii să fie o aproximare implementabilă a entropiei lui $\x$ în următorul sens. Presupunem că $\vx$ și $\hat{\vx}$ sunt vectori aleatori continui. Atunci informația mutuală poate fi scrisă ca
+	\begin{equation}\label{eq:information-entropy}
+		I(\x; \hat\x) = h(\x) - h(\x \mid \hat \x),
+	\end{equation}
+	unde $h(\x \mid \hat \x) = \bE[\log_2 p(\x \mid \hat\x)]$ este \textit{entropia condiționată} a lui $\x$ dată $\hat \x$.
+	Prin urmare, rata minimă de codificare este atinsă când diferența dintre entropia lui $\x$ și entropia condiționată a lui $\x$ dată $\hat \x$ este minimizată printre toate distribuțiile care satisfac constrângerea: $\mathbb{E} [\norm{\x- \hat \x}_2^2] \le \epsilon^2$.
+
+	De fapt, nu este necesar să presupunem că $\x$ și $\hat \x$ sunt continue pentru a obține tipul de mai sus de concluzie. De exemplu, dacă ambii vectori aleatori sunt în schimb discreți, avem după o interpretare adecvată a divergenței KL pentru vectori aleatori cu valori discrete că
+	\begin{equation}
+		I(\x; \hat\x) = H(\x) - H(\x \mid \hat \x).
+	\end{equation}
+	Mai general, noțiuni matematice avansate din teoria măsurii pot fi folosite pentru a defini informația mutuală (și prin urmare rata distorsiunii) pentru variabile aleatoare arbitrare $\x$ și $\hat \x$, inclusiv cele cu distribuții cu dimensiuni reduse destul de exotice; vezi \textcite[\S 8.5]{Cover-Thomas}.
+\end{remark}
+
+\begin{remark}
+    Dat un set de puncte de date în $\X = [\x_1,\ldots, \x_N]$, se poate întotdeauna interpreta ca eșantioane dintr-o distribuție discretă uniformă cu probabilitate egală $1/N$ pe acești $N$ vectori. Entropia pentru o astfel de distribuție este $H(\X) = \frac{1}{N}\log_2 N$.\footnote{Observați din nou, chiar dacă putem codifica acești vectori cu această rată de codificare, nu îi putem decodifica cu o precizie arbitrară.} Cu toate acestea, chiar dacă $\X$ este o distribuție uniformă pe eșantioanele sale, rata de codificare $\cR_{\epsilon}(\X)$ realizabilă cu o schemă de codificare cu pierderi ar putea fi semnificativ mai mică decât $H(\X)$ dacă aceste eșantioane nu sunt atât de uniform distribuite și multe sunt grupate strâns împreună. Prin urmare, pentru a doua distribuție prezentată în Figura \ref{fig:1d-line}, pentru o eroare de cuantizare aleasă corespunzător $\epsilon$, rata de codificare cu pierderi realizabilă poate fi semnificativ mai mică decât codificarea ca o distribuție uniformă.\footnote{Cu toate acestea, pentru această distribuție uniformă discretă, când $\epsilon$ este suficient de mic, avem întotdeauna $H(\X) \approx \cR_{\epsilon}(\X)$.} De asemenea, observați că, cu noțiunea de rată a distorsiunii, dificultatea discutată în Exemplul \ref{eg:two-inrational} dispare și ea: Putem alege două numere raționale care sunt suficient de apropiate de fiecare dintre cele două numere iraționale. Schema de codificare rezultată va avea o complexitate finită.
+\end{remark}
+
+\begin{example}\label{example:sphere-covering-rate-distortion}
+	Uneori, se poate întâmpina o situație opusă când vrem să fixăm mai întâi rata de codificare și încercăm să găsim o schemă de codificare care minimizează distorsiunea. De exemplu, să presupunem că vrem să folosim doar un număr fix de coduri pentru puncte eșantionate dintr-o distribuție și vrem să știm cum să proiectăm codurile astfel încât distorsiunea medie sau maximă să fie minimizată în timpul schemei de codificare/decodificare. De exemplu, dată o distribuție uniformă pe un pătrat unitar, ne întrebăm cât de precis putem codifica puncte extrase din această distribuție, cu să zicem $n$ biți. Această problemă este echivalentă cu a întreba care este raza minimă (i.e., distorsiunea) astfel încât să putem acoperi pătratul unitar cu $2^n$ discuri de această rază. Figura \ref{fig:seven-circles-packing} arată acoperiri aproximativ optime ale unui pătrat cu \(n = 4, 6, 8\), astfel încât \(2^{n} = 16, 64, 256\) discuri, respectiv. Observați că razele optime ale discurilor scad pe măsură ce numărul de discuri \(2^{n}\) crește.
+	\begin{figure}
+		\centering
+		\includegraphics[width=0.3\textwidth]{\toplevelprefix/chapters/chapter3/figs/16.png}
+		\hfill
+		\includegraphics[width=0.3\textwidth]{\toplevelprefix/chapters/chapter3/figs/64.png}
+		\hfill
+		\includegraphics[width=0.3\textwidth]{\toplevelprefix/chapters/chapter3/figs/256.png}
+
+		\caption{Aproximări ale soluțiilor optime pentru \(2^{4}\), \(2^{6}\) și \(2^{8}\) discuri care acoperă un pătrat, împreună cu razele corespunzătoare, calculate folosind un algoritm de optimizare euristică.}
+		\label{fig:seven-circles-packing}
+	\end{figure}
+\end{example}
+
+\begin{figure}[t]
+	\centering 
+	\includegraphics[width=0.6\textwidth]{\toplevelprefix/chapters/chapter3/figs/continuation.png}
+	\caption{\small\textbf{Aproximarea unei distribuții cu dimensiuni reduse prin \(\epsilon\)-bile.} Putem vedea că pe măsură ce parametrul \(\epsilon\) se micșorează, uniunea \(\epsilon\)-bilelor aproximează suportul distribuției adevărate (negru) din ce în ce mai bine. Mai mult, denoiser-ii asociați (a căror mapare intrare-ieșire este dată de săgețile furnizate) obținuți prin aproximarea distribuției adevărate printr-un amestec de Gaussiene, fiecare cu covarianță \((\epsilon^{2}/D)\vI\), aproximează din ce în ce mai bine denoiser-ii adevărați. La \(\epsilon\) mare, astfel de denoiseri nu indică deloc spre distribuția adevărată, în timp ce la \(\epsilon\) mic ei aproximează îndeaproape denoiser-ii adevărați. \Cref{thm:covering-number-rate-distortion} stabilește că această aproximare caracterizează funcția ratei distorsiunii la distorsiuni mici $\epsilon$, unificând abordările paralele ale minimizării ratei de codificare și îndepărtării zgomotului pentru învățarea distribuțiilor cu dimensiuni reduse fără patologii.}
+	\label{fig:continuation}
+\end{figure}
+
+Se dovedește a fi o problemă notoriu de dificilă să obținem expresii în formă închisă pentru funcția ratei distorsiunii \eqref{eqn:rate-distortion-general} pentru distribuții generale $p(\vx)$. Cu toate acestea, așa cum sugerează \Cref{example:sphere-covering-rate-distortion}, există cazuri speciale importante în care \textit{geometria} suportului distribuției $p(\vx)$ poate fi legată de funcția ratei distorsiunii și prin urmare de rata optimă de codificare la nivelul de distorsiune $\epsilon$.
+De fapt, acest exemplu poate fi generalizat la orice setare în care suportul lui $p(\x)$ este un set compact suficient de regulat—inclusiv distribuții cu dimensiuni reduse—și $p(\x)$ este distribuit uniform pe suportul său.
+Aceasta acoperă un număr vast de cazuri de interes practic.
+Formalizăm această noțiune în următorul rezultat, care stabilește această proprietate pentru un caz special.
+
+\begin{theorem}\label{thm:covering-number-rate-distortion}
+	Să presupunem că \(\vx\) este o variabilă aleatoare astfel încât suportul său \(K \doteq \Supp(\vx)\) este un set compact. Definim \textit{numărul de acoperire} \(\cN_{\epsilon}(K)\) ca numărul minim de bile de rază \(\epsilon\) care pot acoperi \(K\), i.e.,
+	\begin{equation}
+		\cN_{\epsilon}(K) \doteq \min\left\{n \in \bN \colon \exists \vp_{1}, \dots, \vp_{n} \in K\ \text{s.t.}\ K \subseteq \bigcup_{i = 1}^{n}B_{\epsilon}(\vp_{i})\right\},
+	\end{equation}
+	unde \(B_{\epsilon}(\vp) = \set{\vxi\in \R^D \given \norm{\vxi - \vp}_2 \leq \epsilon}\) este bila euclidiană de rază \(\epsilon\) centrată la \(\vp\).
+	Atunci avem
+	\begin{equation}
+		\cR_{\epsilon}(\vx) 
+		\leq \log_{2} \cN_{\epsilon}(K).
+	\end{equation}
+	Dacă, în plus, $\vx$ este distribuit uniform pe $K$ și $K$ este un amestec de subspații ortogonale mutuale de rang redus,\footnote{De fapt, este posibil să tratăm $K$ foarte neregulat, cum ar fi fractalii, cu un rezultat paralel, dar enunțul său devine mult mai tehnic: c.f.\ Riegler et al.\ \cite{Riegler2018-jh,Riegler2023-rr}. Oferim o demonstrație simplă în \Cref{app:rate-distortion-covering} care arată rezultatul pentru amestecuri de subspații.}
+	atunci o limită inferioară corespunzătoare este valabilă:
+	\begin{equation}
+		\cR_{\epsilon}(\vx)
+		\geq
+		\log_{2} \cN_{\epsilon}(K) - O(D).
+	\end{equation}
+\end{theorem}
+\begin{proof}
+O demonstrație a acestei teoreme este dincolo de scopul acestei cărți și o amânăm pentru \Cref{app:rate-distortion-covering}.
+\end{proof}
+
+\begin{remark}\label{rem:slb}
+	Ingredientul cheie în demonstrația limitei inferioare din
+	\Cref{thm:covering-number-rate-distortion} este un rezultat important din
+	teoria informației cunoscut sub numele de \textit{limita inferioară Shannon} pentru rata
+	distorsiunii, numită după Claude Shannon, care a derivat-o prima dată într-un caz special
+	\cite{shannon1959coding}. Aceasta
+	afirmă următoarea estimare pentru funcția ratei distorsiunii, pentru orice variabilă
+	aleatoare $\x$ cu
+	o densitate $p(\x)$ și normă pătrată așteptată finită \cite{Linder1994-ej}:
+	\begin{equation}\label{eq:slb}
+		\cR_{\epsilon}(\x)
+		\geq
+		h(\x)
+		- \log_2 \volume(B_{\epsilon})
+		-
+		C_D,
+	\end{equation}
+	unde $C_D > 0$ este o constantă care depinde doar de $D$. Mai mult, această limită inferioară
+	este atinsă cu egalitate pentru distribuții \textit{gaussiene}. Această teoremă nu numai
+	că oferă o estimare optimă a cât de mulți biți sunt necesari pentru a codifica o
+	distribuție gaussiană, dar oferă și un schema explicită de codificare.
+	O schiță a demonstrației este oferită în \Cref{app:rate-distortion-covering}.
+\end{remark}
+
+Implicația \Cref{thm:covering-number-rate-distortion} poate fi rezumată după cum urmează: pentru codificarea suficient de precisă a distribuției lui $\x$, cadrul de codificare cu rata minimă a distorsiunii este complet caracterizat de problema împachetării sferelor pe suportul lui $\x$.
+Esența demonstrației \Cref{thm:covering-number-rate-distortion} poate fi într-adevăr generalizată la distribuții mai complexe, cum ar fi amestecuri suficient de incoerente de varietăți, dar lăsăm aceasta pentru un studiu viitor.
+Deci rata distorsiunii poate fi gândită ca o modalitate „conștientă de probabilitate" de a aproxima suportul distribuției lui \(\vx\) printr-un amestec de multe bile mici.
+
+Acum discutăm o altă conexiune între aceasta și ierarhia de complexitate îndepărtare a zgomotului-difuzie-entropie pe care am discutat-o mai devreme în acest capitol.
+
+\subsection{Rata de Codificare cu Pierderi pentru o Gaussiană cu Dimensiuni Reduse}\label{subsec:lossy DR}
+Acum să presupunem că ni se dă un set de eșantioane de date în $\X = [\x_1, \ldots, \x_N]$ din orice distribuție.\footnote{Sau aceste puncte de date ar putea fi văzute ca o distribuție (empirică) ele însele.} Am dori să venim cu o schemă constructivă care poate codifica datele până la o anumită precizie, să zicem
+\begin{equation}
+	\x_i \mapsto \hat \x_i, \quad \mbox{cu constrângerea} \quad \|\x_i - \hat \x_i\|_2 \le \epsilon.
+\end{equation}
+Observați că aceasta este o condiție suficientă, explicită și interpretabilă care asigură că datele sunt codificate astfel încât \(\frac{1}{N}\sum_{i = 1}^{N} \norm{\x_i- \hat \x_i}_2^{2} \le \epsilon^{2}\). Această ultimă inegalitate este exact constrângerea ratei distorsiunii pentru distribuția empirică furnizată și codificarea sa. De exemplu, în \Cref{example:sphere-covering-rate-distortion}, am folosit acest criteriu simplificat pentru a găsi explicit distorsiunea minimă și schema de codificare explicită pentru o rată de codificare dată.
+
+Fără pierderea generalității, să presupunem că media lui $\X$ este zero, i.e., $\frac{1}{N} \sum_{i = 1}^{N} \x_i = \boldsymbol{0}$. Fără nicio cunoaștere prealabilă despre natura distribuției din spatele lui $\X$, putem vedea $\X$ ca eșantionat dintr-o distribuție Gaussiană $\mathcal{N}(\boldsymbol{0}, {\boldsymbol{\Sigma}})$ cu covarianța\footnote{Se știe că dată o varianță fixă, Gaussiana atinge entropia maximă. Adică, oferă o limită superioară pentru ce ar putea fi cel mai rău caz în termeni de rată de codificare posibilă.}
+\begin{equation}
+	{\boldsymbol{\Sigma}} = \frac{1}{N} \X\X^\top.
+\end{equation}
+Observați că geometric ${\boldsymbol{\Sigma}}$ caracterizează o regiune elipsoidală unde rezidă majoritatea eșantioanelor $\x_i$.
+
+Putem vedea $\hat \X = [\hat \x_1,\ldots, \hat \x_N]$ ca o versiune zgomotoasă a lui $\X = [\x_1, \ldots, \x_N]$:
+\begin{equation}
+	\hat \x_i = \x_i + \vw_i,
+\end{equation}
+unde $\vw_i$ este un zgomot Gaussian $\vw_i  \sim \mathcal{N}(\boldsymbol{0} , {\epsilon^2}  \boldsymbol{I}/{D})$ independent de $\vx_i$. Atunci covarianța lui $\hat \x_i$ este dată de
+\begin{equation}
+	\hat{\boldsymbol{\Sigma}} = \mathbb{E}\left[\hat \x_i \hat \x_i^\top\right] = \frac{\epsilon^2}{D} \boldsymbol{I} + \frac{1}{N} \X\X^\top.
+\end{equation}
+
+Observați că volumul regiunii întinse de vectorii $\x_i$ este proporțional cu rădăcina pătrată a determinantului matricei de covarianță
+\begin{equation}
+	\mbox{volum}(\hat \x_i) \propto \sqrt{\det \big(\hat{\boldsymbol{\Sigma}}\big)} = \sqrt{\det\left(\frac{\epsilon^2}{D} \boldsymbol{I} + \frac{1}{N} \X\X^\top \right)}.
+\end{equation}
+Volumul întins de fiecare vector aleator $\boldsymbol{w}_i$ este proporțional cu
+\begin{equation}
+	\mbox{volum}(\boldsymbol{w}_i) \propto   \sqrt{\det\left(\frac{\epsilon^2}{D} \boldsymbol{I} \right)}.
+\end{equation}
+
+\begin{figure}
+	\centering
+	\includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter3/figs/Gaussian-compression.png}
+	\caption{Acoperirea regiunii întinse de vectorii de date folosind $\epsilon$-bile. Cu cât volumul spațiului este mai mare, cu atât sunt necesare mai multe bile, prin urmare sunt necesari mai mulți biți pentru a codifica și enumera bilele. Fiecare vector cu valori reale $\vx$ poate fi codificat ca numărul bilei în care cade.}
+	\label{fig:ball-packing}
+\end{figure}
+
+Pentru a codifica vectori care cad în regiunea întinsă de $\hat \x_i$, putem acoperi regiunea cu bile ne-suprapuse de rază $\epsilon$, așa cum este ilustrat în \Cref{fig:ball-packing}. Când volumul regiunii întinse de $\hat \x_i$ este semnificativ mai mare decât volumul $\epsilon$-bilei, numărul total de bile de care avem nevoie pentru a acoperi regiunea este aproximativ egal cu raportul celor două volume:
+\begin{equation}
+	\# \,\epsilon\mbox{-bile} \approx \frac{\mbox{volum}(\hat \vx_i)}{\mbox{volum}(\vw_i)} = \sqrt{\det\left(\boldsymbol{I} + \frac{D}{N\epsilon^2} \X\X^\top  \right)}.
+\end{equation}
+Dacă folosim numere binare pentru a eticheta toate $\epsilon$-bilele din regiunea de interes, numărul total de biți binari necesari este astfel
+\begin{equation} 
+	\cR_{\epsilon}(\X) \approx \log_2 (\# \,\epsilon\mbox{-bile}) \approx R_{\epsilon}(\X) \doteq \frac{1}{2} \log \det \left(\boldsymbol{I} + \frac{D}{N\epsilon^2} \X\X^\top \right).
+	\label{eqn:rate-Gaussian}
+\end{equation}
+
+\begin{example}
+	Figura \ref{fig:ball-packing} arată un exemplu al unei distribuții 2D cu un suport elipsoidal -- aproximând suportul unei distribuții Gaussiene 2D. Regiunea este acoperită de bile mici de dimensiune $\epsilon$. Toate bilele sunt numerotate de la $1$ la să zicem $n$. Atunci dat orice vector $\x$ în această regiune, trebuie doar să determinăm cărei $\epsilon$-bile îi este cel mai apropiat, notat ca $\operatorname{ball}_{\epsilon}(\x)$. Pentru a reține $\x$, trebuie doar să reținem numărul acestei bile, care necesită $\log(n)$ biți pentru a stoca. Dacă trebuie să decodificăm $\x$ din acest număr, pur și simplu luăm $\hat \x$ ca centrul bilei. Aceasta duce la o schemă explicită de codificare și decodificare:
+	\begin{equation}
+		\x \longrightarrow \operatorname{ball}_{\epsilon}(\x) \longrightarrow \hat \x = \mbox{centrul lui} \operatorname{ball}_{\epsilon}(\x).
+	\end{equation}
+	Se pot referi la aceste centre de bile ca ``coduri'' ale unei cărți de coduri sau dicționar pentru schema de codificare. Este ușor de văzut că precizia acestei scheme de codificare-decodificare (cu pierderi) este aproximativ raza bilei $\epsilon$.
+	În mod clar $\cR_{\epsilon}(\Z)$ este numărul mediu de biți necesari pentru a codifica numărul bilei fiecărui vector $\z$ cu această schemă de codificare și prin urmare poate fi numit {\em rata de codificare} asociată cu această schemă.
+\end{example}
+
+Din derivarea de mai sus, știm că rata de codificare $\cR_{\epsilon}(\X)$ este (aproximativ) realizabilă cu o schemă explicită de codificare (și decodificare). Are două proprietăți interesante:
+\begin{itemize}
+	\item În primul rând, se poate observa că $R_{\epsilon}(\X)$ seamănă îndeaproape cu funcția ratei distorsiunii unei surse Gaussiene \cite{Cover-Thomas}. Într-adevăr, când $\epsilon$ este mic, expresia de mai sus este o aproximare apropiată a ratei distorsiunii unei surse Gaussiene, așa cum a fost indicat de \cite{MaY2007-PAMI}.
+	\item În al doilea rând, aceeași rată de codificare în formă închisă $R_{\epsilon}(\X)$ poate fi derivată ca o aproximare a \(\cR_{\epsilon}(\vX)\) dacă datele $\X$ sunt presupuse a fi dintr-un subspațiu liniar. Aceasta poate fi arătată prin cuantificarea corectă a descompunerii în valori singulare (SVD) a lui $\X = \boldsymbol{U} \boldsymbol{\Sigma}\boldsymbol{V}^\top$ și construirea unei scheme de codificare cu pierderi pentru vectori în subspațiul întins de $\boldsymbol{U}$ \cite{MaY2007-PAMI}.
+\end{itemize}
+În contextul nostru, expresia în formă închisă $R_{\epsilon}(\X)$ este destul de fundamentală: este rata de codificare asociată cu o schemă explicită și naturală de codificare cu pierderi pentru date extrase fie dintr-o distribuție Gaussiană sau un subspațiu liniar. După cum vom vedea în următorul capitol, această formulă joacă un rol important în înțelegerea arhitecturii rețelelor neurale profunde.
+
+\subsection{Gruparea unui Amestec de Gaussiene cu Dimensiuni Reduse}
+\label{sec:clustering-Gaussians}
+După cum am discutat înainte, setul de date dat $\X$ are adesea structuri intrinseci cu dimensiuni reduse. Prin urmare, codificarea sa ca o Gaussiană generală ar fi foarte redundantă. Dacă putem identifica acele structuri intrinseci în $\X$, am putea proiecta scheme de codificare mult mai bune care dau rate de codificare mult mai mici. Sau echivalent, codurile folosite pentru a codifica astfel de $\X$ pot fi comprimate. Vom vedea că compresia oferă o modalitate unificatoare calculabilă de a identifica astfel de structuri. În această secțiune, demonstrăm această idee importantă cu cea mai de bază familie de structuri cu dimensiuni reduse: un amestec de Gaussiene (cu dimensiuni reduse) sau subspații.
+
+\begin{example}
+	\Cref{fig:two-subspaces} arată un exemplu în care datele $\X$ sunt distribuite în jurul a două subspații (sau Gaussiene cu dimensiuni reduse). Dacă sunt văzute și codificate împreună ca o singură Gaussiană, cartea de coduri discretă (cu pierderi) asociată, reprezentată de toate bilele albastre, este evident foarte redundantă. Putem încerca să identificăm locațiile celor două subspații, notate cu $S_1$ și $S_2$, și să proiectăm o carte de coduri care acoperă doar cele două subspații, i.e., bilele verzi. Dacă putem partiția corect eșantioanele din datele $\X$ în cele două subspații: $\X = [\X_1, \X_2]\bm \Pi$ cu $\X_1 \in S_1$ și $\X_2 \in S_2$, unde $\bm \Pi$ denotă o matrice de permutare, atunci rata de codificare rezultată pentru date va fi mult mai mică. Aceasta dă o reprezentare mai parcimonioasă, prin urmare mai dezirabilă, a datelor.
+\end{example}
+
+\begin{figure}
+	\centering
+	\includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter3/figs/Two-subspaces.png}
+	\caption{Comparație a două scheme de codificare cu pierderi pentru date care sunt distribuite în jurul a două subspații. Una este să împachetăm $\epsilon$-bile (albastre) pentru întregul spațiu întins de cele două subspații; cealaltă este să împachetăm bile doar într-o vecinătate tabulară în jurul celor două subspații. Ultima are în mod evident o carte de coduri mult mai mică și rezultă într-o rată de codificare mult mai mică pentru eșantioane pe subspații.}
+	\label{fig:two-subspaces}
+\end{figure}
+
+Deci, mai general vorbind, dacă datele sunt extrase din orice amestec de subspații sau Gaussiene cu dimensiuni reduse, ar fi de dorit să identificăm acele componente și să codificăm datele pe baza dimensiunilor intrinseci ale acelor componente. Se dovedește că nu pierdem multă generalitate presupunând că datele sunt extrase dintr-un amestec de Gaussiene cu dimensiuni reduse. Aceasta deoarece un amestec de Gaussiene poate aproxima îndeaproape majoritatea distribuțiilor generale \cite{borkar2016gaussian}.
+
+\paragraph{Problema grupării.}
+Acum pentru această familie specifică de distribuții, cum putem identifica efectiv și eficient acele componente cu dimensiuni reduse dintr-un set de eșantioane
+\begin{equation}
+	\X = \left[\x_1, \x_2, \ldots, \x_N\right],
+\end{equation}
+extrase din ele? Cu alte cuvinte, dat întregul set de date $\X$, vrem să-l partițăm, sau grupăm, în multiple, să zicem $K$, subseturi:
+\begin{equation}
+	\X\bm \Pi = [\X_1, \X_2, \dots, \X_K],
+\end{equation}
+unde fiecare subset constă din eșantioane extrase doar dintr-o Gaussiană cu dimensiuni reduse sau subspațiu și $\bm \Pi$ este o matrice de permutare pentru a indica apartenența partiției. Observați că, în funcție de situație, partiția ar putea fi fie deterministă sau probabilistică. Așa cum s-a arătat în \cite{ma2007segmentation}, pentru amestecul de Gaussiene, partiția probabilistică nu duce la o rată de codificare mai mică. Deci pentru simplitate, considerăm aici doar o partiție deterministă.
+
+\paragraph{Grupare prin compresie cu pierderi.}
+Principala dificultate în rezolvarea problemei de grupare de mai sus este că în mod normal nu cunoaștem numărul de clustere $K$, nici nu cunoaștem dimensiunea fiecărei componente. Există o lungă istorie pentru studiul acestei probleme de grupare. Manualul \cite{GPCA} oferă o acoperire sistematică și cuprinzătoare a diferitelor abordări ale acestei probleme. Pentru a găsi o abordare eficientă la această problemă, trebuie mai întâi să înțelegem și să clarificăm de ce vrem să grupăm. Cu alte cuvinte, ce câștigăm exact din gruparea datelor, comparativ cu a nu grupa? Cum măsurăm câștigul? Din perspectiva compresiei datelor, o grupare corectă ar trebui să ducă la o schemă de codificare (și decodificare) mai eficientă.
+
+Pentru orice set de date dat $\X$, există deja două scheme de codificare evidente ca bază de referință. Ele reprezintă două moduri extreme de a codifica datele:
+\begin{itemize}
+	\item Pur și simplu vedem toate eșantioanele împreună ca extrase dintr-o singură Gaussiană. Rata de codificare asociată este, așa cum a fost derivată înainte, dată de:
+	      \begin{equation}
+		      \cR_{\epsilon}(\vX) \approx R_{\epsilon}(\X) = \frac{1}{2} \log \det \left(\boldsymbol{I} + \frac{D}{N\epsilon^2} \X\X^\top \right).
+	      \end{equation}
+	\item Pur și simplu memorăm toate eșantioanele separat prin atribuirea unui număr diferit fiecărui eșantion. Rata de codificare ar fi:
+	      \begin{equation}
+		      \cR_0(\X) = \log(N).
+	      \end{equation}
+\end{itemize}
+
+Observați că oricare schemă de codificare poate deveni soluția ``optimă'' pentru o anumită alegere (extremă) a erorii de cuantizare $\epsilon$:
+\begin{enumerate}
+	\item {\em Regimul Leneș}: Dacă alegem $\epsilon$ să fie extrem de mare, toate eșantioanele din $\X$ pot fi acoperite de o singură bilă. Rata este  $\lim_{\epsilon \rightarrow \infty} \cR_\epsilon \rightarrow \frac{1}{2}\log\det (\boldsymbol{I}) = 0$.
+	\item {\em Regimul de Memorare}: Dacă $\epsilon$ este extrem de mic, fiecare eșantion din $\X$  este acoperit de o $\epsilon$-bilă diferită, prin urmare totalul este $N$. Rata este $\lim_{\epsilon \rightarrow 0} \cR_\epsilon \rightarrow \log(N)$.
+\end{enumerate}
+Observați că prima schemă corespunde scenariului când cineva nu se preocupă deloc de nimic interesant despre distribuție. Nu vrei să economisești niciun bit pentru nimic informativ. Numim aceasta ``regimul leneș''. A doua schemă corespunde scenariului când cineva vrea să decodifice fiecare eșantion cu o precizie extrem de mare. Deci ar fi mai bine să ``memoreze'' fiecare eșantion. Numim aceasta ``regimul de memorare''.
+\begin{figure}
+	\centering
+	\includegraphics[width=0.9\linewidth]{\toplevelprefix/chapters/chapter3/figs/circle-packing.png}
+	\caption{Un număr de eșantioane aleatorii pe un plan 2D. Considerați un $\epsilon$-disc atribuit fiecărui eșantion cu eșantionul ca centru. Densitatea eșantioanelor crește de la stânga la dreapta.}
+	\label{fig:circle-packing}
+\end{figure}
+\begin{example}
+	Pentru a vedea când regimul de memorare este preferat sau nu, să considerăm un număr, să zicem $N$, de eșantioane distribuite aleatoriu într-o arie unitară pe un plan 2D.\footnote{Să zicem că punctele sunt extrase printr-un proces Poisson cu densitate $N$ puncte pe unitate de arie.} Imaginați-vă că încercăm să proiectăm o schemă de codificare cu pierderi cu o eroare de cuantizare fixă $\epsilon$. Aceasta este echivalentă cu punerea unui $\epsilon$-disc în jurul fiecărui eșantion, așa cum este arătat în \Cref{fig:circle-packing}. Când $N$ este mic, șansa ca toate discurile să se suprapună între ele este zero. O carte de coduri de dimensiune $N$ este necesară și optimă în acest caz. Când $N$ sau densitatea atinge o anumită valoare critică $N_c$, cu probabilitate mare toate discurile încep să se suprapună și să se conecteze într-un cluster care acoperă întregul plan---acest fenomen este cunoscut ca ``percolație'' continuă \cite{Gilbert-1961,Mertens-Moore-2012}. Când $N$ devine mai mare decât această valoare, discurile se suprapun puternic. Numărul $N$ de discuri devine foarte redundant deoarece vrem doar să codificăm puncte pe plan până la precizia dată $\epsilon$. Numărul de discuri necesare pentru a acoperi toate eșantioanele este mult mai mic decât $N$.\footnote{De fapt, există algoritmi eficienți pentru a găsi o astfel de acoperire \cite{Booth-2001}.}
+\end{example}
+
+Atât regimul leneș cât și cel de memorare sunt oarecum triviale și poate sunt de puțin interes teoretic sau practic. Oricare schemă ar fi departe de a fi optimă când este folosită pentru a codifica un număr mare de eșantioane extrase dintr-o distribuție care are un {\em suport compact și cu dimensiuni reduse}. Regimul interesant există între aceste două.
+\begin{example}
+	\begin{figure}[t]
+		\centering
+		\includegraphics[width=0.4\linewidth]{\toplevelprefix/chapters/chapter3/figs/Two-lines-and-plane.png}
+		\includegraphics[width=0.9\linewidth]{\toplevelprefix/chapters/chapter3/figs/Coding-Rate.jpg}
+		\caption{Sus: 358 eșantioane zgomotoase extrase din două linii și un plan în $\mathbb{R}^3$. Jos: efectul variației lui $\epsilon$ asupra rezultatului grupării și rata de codificare. Linia roșie marchează varianța $\epsilon_0$ a zgomotului Gaussian adăugat la eșantioane.}
+		\label{fig:two-lines-and-plane}
+		\label{fig:two-lines-and-plane-epsilon}
+	\end{figure}
+	\Cref{fig:two-lines-and-plane} arată un exemplu cu eșantioane zgomotoase extrase din două linii și un plan în $\mathbb{R}^3$. Așa cum observăm din graficul (c) din dreapta, rata optimă de codificare scade monoton pe măsură ce creștem $\epsilon$, așa cum era anticipat din proprietatea funcției ratei distorsiunii. Graficele (a) și (b) arată, când variază $\epsilon$ de la foarte mic (aproape de zero) la foarte mare (către infinit), numărul optim de clustere când rata de codificare este minimă. Putem vedea clar regimul leneș și regimul de memorare la cele două capete ale graficelor. Dar se poate observa și în graficul (b), când eroarea de cuantizare $\epsilon$ este aleasă să fie în jurul nivelului adevăratei varianțe a zgomotului $\epsilon_0$, numărul optim de clustere este numărul ``corect'' trei care reprezintă două plane și un subspațiu. Ne referim informal la acest regim de mijloc ca ``regimul de generalizare''. Observați că o tranziție de fază ascuțită are loc între aceste regimuri.\footnote{Până acum, din cunoștințele noastre, nu există o justificare teoretică riguroasă pentru aceste comportamente de tranziție de fază.}
+\end{example}
+
+Din discuția și exemplele de mai sus, vedem că, atunci când eroarea de cuantizare relativă la densitatea eșantionului\footnote{sau densitatea eșantionului relativă la eroarea de cuantizare} este într-un interval corespunzător, minimizarea ratei de codificare cu pierderi ne-ar permite să descoperim distribuția subiacentă (cu dimensiuni reduse) a datelor eșantionate. {\em Prin urmare, cuantizarea, începută ca o alegere de practicitate, pare să devină necesară pentru învățarea unei distribuții continue din distribuția sa empirică cu eșantioane finite.} Deși o teorie riguroasă pentru explicarea acestui fenomen rămâne evazivă, aici, pentru scopuri de învățare, ne pasă cum să exploatăm fenomenul pentru a proiecta algoritmi care pot găsi distribuția corectă.
+
+Să folosim exemplul simplu arătat în \Cref{fig:two-subspaces} pentru a ilustra ideile de bază. Dacă cineva poate partiția toate eșantioanele din $\X$ în două clustere în $\X_1$ și $\X_2$, cu $N_1$ și $N_2$ eșantioane respectiv, atunci rata de codificare asociată ar fi\footnote{Ignorăm aici câțiva biți suplimentari necesari pentru a codifica apartenența pentru fiecare eșantion, să zicem prin codificarea Huffman.}
+\begin{equation}
+	R_{\epsilon}^c(\X\mid \boldsymbol{\Pi}) = \frac{N_1}{N}R_{\epsilon}(\X_1) + \frac{N_2}{N}R_{\epsilon}(\X_2),
+\end{equation}
+unde folosim $\boldsymbol{\Pi}$ pentru a indica apartenența partiției. Dacă partiția respectă structurile cu dimensiuni reduse ale distribuției, în acest caz $\X_1$ și $\X_2$ aparținând celor două subspații respectiv, atunci rata de codificare rezultată ar trebui să fie semnificativ mai mică decât cele două scheme de bază de mai sus:
+\begin{equation}
+	R_{\epsilon}^c(\X \mid \boldsymbol{\Pi}) \ll R_{\epsilon}(\X), \quad     R_{\epsilon}^c(\X \mid \boldsymbol{\Pi}) \ll R_0(\X).
+\end{equation}
+În general, putem formula problema de grupare într-o problemă de optimizare care minimizează rata de codificare:
+\begin{equation}
+	\min_{\boldsymbol{\Pi}}  \bc{ R_{\epsilon}^c(\X \mid \boldsymbol{\Pi})
+	\doteq \sum_{k=1}^K \frac{N_k}{N}R_{\epsilon}(\X_k)}.
+\end{equation}
+
+\paragraph{Strategii de optimizare pentru grupare.}
+Întrebarea rămasă este cum optimizăm obiectivul ratei de codificare de mai sus pentru a găsi clusterele optime. Există trei abordări naturale la acest obiectiv:
+\begin{enumerate}
+	\item Putem începe cu întregul set $\X$ ca un singur cluster (i.e.\ regimul leneș) și apoi căutăm (să zicem aleatoriu) să-l partițăm astfel încât să ducă la o rată de codificare mai mică.
+	\item Invers, putem începe cu fiecare eșantion $\x_i$ ca propriul său cluster (i.e.\ regimul de memorare) și căutăm să îmbinăm clustere care ar rezulta într-o rată de codificare mai mică.
+	\item Alternativ, dacă am putea reprezenta (sau aproxima) apartenența $\boldsymbol{\Pi}$ ca niște parametri continui, am putea folosi metode de optimizare precum coborârea gradientului (GD).
+\end{enumerate}
+Prima abordare nu este atât de atractivă computațional deoarece numărul de partiții posibile pe care trebuie să le încercăm este exponențial în numărul de eșantioane. De exemplu, numărul de partiții ale lui $\X$ în două subseturi de dimensiune egală este $N \choose N/2$ care explodează pe măsură ce $N$ devine mare. Vom explora a treia abordare în următorul \Cref{ch:representation}. Acolo, vom vedea cum rolul rețelelor neurale profunde, în special transformatoarelor, este conectat cu obiectivul ratei de codificare.
+
+Dacă avem două clustere $\X_k$ și $\X_l$, dacă vrem să codificăm eșantioanele ca două clustere separate, lungimea biților binari necesari este
+\begin{equation*}
+	L^c(\X_k, \X_l) = N_k R_\epsilon(\X_k) + N_l R_\epsilon(\X_l) - N_k \log\frac{N_k}{N_k + N_l} - N_l \log\frac{N_l}{N_k + N_l}.
+\end{equation*}
+Ultimii doi termeni sunt numărul de biți necesari pentru a codifica apartenența eșantioanelor conform codului Huffman.
+
+Apoi, date fiind oricare două clustere separate $\X_1$ și $\X_2$, putem decide dacă să le îmbinăm sau nu pe baza diferenței dintre cele două lungimi de codificare:
+\begin{equation}
+	L(\X_k \cup \X_l) - L^c(\X_k, \X_l)
+\end{equation}
+este pozitivă sau negativă și $\X_k \cup \X_l$ denotă reuniunea seturilor de eșantioane în $\bm X_k$ și $\bm X_l$. Dacă este negativă, înseamnă că lungimea de codificare ar deveni mai mică dacă îmbinăm cele două clustere într-unul singur. Acest fapt simplu duce la următorul algoritm de grupare propus de \cite{ma2007segmentation}:
+\begin{algorithm}[!htbp]
+	\caption{Descreștere Abruptă pe Perechi a Lungimii de Codificare}\label{alg:steepest_descent_coding_length}
+	\begin{algorithmic}[1]
+		\Require{\(N\) puncte de date \(\{\vx_{i}\}_{i = 1}^{N}\)}
+		\Ensure{Un set \(\cC\) de clustere}
+
+		\Procedure{DescreștereAbruptăPePerechiaLungimiiDeCodificare}{$\{\vx_{i}\}_{i = 1}^{N}$}
+		\State{\(\cC \gets \{\{\bm x_{i}\}\}_{i = 1}^{N}\)} \Comment{Inițializează \(N\) clustere \(\vX_{k}\) cu câte un element fiecare}
+		\While{\(\abs{\cC} > 1\)}
+		\If{\(\displaystyle \min_{\vX_{k}, \vX_{l} \in \cC}[L(\vX_{k} \cup \vX_{l}) -L^{c}(\vX_{k}, \vX_{l})] \geq 0\)} \Comment{Dacă nu se salvează biți prin nicio îmbinare}
+		\State{\Return{\(\cC\)}} \Comment{Returnează \(\cC\) și ieși}
+		\Else
+		\State{\(\displaystyle \vX_{k^{\ast}}, \vX_{l^{\ast}} \gets \argmin_{\vX_{k}, \vX_{l} \in \cC}[L(\vX_{k} \cup \vX_{l}) - L^{c}(\vX_{k}, \vX_{l})]\)} \Comment{Îmbină clusterele care salvează cei mai mulți biți}
+		\State{\(\displaystyle \cC \gets [\cC \setminus \{\vX_{k^{\ast}}, \vX_{l^{\ast}}\}] \cup \{\vX_{k^{\ast}} \cup \vX_{l^{\ast}}\}\)} \Comment{Elimină clusterele neîmbinate și adaugă înapoi cel îmbinat}
+		\EndIf
+		\EndWhile
+		\State{\Return{\(\cC\)}}  \Comment{Dacă toate îmbinările produc economii, returnează un cluster}
+		\EndProcedure
+	\end{algorithmic}
+\end{algorithm}
+
+Notați că acest algoritm este tractabil deoarece numărul total de comparații (pe perechi) și îmbinări este de aproximativ $O(N^2\log N)$. Cu toate acestea, datorită naturii sale lacome, nu există nicio garanție teoretică că procesul va converge la soluția de grupare optimă global. Cu toate acestea, după cum s-a raportat în \cite{ma2007segmentation}, în practică, acest algoritm aparent simplu funcționează extrem de bine. Rezultatele de grupare reprezentate în \Cref{fig:two-lines-and-plane} au fost de fapt calculate prin acest algoritm.
+
+\begin{example}[Segmentarea Imaginilor]\label{eg:image-segmentation} Măsura de mai sus a lungimii de codificare și algoritmul de grupare asociat presupun că distribuția datelor este un amestec de Gaussiene (cu dimensiuni reduse). Deși aceasta pare oarecum idealistă, măsura și algoritmul pot fi deja foarte utile și chiar puternice în scenarii când modelul este (aproximativ) valid.
+
+	De exemplu, o imagine naturală constă de obicei din mai multe regiuni cu texturi aproape omogene. Dacă luăm multe ferestre mici din fiecare regiune, ele ar trebui să semene cu eșantioane extrase dintr-o Gaussiană (cu dimensiuni reduse), așa cum este ilustrat în \Cref{fig:image-patch}. \Cref{fig:image-segmentation} arată rezultatele segmentării imaginii pe baza aplicării algoritmului de grupare de mai sus direct pe patch-urile de imagine. Mai multe detalii tehnice privind personalizarea algoritmului la problema segmentării imaginii pot fi găsite în \cite{Mobahi-IJCV2011}.
+\end{example}
+
+\begin{figure}
+	\centering
+	\includegraphics[width=0.4\linewidth]{\toplevelprefix/chapters/chapter3/figs/image-segmentation-tiles.png}
+	\caption{Patch-uri de imagine cu o dimensiune de $w\times w$ pixeli.}
+	\label{fig:image-patch}
+\end{figure}
+
+\begin{figure}[th]
+	\centering
+	\includegraphics[width=1.0\linewidth]{\toplevelprefix/chapters/chapter3/figs/image-segmentation.png}
+	\caption{Segmentarea imaginii bazată pe algoritmul de grupare a ratei de codificare.}
+	\label{fig:image-segmentation}
+\end{figure}
+
+\section{Maximizarea Câștigului de Informație}
+\label{sec:chap4-representation-learning-problem}
+
+Până acum în acest capitol, am discutat cum să identificăm o distribuție cu structuri cu dimensiuni reduse prin principiul compresiei. După cum am văzut din secțiunile anterioare două, compresia computațională poate fi realizată fie prin operația de îndepărtare a zgomotului sau clustering. \Cref{fig:Gaussian-Subspaces} ilustrează acest concept cu exemplul nostru favorit.
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.8\linewidth]{\toplevelprefix/chapters/chapter3/figs/Gaussian-Subspaces.png}
+    \caption{Identificarea unei distribuții cu dimensiuni reduse cu două subspații (stânga) prin îndepărtarea zgomotului sau clustering, pornind de la o distribuție Gaussiană aleatorie generică (dreapta).}
+    \label{fig:Gaussian-Subspaces}
+\end{figure}
+Desigur, scopul final pentru identificarea unei distribuții de date este să o folosim pentru a facilita anumite sarcini ulterioare precum segmentarea, clasificarea sau generarea (de imagini). Prin urmare, modul în care distribuția rezultată este ``reprezentată'' contează enorm cu privire la modul în care informațiile legate de aceste sarcini ulterioare pot fi recuperate și utilizate eficient și efectiv. Aceasta ridică în mod natural o întrebare fundamentală: {\em ce face o reprezentare cu adevărat ``bună'' pentru utilizare ulterioară?} În cele ce urmează, vom explora proprietățile esențiale pe care o reprezentare semnificativă și utilă ar trebui să le posede și cum aceste proprietăți pot fi caracterizate și urmărite explicit prin maximizarea câștigului de informație.
+
+\paragraph{Cum să măsurăm calitatea reprezentărilor.}
+Se poate vedea un set de date dat ca eșantioane ale unui vector aleator $\x$ cu o anumită distribuție într-un spațiu cu dimensiuni înalte, să zicem $\mathbb{R}^D$. De obicei, distribuția lui $\x$ are o dimensiune intrinsecă mult mai mică decât spațiul ambiental. În general, {\em învățarea unei reprezentări} se referă la învățarea unei mapări continue, să zicem $f(\cdot)$, care transformă $\x$ într-un așa-numit {\em vector de caracteristici} $\z$ într-un alt spațiu (de obicei cu dimensiuni mai mici), să zicem $\mathbb{R}^d$, unde $d < D$. Se speră că prin o astfel de mapare
+\begin{equation}
+	\x \in \mathbb{R}^D \xrightarrow{\hspace{2mm} f(\x)\hspace{2mm}} \z  \in \mathbb{R}^d,
+	\label{eqn:chap4-1-encoding}
+\end{equation}
+structurile intrinseci cu dimensiuni reduse ale lui $\x$ sunt identificate și reprezentate de $\z$ într-un mod mai compact și structurat pentru a facilita sarcinile ulterioare precum clasificarea sau generarea. Caracteristica $\z$ poate fi văzută ca un cod (învățat) compact pentru datele originale $\x$, astfel încât maparea $f$ este numită și \textit{codificator}.
+Întrebarea fundamentală a învățării reprezentărilor este
+\begin{center}
+	\noindent{\em Care este o măsură principială și eficientă pentru calitatea reprezentărilor?}
+\end{center}
+
+Conceptual, calitatea unei reprezentări $\z$ depinde de cât de bine identifică informația cea mai relevantă și suficientă a lui $\x$ pentru sarcinile ulterioare și cât de eficient reprezintă această informație.
+Pentru mult timp, s-a crezut și s-a argumentat că „suficiența" sau „calitatea" unei reprezentări de caracteristici învățate ar trebui să fie definită în termenii unei sarcini specifice. De exemplu, $\z$ trebuie doar să fie suficient pentru a prezice eticheta de clasă $\y$ într-o problemă de clasificare. Mai jos, să începem cu problema clasică a clasificării imaginilor și să argumentăm de ce o astfel de noțiune de „reprezentare" specifică sarcinii este limitată și trebuie să fie generalizată.
+
+\subsection{Reprezentări Discriminative Liniare}\label{subsec:LDR}
+
+Presupunem că $\bm{x} \in \mathbb{R}^D$ este un vector aleator extras dintr-un amestec de $K$ distribuții (componente) $\mathcal{D} = \{\mathcal{D}_k\}_{k=1}^K$. Dat un set finit de eșantioane i.i.d. $\X = [\x_1, \x_2, \ldots, \x_N] \in \Re^{D\times N}$ ale vectorului aleator $\bm x$, {\em căutăm o reprezentare bună} printr-o mapare continuă $f(\x): \mathbb{R}^D \rightarrow \mathbb{R}^d$ care captează structurile intrinseci ale lui $\x$ și facilitează cel mai bine sarcina ulterioară de clasificare.\footnote{Clasificarea este domeniul în care învățarea profundă a demonstrat succesul inițial, declanșând interesul exploziv pentru rețelele profunde. Deși studiul nostru se concentrează pe clasificare, credem că ideile și principiile pot fi generalizate natural la alte setări, cum ar fi regresia.} Pentru a ușura sarcina de învățare a distribuției $\mathcal{D}$, în setarea populară de clasificare supervizată, o etichetă de clasă adevărată (sau un cuvânt cod pentru fiecare clasă), reprezentată de obicei printr-un vector one-hot $\y_i \in \mathbb{R}^K$, este dată pentru fiecare eșantion $\x_i$.
+
+\paragraph{Codificarea informației de clasă prin entropie încrucișată.} Studii extinse au arătat că pentru multe seturi de date practice (de exemplu, imagini, audio și limbaje naturale), maparea (de codificare) de la datele $\bm{x}$ la eticheta sa de clasă $\bm{y}$ poate fi modelată eficient prin antrenarea unei rețele profunde,\footnote{Aici să nu ne îngrijorăm încă despre ce rețea ar trebui să folosim aici și de ce. Scopul aici este să luăm în considerare orice rețea profundă testată empiric. Vom lăsa justificarea arhitecturilor de rețea pentru următorul capitol.} notată aici ca $$f(\x, \theta):\x \mapsto \y$$ cu parametrii rețelei $\theta \in \Theta$, unde $\Theta$ denotă spațiul parametrilor. Pentru ca ieșirea $f(\x, \theta)$ să se potrivească bine cu eticheta $\y$, dorim să minimizăm {\em pierderea de entropie încrucișată} pe un set de antrenare $\{(\x_i, \y_i)\}_{i=1}^N$:
+\begin{equation}
+   \min_{\theta \in \Theta} \; - \mathbb{E}[\langle \y, \log(f(\x, \theta)) \rangle] \, \approx - \frac{1}{N}\sum_{i=1}^N \langle \y_i, \log\left(f(\x_i, \theta)\right) \rangle.
+   \label{chap4-eqn:cross-entropy}
+\end{equation}
+Parametrii optimi ai rețelei $\theta$ sunt găsiți de obicei prin optimizarea obiectivului de mai sus printr-o schemă eficientă de coborâre a gradientului, cu gradienții calculați prin propagare înapoi (BP), așa cum este descris în \Cref{app:BP-section} din \Cref{app:optimization}.
+
+În ciuda eficacității și popularității sale enorme, există două limitări serioase cu această abordare: 1) Își propune doar să prezică etichetele $\y$ chiar dacă ar putea fi etichetate greșit. Studiile empirice arată că rețelele profunde, folosite ca o „cutie neagră", pot chiar să se potrivească cu etichete aleatoare~\cite{zhang2017understanding}.
+2) Cu o astfel de potrivire a datelor de la capăt la capăt, în ciuda multor eforturi empirice în încercarea de a interpreta caracteristicile învățate astfel, nu este clar în ce măsură caracteristicile intermediare învățate de rețea captează structurile intrinseci ale datelor care fac posibilă clasificarea semnificativă în primul rând. Proprietățile geometrice și statistice precise ale caracteristicilor învățate sunt de asemenea adesea obscure, ceea ce duce la lipsa de interpretabilitate și garanții de performanță ulterioare (de exemplu, generalizabilitate, transferabilitate și robustețe etc.) în învățarea profundă.
+Prin urmare, {\em unul dintre obiectivele acestei secțiuni este să abordeze astfel de limitări prin reformularea obiectivului către învățarea de reprezentări explicite semnificative și utile pentru datele $\x$, nu limitate la clasificare.}
+
+\begin{figure}
+	\centering
+	\includegraphics[width=0.95\linewidth]{\toplevelprefix/chapters/chapter3/figs/neural_collapse.pdf}
+	\caption{Evoluția ieșirilor stratului penultim ale unei rețele neuronale VGG13 când este antrenată pe setul de date CIFAR10 cu 3 clase selectate aleatoriu. Figura din \cite{papyan2020prevalence}.}
+	\label{chap4-fig:neural-collapse}
+\end{figure}
+
+\paragraph{Caracteristici discriminative minime prin gâtuire informațională.}
+O abordare populară pentru a interpreta rolul rețelelor profunde este de a vedea ieșirile straturilor intermediare ale rețelei ca selectând anumite caracteristici latente $\z = f(\x, \theta) \in \Re^d$ ale datelor care sunt discriminative între mai multe clase. Reprezentările învățate $\z$ facilitează apoi sarcina ulterioară de clasificare pentru prezicerea etichetei de clasă $\y$ prin optimizarea unui clasificator $g(\z)$:
+\begin{equation}
+	\x   \xrightarrow{\hspace{2mm} f(\x, \theta)\hspace{2mm}} \z  \xrightarrow{\hspace{2mm} g(\z) \hspace{2mm}} \y.
+\end{equation}
+Știm din teoria informației~\cite{Cover-Thomas} că {\em informația mutuală} între două variabile aleatoare, să zicem $\x,\z$, este definită ca fiind
+\begin{equation}
+	I(\x; \z) = H(\x) - H(\x\mid \z),
+\end{equation}
+unde $H(\x \vert \z)$ este entropia condiționată a lui $\x$ dat $\z$. Informația mutuală este cunoscută și ca {\em câștigul de informație}: Măsoară cu cât poate fi redusă entropia variabilei aleatoare $\x$ odată ce $\z$ este dat. Sau echivalent, măsoară câtă informație conține $\z$ despre $\x$. Formularea {\em gâtuirii informaționale} (IB) \cite{Tishby-ITW2015} presupune în plus că rolul rețelei este să învețe $\z$ ca statistica minimă suficientă pentru prezicerea lui $\y$. Formal, caută să maximizeze informația mutuală $I(\z, \y)$ între $\z$ și $\y$ în timp ce minimizează informația mutuală $I(\x, \z)$ între $\x$ și $\z$:
+\begin{equation}
+	\max_{\theta\in \Theta}\; \mbox{IB}(\x, \y, \z) \doteq I(\z; \y) - \beta I(\x; \z) \quad\ \mathrm{s.t.}\ \z = f(\x, \theta),
+	\label{chap4-eqn:information-bottleneck}
+\end{equation}
+unde $\beta >0$.
+
+Având în vedere că se pot depăși unele avertismente asociate cu acest cadru \cite{kolchinsky2018caveats-ICLR2018}, cum ar fi modul de a evalua cu precizie informația mutuală cu eșantioane finite de distribuții degenerate, acest cadru poate fi util în explicarea anumitor comportamente ale rețelelor profunde.
+De exemplu, lucrările recente \cite{papyan2020prevalence} arată într-adevăr că reprezentările învățate prin pierderea de entropie încrucișată \eqref{chap4-eqn:cross-entropy} prezintă un fenomen de \emph{colaps neural}.
+Adică, caracteristicile fiecărei clase sunt mapate la un vector unidimensional, în timp ce toate celelalte informații ale clasei sunt suprimate, așa cum este ilustrat în \Cref{chap4-fig:neural-collapse}.
+\begin{remark}
+    Colapsul neural se referă la un fenomen observat în rețelele neuronale profunde antrenate pentru clasificare, unde reprezentările de caracteristici învățate și ponderile clasificatorului prezintă un comportament extrem de simetric și structurat în timpul fazei terminale de antrenare \cite{papyan2020prevalence,zhu2021geometric}. În mod specific, în cadrul fiecărei clase, caracteristicile colapsează la media lor de clasă, iar între clase, aceste medii devin maxim separate, formând o configurație echiangulară simplă. Clasificatorul liniar se aliniază cu media clasei până la rescalare. În plus, clasificatorul de ultim strat converge pentru a alege orice clasă are cea mai apropiată medie de clasă de antrenare. Colapsul neural dezvăluie conexiuni profunde între dinamica optimizării, generalizarea și structurile geometrice care apar în învățarea supervizată.
+\end{remark}
+
+Din exemplul de mai sus al clasificării, vedem că reprezentarea învățată astfel oferă un codificator foarte simplu care în esență mapează fiecare clasă de date la un singur cuvânt cod: vectorul one-hot reprezentând fiecare clasă. Din perspectiva compresiei cu pierderi, un astfel de codificator are prea multe pierderi pentru a păstra informații în distribuția datelor. Alte informații, cum ar fi cele utile pentru sarcini precum generarea de imagini, sunt pierdute sever într-un astfel de proces de învățare supervizată. Pentru a remedia această situație, dorim să învățăm o schemă de codificare diferită astfel încât reprezentarea de caracteristici rezultată să poată captura informații mult mai bogate despre distribuția datelor, nu limitate doar la cele utile pentru clasificare.
+
+\begin{figure}[ht]
+	\centering
+	\includegraphics[width=0.99\linewidth]{\toplevelprefix/chapters/chapter3/figs/Expansion2.png}
+	\caption{După identificarea distribuției de date cu dimensiuni reduse, am dori să transformăm în continuare distribuția datelor într-o reprezentare cu structură mai informativă: $R$ este numărul de bile de $\epsilon$ care acoperă întregul spațiu și $R^c$ este suma numerelor pentru toate subspațiile (bilele verzi). $\Delta R$ este diferența lor (numărul de bile albastre).}\label{fig:sphere-packing}
+	\label{fig:informative-representation}
+\end{figure}
+
+\paragraph{Reprezentări discriminative liniare.}
+Dacă datele date $\X$ ale unei distribuții mixte $\mathcal{D}$ pot fi clasificate sau grupate efectiv depinde de cât de separabile (sau discriminative) sunt (sau pot fi făcute) distribuțiile componente $\mathcal{D}_k$. O ipoteză de lucru populară este că distribuția fiecărei clase are structuri intrinseci relativ {\em cu dimensiuni reduse}. Prin urmare, putem presupune că distribuția $\mathcal{D}_k$ a fiecărei clase are un suport pe o subvarietate cu dimensiuni reduse, să zicem $\mathcal{M}_k$ cu dimensiunea $d_k \ll D$, iar distribuția $\mathcal D$ a lui $\x$ este suportată pe amestecul acelor subvarietăți, $\mathcal M = \cup_{k=1}^K \mathcal{M}_k$, în spațiul ambiental cu dimensiuni înalte $\Re^D$.
+
+Nu numai că trebuie să identificăm distribuția cu dimensiuni reduse, dar vrem și să reprezentăm distribuția într-o formă care facilitează cel mai bine sarcinile ulterioare precum clasificarea, gruparea și generarea condiționată (cum vom vedea în viitor). Pentru a face acest lucru, cerem ca reprezentările noastre de caracteristici învățate să aibă următoarele proprietăți:
+\begin{enumerate}
+	\item {\em Compresibile în cadrul clasei:} Caracteristicile eșantioanelor din aceeași clasă ar trebui să fie puternic {\em corelate} în sensul că aparțin unui subspațiu liniar cu dimensiuni reduse.
+	\item {\em Discriminative între clase:} Caracteristicile eșantioanelor din clase diferite ar trebui să fie foarte {\em necorelate} și să aparțină unor subspații liniare cu dimensiuni reduse diferite.
+	\item {\em Reprezentare maxim diversă:} Dimensiunea (sau varianța) caracteristicilor fiecărei clase ar trebui să fie {\em cât mai mare posibil} atât timp cât sunt incoerente cu celelalte clase.
+\end{enumerate}
+Ne referim la o astfel de reprezentare ca {\em reprezentare discriminativă liniară} (LDR). Observați că prima proprietate se aliniază bine cu obiectivul clasicei {\em analize a componentelor principale} (PCA) pe care am discutat-o în \Cref{sub:pca}. A doua proprietate seamănă cu cea a clasicei {\em analize discriminante liniare} (LDA)~\cite{HastieTiFr09}. Figura \ref{fig:informative-representation} ilustrează aceste proprietăți cu un exemplu simplu când distribuția datelor este de fapt un amestec de două subspații. Prin compresie (denoising sau grupare), identificăm mai întâi că distribuția adevărată a datelor este un amestec de două subspații cu dimensiuni reduse (mijloc) în loc de o distribuție gaussiană generică (stânga). Apoi am dori să transformăm distribuția astfel încât cele două subspații să devină în cele din urmă mutual incoerente/independente (dreapta).
+
+\begin{remark}
+    Analiza discriminantă liniară (LDA)~\cite{HastieTiFr09} este o tehnică de reducere a dimensionalității supervizată care își propune să găsească o proiecție liniară a datelor care maximizează separabilitatea claselor. În mod specific, date fiind date etichetate, LDA caută o transformare liniară care proiectează intrările cu dimensiuni înalte pe un spațiu cu dimensiuni mai mici unde clasele sunt maxim separate. Rețineți că PCA este o metodă nesupervizată care proiectează datele pe direcțiile de varianță maximă fără a lua în considerare etichetele de clasă. În timp ce PCA se concentrează pur pe păstrarea structurii de varianță globală, LDA exploatează explicit informațiile etichetei pentru a îmbunătăți puterea discriminativă; vezi comparația din \Cref{fig:LDA}.
+\end{remark}
+
+\begin{figure}
+	\centering
+	\includegraphics[width=0.7\linewidth]{\toplevelprefix/chapters/chapter3/figs/LDA.png}\vspace{-0.1in}
+	\caption{Comparație între PCA și LDA. Figuri adoptate de la \url{https://sebastianraschka.com/Articles/2014_python_lda.html}.}
+	\label{fig:LDA}
+\end{figure}
+
+A treia proprietate este de asemenea importantă deoarece dorim ca caracteristicile învățate să dezvăluie toate cauzele posibile pentru care o clasă este diferită de toate celelalte clase. De exemplu, pentru a distinge „măr" de „portocală", ne pasă nu doar de culoare, ci și de formă și frunze. În mod ideal, dimensiunea fiecărui subspațiu $\{\mathcal{S}_k\}$ ar trebui să fie egală cu cea a subvarietății corespunzătoare $\mathcal{M}_k$. Această proprietate va fi importantă dacă am dori ca harta $f(\x,\theta)$ să fie {\em inversabilă} pentru sarcini precum generarea de imagini. De exemplu, dacă extragem diferite puncte de eșantion din subspațiul de caracteristici pentru „măr", ar trebui să putem să le decodificăm pentru a genera imagini diverse de mere. Caracteristica învățată din minimizarea entropiei încrucișate \eqref{chap4-eqn:cross-entropy} clar nu are această proprietate.
+
+În general, deși structurile intrinseci ale fiecărei clase/cluster pot fi cu dimensiuni reduse, ele nu sunt în niciun caz pur și simplu liniare (sau gaussiene) în reprezentarea lor originală $\x$ și trebuie să fie făcute liniare mai întâi, printr-o transformare neliniară.\footnote{Vom discuta cum se poate face acest lucru explicit în \Cref{ch:autoencoding}.} Prin urmare, în general, folosim transformarea neliniară $f(\x,\theta)$ pentru a căuta o reprezentare a datelor astfel încât subspațiile care reprezintă toate clasele să fie subspații liniare maxim incoerente. Pentru a fi mai preciși, vrem să învățăm o mapare {$\z = f(\x,\theta)$} care mapează fiecare dintre subvarietățile $\mathcal{M}_k \subset \Re^D$ (\Cref{chap4-fig:mcr-diagram} stânga) la un subspațiu {\em liniar} $\mathcal{S}_k \subset \Re^d$ (\Cref{chap4-fig:mcr-diagram} dreapta). Într-o anumită măsură, subspațiile multiple rezultate $\{\mathcal{S}_k\}$ pot fi văzute ca {\em componente principale generalizate} discriminative \cite{GPCA} sau, dacă sunt ortogonale, {\em componente independente} \cite{hyvarinen2000independent} ale caracteristicilor rezultate $\z$ pentru datele originale $\bm x$.
+După cum vom vedea în următorul \Cref{ch:representation}, rețelele profunde joacă exact rolul de modelare și realizare a acestei transformări neliniare de la distribuția datelor la reprezentări discriminative liniare.
+
+\subsection{Principiul Reducerii Maxime a Ratei de Codare}\label{subsec:MCR2}
+
+Deși cele trei proprietăți---{\em discriminative între clase}, {\em compresibile în cadrul clasei} și {\em reprezentare maxim diversă}---pentru reprezentările discriminative liniare (LDR) sunt toate proprietăți foarte dorite ale reprezentării învățate $\z$, ele nu sunt în niciun caz ușor de obținut: Sunt aceste proprietăți compatibile astfel încât să ne putem aștepta să le obținem pe toate odată? Dacă da, există un obiectiv {\em simplu dar principial} care poate măsura calitatea reprezentărilor rezultate în termenii tuturor acestor proprietăți? Cheia acestor întrebări {este să găsim} o „măsură principială de compactitate" sau „câștig de informație" pentru distribuția unei variabile aleatoare $\z$ sau din eșantioanele sale finite $\{\bm z_i\}_{i=1}^N$. O astfel de măsură ar trebui să caracterizeze direct și precis proprietățile geometrice sau statistice intrinseci ale distribuției, în termenii dimensiunii sau {volumului} său intrinsec. Spre deosebire de entropia încrucișată \eqref{chap4-eqn:cross-entropy} sau gâtuirea informațională \eqref{chap4-eqn:information-bottleneck}, o astfel de măsură nu ar trebui să depindă exclusiv de etichetele de clasă, astfel încât să poată funcționa în setări mai generale precum setări supervizate, auto-supervizate, semi-supervizate și nesupervizate.
+
+\begin{figure}
+	\centering
+	\includegraphics[width=0.8\linewidth]{\toplevelprefix/chapters/chapter3/figs/mcr_diagram.png}
+	\caption{Distribuția $\mathcal D$ a datelor cu dimensiuni înalte $\x\in \Re^D$ este suportată pe o varietate $\mathcal{M}$ și clasele sale pe subvarietăți cu dimensiuni reduse $\mathcal{M}_k$. Ne propunem să învățăm o mapare $f(\x, \theta)$ parametrizată de $\theta$ astfel încât $\z_i = f(\x_i, \theta)$ să se afle pe o uniune de subspații maxim necorelatși $\{\mathcal{S}_k\}$.}
+	\label{chap4-fig:mcr-diagram}
+\end{figure}
+
+Fără pierdere de generalitate, presupunem că distribuția $\mathcal D$ a vectorului aleator $\x$ este suportată pe un amestec de distribuții, adică $\mathcal D = \cup_{k=1}^K \mathcal{D}_k$, unde fiecare $\mathcal{D}_k \subset \Re^D$ are o dimensiune intrinsecă scăzută în spațiul ambiental cu dimensiuni înalte $\Re^D$. Fie $\bm X_k \in \Re^{D\times N_k}$ matricea de date ale cărei coloane sunt eșantioane extrase din distribuția $\mathcal{D}_k$, unde $N_k$ denotă numărul de eșantioane pentru fiecare $k=1,\dots,K$. Apoi, folosim $\bm X=[\bm X_1,\dots,\bm X_K] \in \Re^{D\times N}$ pentru a denota toate eșantioanele, unde $N=\sum_{k=1}^K N_k$.
+Amintim că folosim și $\vx_i$ pentru a denota al $i$-lea eșantion al lui $\X$, adică $\X=[\vx_1,\dots,\vx_N]$. Sub o mapare de codificare:
+\begin{equation}
+	\x   \xrightarrow{\hspace{2mm} f(\x)\hspace{2mm}} \z,
+\end{equation}
+eșantioanele de intrare sunt mapate la $\vz_i = f(\vx_i)$ pentru fiecare $i=1,\dots,N$. Cu un abuz de notație, scriem și $\Z_k = f(\X_k)$ și $\Z = f(\X)$. Prin urmare, avem $\Z = [\bm Z_1,\dots,\bm Z_K]$ și $\Z = [\vz_1,\dots\vz_N]$.
+
+Pe de o parte, pentru ca caracteristicile învățate să fie discriminative, caracteristicile diferitelor clase/clustere sunt preferate să fie {\em maxim incoerente} între ele. Prin urmare, împreună ar trebui să acopere un spațiu cu cel mai mare volum posibil (sau dimensiune) și rata de codare a întregului set $\Z$ ar trebui să fie cât mai mare posibil. Pe de altă parte, caracteristicile învățate ale aceleiași clase/cluster ar trebui să fie foarte corelate și coerente. Prin urmare, fiecare clasă/cluster ar trebui să acopere doar un spațiu (sau subspațiu) cu un volum foarte mic și rata de codare ar trebui să fie cât mai mică posibil. Acum, vom introduce cum să măsurăm rata de codare a caracteristicilor învățate.
+
+\paragraph{Rata de codare a caracteristicilor.} În mod notabil, o provocare practică în evaluarea ratei de codare este că distribuția de bază a reprezentărilor de caracteristici $\Z$ este de obicei necunoscută. Pentru a aborda acest lucru, putem aproxima caracteristicile $\Z = [\z_1, \ldots, \z_N]$ ca eșantioane extrase dintr-o distribuție gaussiană multivariată. Sub această ipoteză, așa cum s-a discutat în \Cref{subsec:lossy DR}, compactitatea caracteristicilor $\Z$ {\em ca întreg} poate fi măsurată în termenii lungimii medii de codare pe eșantion, denumită {\em rata de codare}, supusă unui nivel de precizie $\epsilon > 0$ (vezi \eqref{eqn:rate-Gaussian}) definită după cum urmează:
+\begin{equation}
+	R_{\epsilon}(\Z) = \frac{1}{2}\log\det\left(\I + \frac{d}{N\epsilon^{2}}\Z\Z^{\top}\right).
+	\label{chap4-eqn:coding-length-eval}
+\end{equation}
+
+Pe de altă parte, sperăm că o transformare neliniară $f(\x)$ mapează fiecare subvarietate specifică clasei $\mathcal{M}_k \subset \mathbb{R}^D$ la un subspațiu liniar maxim incoerent $\mathcal{S}_k \subset \mathbb{R}^d$ astfel încât caracteristicile învățate $\Z$ să se afle într-o uniune de subspații cu dimensiuni reduse. Această structură permite o evaluare mai precisă a ratei de codare prin analizarea fiecărui subspațiu separat.
+Amintim că coloanele lui $\Z_k$ denotă caracteristicile eșantioanelor din $\X_k$ pentru fiecare $k=1,\dots,K$. Rata de codare pentru caracteristicile din $\bm Z_k$ poate fi calculată după cum urmează:
+\begin{align}
+    R_{\epsilon}(\Z_k) = \frac{N_k}{2N}\log\det\left(\I + \frac{d}{N_k\epsilon^{2}}\Z_k\Z_k^{\top}\right)
+\end{align}
+Apoi, suma ratelor medii de codare ale caracteristicilor din fiecare clasă este
+\begin{equation}
+	 R_{\epsilon}^c(\Z) \doteq \sum_{k=1}^K R_{\epsilon}(\Z_k),
+	\label{chap4-eqn:compress-loss-eval}
+\end{equation}
+
+Prin urmare, o reprezentare bună $\Z$ a lui $\X$ este cea care realizează o diferență mare între rata de codare pentru întreg și cea pentru toate clasele:
+\begin{equation}
+	\Delta R_{\epsilon}(\Z) \doteq R_{\epsilon}(\Z) - R_{\epsilon}^c(\Z).
+	\label{chap4-eqn:coding-length-reduction}
+\end{equation}
+Observați că, conform discuțiilor noastre anterioare din acest capitol, această diferență poate fi interpretată ca cantitatea de „informație câștigată" prin identificarea clusterelor corecte cu dimensiuni reduse $\Z_k$ în cadrul setului general $\Z$.
+
+Dacă alegem maparea noastră de caracteristici $f(\cdot)$ să fie o rețea neuronală profundă $f(\cdot,\theta)$ cu parametrii rețelei $\theta$, procesul general al reprezentării caracteristicilor și reducerea ratei rezultată pot fi ilustrate prin următoarea diagramă:
+\begin{equation}
+	\X
+	\xrightarrow{\hspace{2mm} f(\x, \theta)\hspace{2mm}} \Z  \xrightarrow{\hspace{2mm} \epsilon \hspace{2mm}} \Delta R_{\epsilon}(\Z).
+	\label{chap4-eqn:flow}
+\end{equation}
+Rețineți că $\Delta R_{\epsilon}$ este {\em monotonă} în scala caracteristicilor $\Z$. Pentru a asigura o comparație corectă între diferite reprezentări, este esențial să {\em normalizăm scala} caracteristicilor învățate. Aceasta poate fi realizată fie prin impunerea normei Frobenius a fiecărei clase $\Z_k$ să scaleze cu numărul de caracteristici din $\Z_k \in \mathbb R^{d \times N_k}$, adică $\|\Z_k\|_F^2 = N_k$, sau prin normalizarea fiecărei caracteristici să fie pe sfera unitară, adică $\z_i \in \mathbb{S}^{d-1}$, unde $N_k=\mathrm{tr}(\bm \Pi_k)$ denotă numărul de eșantioane din clasa $k$. Această formulare oferă o justificare naturală pentru necesitatea „normalizării pe loturi" în practica antrenării rețelelor neuronale profunde \cite{ioffe2015batch}.
+
+Odată ce reprezentările sunt comparabile, obiectivul devine să învățăm un set de caracteristici $\Z = f(\X, \theta)$ astfel încât să maximizeze reducerea între rata de codare a tuturor caracteristicilor și cea a sumei caracteristicilor în raport cu clasele lor:
+\begin{equation}
+	\begin{aligned}
+		\max_{\theta } & \;  \Delta R_{\epsilon}\big(\Z \big) \doteq R_{\epsilon}(\Z) - R_{\epsilon}^c(\Z ), \\
+		\mbox{s.c.} & \ \ \, \Z = f(\bm X, \theta),\  \|\Z_k\|_F^2 = N_k,\ k=1,\dots,K. 
+	\end{aligned}
+	\label{eqn:maximal-rate-reduction}
+\end{equation}
+Ne referim la aceasta ca principiul {\em reducerii maxime a ratei de codare} (MCR$^2$), o întruchipare adevărată a celebrului citat al lui Aristotel:
+\begin{quote}
+	\centering
+	„{\em Întregul este mai mare decât suma părților sale.}"
+\end{quote}
+Pentru a învăța cea mai bună reprezentare, cerem ca {\em întregul să fie maxim mai mare decât suma părților sale}. Să examinăm din nou exemplul arătat în \Cref{fig:informative-representation}. Din perspectiva compresiei, reprezentarea din dreapta este {\em cea mai compactă} în sensul că diferența dintre rata de codare când toate caracteristicile sunt codificate ca o singură gaussiană (albastru) și cea când caracteristicile sunt grupate corespunzător și codificate ca două subspații separate (verde) este maximă.\footnote{Intuitiv, raportul dintre „volumul" întregului spațiu acoperit de toate caracteristicile și cel efectiv ocupat de caracteristici este maxim.}
+
+Rețineți că principiul MCR$^2$ de mai sus este proiectat pentru probleme de învățare supervizată, unde apartenența la grup (sau etichetele de clasă) sunt cunoscute. Cu toate acestea, acest principiu poate fi extins natural la probleme de învățare nesupervizată prin introducerea unei matrici de apartenență, care codifică atribuirea (potențial slabă) a fiecărui punct de date la grupuri sau clustere latente. În mod specific, fie $\bm \Pi = \{\bm \Pi_k\}_{k=1}^K \subset \R^{N\times N}$ un set de matrici diagonale ale căror intrări diagonale codifică apartenența celor $N$ eșantioane în $K$ clase. Adică, $\bm \Pi$ se află într-un simplex $\Omega \doteq \{\bm \Pi: \bm \Pi_k \ge \bm 0: \sum_{k=1}^K \bm \Pi_k = \bm I_N\}$. Apoi, putem defini rata medie de codare în raport cu partiția $\bm \Pi$ ca
+\begin{align}\label{eq:MCRc}
+    R_{\epsilon}^c(\Z \mid \bm \Pi) \doteq \sum_{k=1}^K \frac{\mathrm{tr}(\bm \Pi_k)}{2N}\log\det\left(\bm I + \frac{d}{\mathrm{tr}(\bm \Pi_k)\epsilon^2}\bm Z\bm \Pi_k \bm Z^\top \right).
+\end{align}
+Când $\bm Z$ este dat, $R_{\epsilon}^c(\Z \vert \bm \Pi)$ este o funcție concavă a lui $\bm \Pi$. Atunci principiul MCR$^2$ pentru probleme de învățare nesupervizată devine următorul:
+\begin{align}\label{eq:MCR-pi}
+    \max_{\bm \Pi, \theta} & \  \Delta R_{\epsilon}\big(\Z  \mid \bm \Pi) \doteq R_{\epsilon}(\bm Z) - R_{\epsilon}^c(\Z \mid \bm \Pi) \notag \\ 
+   \mathrm{s.c.}  & \ \ \ \bm Z = f(\bm X, \theta),\ \|\bm Z \bm \Pi_k\|_F^2 = N_k,\ k = 1,\dots,K,\ \bm\Pi \in \Omega.
+
+\end{align}
+Comparativ cu \eqref{eqn:maximal-rate-reduction}, formularea de aici permite optimizarea comună atât a apartenenței la grup, cât și a parametrilor rețelei. În special, când $\bm \Pi$ este fixat la o matrice de apartenență la grup care atribuie $N$ puncte de date în $K$ grupuri, această problemă poate recupera Problema \eqref{eqn:maximal-rate-reduction}.
+
+\begin{figure}[t]
+	\centering
+	\includegraphics[width=0.8\linewidth]{\toplevelprefix/chapters/chapter3/figs/mcr2-global.png}
+	\caption{{\bf Peisaj local de optimizare:} Conform Teoremei \ref{thm:MCR2-properties}, maximul global al obiectivului de reducere a ratei corespunde unei soluții cu subspații mutual incoerente.}
+	\label{fig:mcr-global}
+\end{figure}
+
+\vspace{-0.1in}
+
+\subsection{Proprietăți de Optimizare ale Reducerii Ratei de Codare}
+\label{sec:MCR-landscape}
+
+În această subsecțiune, studiem proprietățile de optimizare ale funcției MCR$^2$ prin analizarea soluțiilor sale optime și a structurii peisajului său de optimizare. Pentru a evita dificultatea tehnică introdusă de rețelele neuronale, considerăm o versiune simplificată a Problemei \eqref{eqn:maximal-rate-reduction} după cum urmează:
+\begin{align}\label{eqn1:maximal-rate-reduction}
+    \max_{\bm Z}\ R_{\epsilon}(\Z) - R_{\epsilon}^c(\Z)\qquad \mathrm{s.c.}\quad \|\bm Z_k\|_F^2 = N_k,\ k =1,\dots,K. 
+\end{align}
+În teorie, principiul MCR$^2$ \eqref{eqn1:maximal-rate-reduction} beneficiază de o mare generalizabilitate și poate fi aplicat reprezentărilor $\Z$ ale {\em oricăror} distribuții atâta timp cât ratele $R_\epsilon$ și $R^c_\epsilon$ pentru distribuții pot fi evaluate precis și eficient. Reprezentarea optimă $\Z^{\ast}$ ar trebui să aibă unele proprietăți geometrice și statistice interesante. Aici dezvăluim proprietăți frumoase ale reprezentării optime cu cazul special al subspațiilor, care au multe cazuri de utilizare importante în învățarea automată. Când reprezentarea dorită pentru $\Z$ este mai multe subspații, ratele $R_\epsilon$ și $R^c_\epsilon$ în \eqref{eqn1:maximal-rate-reduction} sunt date de \eqref{chap4-eqn:coding-length-eval} și \eqref{chap4-eqn:compress-loss-eval}, respectiv. La reducerea maximă a ratei, MCR$^2$ își atinge reprezentările optime, notate ca $\Z^{\ast} = [\Z_1^*,\dots,\Z_K^*]$ cu $\rank{(\Z_{k}^*)}\le d_k$. Se poate arăta că $\Z^{\ast}$ are următoarele proprietăți dorite (vezi \cite{yu2020learning} pentru o declarație formală și demonstrații detaliate).
+
+\begin{theorem}[\bf Caracterizarea Soluțiilor Optime Globale]
+	Presupunem că $\Z^{\ast} = [\Z_1^*,\dots,\Z_K^*]$ este o soluție optimă globală a Problemei~\eqref{eqn1:maximal-rate-reduction}. Următoarele afirmații sunt valabile:
+	\begin{itemize}
+		\item {\em Discriminativă între clase}: Atâta timp cât spațiul ambiental este adecvat de mare ($d \ge \sum_{k=1}^{K} d_k$), subspațiile sunt toate ortogonale între ele, {\em adică}, $(\Z_{k}^*)^{\top} \Z_{l}^* = \bm{0}$ pentru $k \not= l$.
+		\item {\em Reprezentare maxim diversă}:
+		      Atâta timp cât precizia de codare este adecvat de înaltă, adică $\epsilon ^4 < c\cdot \min_{k}\left\{ \frac{N_k}{N}\frac{d^2}{d_k^2}\right\}$, unde $c>0$ este o constantă. Fiecare subspațiu își atinge dimensiunea maximă, adică $\mathrm{rank}{(\Z_{k}^*)}= d_k$. În plus, cele mai mari $d_k-1$ valori singulare ale lui $\Z_{k}^*$ sunt egale.
+		      \label{thm:MCR2-properties}
+	\end{itemize}
+\end{theorem}
+
+Această teoremă indică faptul că principiul MCR$^2$ promovează încorporarea datelor în mai multe subspații independente (așa cum este ilustrat în \Cref{fig:mcr-global}), cu caracteristici distribuite {\em izotropic} în fiecare subspațiu (cu excepția posibil a unei dimensiuni). În mod notabil, această teoremă confirmă, de asemenea, că caracteristicile învățate prin principiul MCR$^2$ prezintă proprietățile discriminative cu dimensiuni reduse dorite discutate în \Cref{subsec:LDR}. În plus, dintre toate aceste reprezentări discriminative, preferă pe cea cu cele mai mari dimensiuni în spațiul ambiental. Aceasta este substanțial diferită de obiectivul gâtuirii informaționale~\eqref{chap4-eqn:information-bottleneck}.
+
+\begin{example}[Clasificarea Imaginilor pe CIFAR-10]
+	Aici prezentăm cum obiectivul MCR$^2$ ajută la învățarea unor reprezentări mai bune decât entropia încrucișată \eqref{chap4-eqn:cross-entropy} pentru clasificarea imaginilor. Aici adoptăm arhitectura populară de rețea neuronală, ResNet-18~\cite{he2016deep}, pentru a modela maparea de caracteristici $\z = f(\x,\theta)$. Optimizăm parametrii rețelei neuronale $\theta$ pentru a maximiza reducerea ratei de codare. Evaluăm performanța cu setul de date de clasificare a imaginilor CIFAR10~\cite{krizhevsky2009learning}.
+
+	\begin{figure}[t]
+		\begin{subfigure}[t]{0.42\textwidth}
+			\centering
+			\includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter3/figs/loss_log.pdf}
+			\caption{Evoluția lui $R_\epsilon$, $R^c_\epsilon$, $\Delta R_\epsilon$ în timpul procesului de antrenare.}
+			\label{fig:train-test-loss-pca-1}
+		\end{subfigure}
+		\hfill
+		\begin{subfigure}[t]{0.42\textwidth}
+			\centering
+			\includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter3/figs/pca_mainline.pdf}
+			\caption{PCA: {\small (\textbf{roșu}) date generale; (\textbf{albastru}) clase individuale}.}
+			\label{fig:train-test-loss-pca-3}
+		\end{subfigure}
+		\caption{\small Evoluția ratelor MCR$^2$ în procesul de antrenare, componentele principale ale caracteristicilor învățate.}
+		\label{fig:train-test-loss-pca}
+	\end{figure}
+
+	\begin{figure*}[b]
+		\begin{center}
+			\includegraphics[width=0.42\textwidth]{\toplevelprefix/chapters/chapter3/figs/heatmap_mcr2.pdf}
+			\hspace{0.25cm}
+			\includegraphics[width=0.42\textwidth]{\toplevelprefix/chapters/chapter3/figs/heatmap_ce.png}
+			\caption{\small Similaritate cosinus între caracteristicile învățate folosind obiectivul MCR$^2$ (\textbf{stânga}) și pierderea CE (\textbf{dreapta}).}
+			\label{fig:heatmap-plot}
+		\end{center}
+		\vskip -0.1in
+	\end{figure*}
+
+	\Cref{fig:train-test-loss-pca-1} ilustrează cum cele două rate și diferența lor (atât pentru datele de antrenare, cât și pentru cele de test) evoluează pe parcursul epocilor de antrenare: După o fază inițială, $R_\epsilon$ crește treptat în timp ce $R^c_\epsilon$ scade, indicând că caracteristicile $\bm Z$ se extind ca întreg în timp ce fiecare clasă $\bm Z_k$ este comprimată.
+	\Cref{fig:train-test-loss-pca-3} arată distribuția valorilor singulare pe $\Z_k$. \Cref{fig:heatmap-plot} arată similaritățile cosinus între caracteristicile învățate sortate pe clasă. Comparăm similaritățile caracteristicilor învățate folosind entropia încrucișată \eqref{chap4-eqn:cross-entropy} și obiectivul MCR$^2$ \eqref{eqn:maximal-rate-reduction}. Din grafice, se poate vedea clar că reprezentările învățate folosind pierderea MCR$^2$ sunt mult mai diverse decât cele învățate folosind pierderea de entropie încrucișată. Mai multe detalii ale acestui experiment pot fi găsite în \cite{chan2021redunet}.
+	\label{eg:Rate-Reduction-CIFAR10}
+\end{example}
+
+Cu toate acestea, a existat o lipsă aparentă de justificare a arhitecturilor de rețea folosite în experimentele de mai sus. Nu este încă clar de ce rețeaua adoptată aici (ResNet-18) este potrivită pentru reprezentarea hărții $f(\x, \theta)$, cu atât mai puțin pentru interpretarea operatorilor de strat și a parametrilor $\theta$ învățați în interior. În următorul capitol, {\em vom arăta cum să derivăm arhitecturile și componentele de rețea în întregime ca o „cutie albă" din obiectivul dorit (să zicem reducerea ratei)}.
+
+\paragraph{MCR$^2$ regularizat.}
+Teorema de mai sus caracterizează proprietățile optimelor globale ale obiectivelor de reducere a ratei. Dar ce se întâmplă cu alte optime, cum ar fi cele locale? Din cauza constrângerilor normei Frobenius, este o sarcină dificilă să analizăm Problema \eqref{eqn1:maximal-rate-reduction} dintr-o perspectivă teoretică de optimizare. Prin urmare, considerăm formularea Lagrangiană a \eqref{eqn1:maximal-rate-reduction}. Aceasta poate fi văzută ca o relaxare strânsă sau chiar o problemă echivalentă a \eqref{eqn1:maximal-rate-reduction} ale cărei soluții optime sunt de acord în setări specifice ale parametrului de regularizare; vezi \cite[Propozițiunea 1]{wang2024global}.
+În mod specific, formularea pe care o studiem, denumită de acum înainte ca {\textit{problema MCR$^2$ regularizată}}, este următoarea:
+\begin{align}\label{eq:MCR-reg}
+	\max_{\bm Z}\ R_{\epsilon}(\Z) - R_{\epsilon}^c(\Z) - \frac{\lambda}{2}\|\bm Z\|_F^2,
+\end{align}
+unde $\lambda > 0$ este parametrul de regularizare. Deși programul \eqref{eq:MCR-reg} este extrem de neconcav și implică inverse de matrice în calculul gradientului său, putem totuși caracteriza explicit optimele sale locale și globale după cum urmează.
+
+\begin{theorem}[\bf Optime Locale și Globale]\label{thm:mcr-global-opt}
+	Fie $N_k$ numărul de eșantioane de antrenare din clasa $k$ pentru fiecare $k \in \{1,\dots,K\}$, $N_{\max} \doteq \max\{N_1,\dots,N_K\}$, $\alpha=d/(N\epsilon^2)$, și $\alpha_{k} = d/(N_k\epsilon^2)$ pentru fiecare $k \in \{1,\dots,K\}$. Dată fiind o precizie de codare $\epsilon > 0$, dacă parametrul de regularizare satisface
+	\begin{align}\label{eq:lambda}
+		\lambda \in \left(0, \frac{d(\sqrt{N/N_{\max}}-1)}{N(\sqrt{N/N_{\max}}+1)\epsilon^2} \right],
+	\end{align}
+	atunci următoarele afirmații sunt valabile: \\
+	(i) ({\bf Maximizatori locali}) $\bm Z^* = \left[\bm Z_1^*,\dots,\bm Z_K^* \right]$ este un maximizator local al Problemei \eqref{eq:MCR-reg} dacă și numai dacă blocul $k$ admite următoarea descompunere
+	\begin{align}\label{eq:Zk opti}
+		\bm Z_k^* = \left(\frac{ \eta_k + \sqrt{\eta_k^2 - 4\lambda^2N/N_k}}{2\lambda \alpha_{k}}\right)^{1/2} \bm U_k \bm V_k^\top,
+	\end{align}
+	unde (a) $r_k = \mathrm{rank}(\bm Z_k^*)$ satisface $r_k \in [0,\min\{N_k,d\})$ și $\sum_{k=1}^K r_k \le \min\{N,d\}$, (b) $\bm U_k \in \mathcal{O}^{d \times r_k}$ satisface $\bm U_k^{\top}\bm U_l = \bm 0$ pentru toți $k \neq l$, $\bm V_k \in \mathcal{O}^{N_k \times r_k}$, și (c) $\eta_k=(\alpha_k-\alpha) - \lambda(N/N_k+1)$ pentru fiecare $k\in \{1,\dots,K\}$.
+	\\
+	(ii) ({\bf Maximizatori globali}) $\bm Z^* = \left[\bm Z_1^*,\dots,\bm Z_K^* \right]$ este un maximizator global al Problemei \eqref{eq:MCR-reg} dacă și numai dacă (a) satisface toate condițiile de mai sus și $\sum_{k=1}^K r_k = \min\{m,d\}$, și (b) pentru toți $k \neq l \in [K]$ satisfăcând $N_k < N_l$ și $r_l > 0$, avem $r_k = \min\{N_k,d\}$.
+\end{theorem}
+
+\begin{figure}[t]
+	\centering
+	\includegraphics[width=0.8\linewidth]{\toplevelprefix/chapters/chapter3/figs/mcr2-global-local.png}
+	\caption{{\bf Peisaj global de optimizare:} Conform \cite{sun2015nonconvex,lee2016gradient}, \Cref{thm:mcr-global-opt,thm:mcr-benign-opt-landscape}, atât maximele globale, cât și cele locale ale obiectivului (regularizat) de reducere a ratei corespund unei soluții cu subspații mutual incoerente. Toate celelalte puncte critice sunt puncte de șa stricte.}
+	\label{fig:mcr-global-local}
+\end{figure}
+
+Această teoremă caracterizează explicit optimele locale și globale ale problemei \eqref{eq:MCR-reg}. Intuitiv, aceasta arată că caracteristicile reprezentate de fiecare maximizator local al Problemei \eqref{eq:MCR-reg} sunt cu dimensiuni reduse și discriminative. Deși am caracterizat soluțiile optime locale și globale în Teorema~\ref{thm:mcr-global-opt}, rămâne necunoscut dacă aceste soluții pot fi calculate eficient folosind GD pentru a rezolva problema \eqref{eq:MCR-reg}, deoarece GD se poate bloca la alte puncte critice, cum ar fi un punct de șa.
+Din fericire, \cite{sun2015nonconvex,lee2016gradient} au arătat că dacă o funcție este de două ori continuu diferențiabilă și satisface {\em proprietatea de șa strictă}, adică fiecare punct critic este fie un minimizator local, fie un punct de șa strict\footnote{Spunem că un punct critic este un punct de șa strict al Problemei \eqref{eq:MCR-reg} dacă are o direcție cu curbură strict pozitivă~\cite{sun2015nonconvex}. Aceasta include puncte de șa clasice cu curbură strict pozitivă, precum și minimizatori locali.}, GD converge la minimizatorul său local aproape sigur cu inițializare aleatorie. Investigăm peisajul global de optimizare al problemei \eqref{eq:MCR-reg} prin caracterizarea tuturor punctelor sale critice după cum urmează.
+
+\begin{theorem}[\bf Peisaj Global de Optimizare Benign]\label{thm:mcr-benign-opt-landscape}
+	Dată fiind o precizie de codare $\epsilon > 0$, dacă parametrul de regularizare satisface \eqref{eq:lambda}, se susține că orice punct critic $\bm Z$ al problemei \eqref{eq:MCR-reg} este fie un maximizator local, fie un punct de șa strict.
+\end{theorem}
+Împreună, cele două teoreme de mai sus arată că caracteristicile învățate asociate cu fiecare maximizator local al obiectivului de reducere a ratei---nu doar maximizatorii globali---sunt structurate ca subspații incoerente cu dimensiuni reduse. Mai mult, obiectivul (regularizat) de reducere a ratei \eqref{eqn:maximal-rate-reduction} are un peisaj foarte benign cu doar maxime locale și șei stricte ca puncte critice, așa cum este ilustrat în \Cref{fig:mcr-global-local}.
+Conform \cite{sun2015nonconvex,lee2016gradient}, \Cref{thm:mcr-global-opt,thm:mcr-benign-opt-landscape} implică faptul că reprezentările cu dimensiuni reduse și discriminative (LDR) pot fi găsite eficient prin aplicarea coborârii gradientului (stochastic) la obiectivul de reducere a ratei \eqref{eqn:maximal-rate-reduction} din inițializare aleatorie. Aceste rezultate explică, de asemenea, indirect de ce în \Cref{eg:Rate-Reduction-CIFAR10}, dacă rețeaua aleasă este suficient de expresivă și antrenată bine, reprezentarea rezultată oferă de obicei o reprezentare liniară incoerentă care corespunde probabil soluției optime globale.
+Cititorii interesați sunt referiți la \cite{wang2024global} pentru demonstrații.
+
+\section{Rezumat și Note}
+
+Utilizarea denoising-ului și difuziei pentru eșantionare are o istorie bogată. Prima lucrare care este clar despre un model de difuzie este probabil \cite{Sohl-Dickstein2015}, dar înainte de aceasta există multe lucrări despre denoising ca problemă computațională și statistică. Cea mai relevantă dintre acestea este probabil \cite{hyvarinen05a}, care folosește explicit funcția de scor pentru denoising (precum și pentru a efectua analiza componentelor independente). Cele mai populare urmări sunt practic co-apărute: \cite{ho2020denoising,song2019}. De atunci, mii de lucrări s-au bazat pe modele de difuzie; vom revizita acest subiect în \Cref{ch:autoencoding}.
+
+Multe dintre aceste lucrări folosesc un proces stochastic diferit de combinația liniară simplă \eqref{eq:gen_additive_gaussian_noise_model}. De fapt, toate lucrările enumerate mai sus subliniază necesitatea de a adăuga zgomot gaussian \textit{independent} la începutul fiecărui pas al procesului înainte. Lucrarea orientată teoretic folosește de fapt mișcarea browniană sau ecuații diferențiale stochastice pentru a formula procesul înainte \cite{song2020score}. Cu toate acestea, deoarece combinațiile liniare de gaussiene rezultă tot în gaussiene, \textit{distribuțiile marginale} ale acestor procese iau încă forma \eqref{eq:gen_additive_gaussian_noise_model}. Cea mai mare parte a discuției noastre necesită doar ca distribuțiile marginale să fie ceea ce sunt, și prin urmare modelul nostru excesiv de simplist este de fapt destul pentru aproape totul. De fapt, singura dată când distribuțiile marginale nu sunt suficiente este când derivăm o expresie pentru \(\Ex[\vx_{s} \mid \vx_{t}]\) în termenii lui \(\Ex[\vx \mid \vx_{t}]\). Diferite procese (de zgomot) dau diferite astfel de expresii, care pot fi folosite pentru eșantionare (și desigur există și alte moduri de a deriva eșantionatoare eficiente, cum ar fi mereu popularul eșantionator DDPM). Procesul din \eqref{eq:gen_additive_gaussian_noise_model} este, totuși, un proces stochastic de bună credință, a cărui iterație de denoising „naturală" ia forma popularului algoritm DDIM \cite{song2020denoising}. (Chiar și această echivalență nu este trivială; cităm \cite{de2025distributional} ca justificare.)
+
+Pe lângă lucrarea teoretică \citep{li2024d} acoperită în \Cref{sec:denoising-intro}, și linia de lucrări pe care o construiește, care studiază eficiența de \textit{eșantionare} a modelelor de difuzie când datele au structură cu dimensiuni reduse, există un corp mare de lucrări care studiază eficiența de \textit{antrenare} a modelelor de difuzie când datele au structură cu dimensiuni reduse. În mod specific, \citet{chen2023score} și \citep{wang2024diffusion} au caracterizat eroarea de aproximare și estimare a denoiserilor când datele aparțin unui amestec de gaussiene de rang redus, arătând că numărul de eșantioane de antrenare necesare pentru a învăța cu precizie distribuția scalează cu dimensiunea intrinsecă a datelor mai degrabă decât cu distribuția ambientală. Există o lucrare \textit{metodologică} considerabilă care încearcă să utilizeze structura cu dimensiuni reduse a datelor pentru a face diverse lucruri cu modele de difuzie. Evidențiem trei aici: editarea imaginii \citep{chen2024exploring}, filigranul \citep{li2024shallow} și dezînvățarea \citep{chen2025dual}, deși, ca întotdeauna, aceasta este o listă neexhaustivă.
+
+\section{Exerciții și Extensii}
+
+\begin{exercise}
+    Vă rugăm să arătați că \eqref{eq:optimal_denoiser} este soluția optimă a Problemei \eqref{eq:denoising_loss}.
+\end{exercise}
+
+\begin{exercise}\label{exercise:conditional_gaussian}
+  Considerați vectorii aleatori $\vx \in \bR^D$ și $\vy \in \bR^d$, astfel încât perechea $(\vx, \vy) \in \bR^{D + d}$ este în comun gaussiană. Aceasta înseamnă că
+  \begin{equation*}
+    \begin{bmatrix}
+      \vx \\
+      \vy
+    \end{bmatrix}
+    \sim
+    \cN \left(
+      \begin{bmatrix}
+        \vmu_{\vx} \\
+        \vmu_{\vy}
+      \end{bmatrix}
+      ,
+      \begin{bmatrix}
+        \vSigma_{\vx} & \vSigma_{\vx\vy} \\
+        \vSigma_{\vx\vy}^\top & \vSigma_{\vy}
+      \end{bmatrix}
+    \right),
+  \end{equation*}
+  unde parametrii de medie și covarianță sunt dați de
+  \begin{equation*}
+    \vmu_{\vx} = \bE[\vx],\quad \vmu_{\vy} = \bE[\vy],\quad
+    \begin{bmatrix}
+      \vSigma_{\vx} & \vSigma_{\vx\vy} \\
+      \vSigma_{\vx\vy}^\top & \vSigma_{\vy}
+    \end{bmatrix}
+    =
+    \bE\left[
+      \begin{bmatrix}
+        \vx - \bE[\vx] \\
+        \vy - \bE[\vy]
+      \end{bmatrix}
+      \begin{bmatrix}
+        \vx - \bE[\vx] \\
+        \vy - \bE[\vy]
+      \end{bmatrix}^\top
+      \right]
+  \end{equation*}
+  Presupunem că $\vSigma_{\vy}$ este pozitiv definită (prin urmare inversabilă); atunci semipozitivitatea matricei de covarianță este echivalentă cu condiția complementului Schur $\vSigma_{\vx} - \vSigma_{\vx\vy} \vSigma_{\vy}^{-1} \vSigma_{\vx\vy}^\top \succeq \Zero$.
+
+  În acest exercițiu, vom demonstra că distribuția condiționată $p_{\vx \mid \vy}$ este gaussiană: și anume,
+  \begin{equation}\label{eq:gaussian-conditional-eqn}
+    p_{\vx \mid \vy} \sim \cN\left(
+      \vmu_{\vx} + \vSigma_{\vx\vy} \vSigma_{\vy}^{-1} (\vy - \vmu_{\vy}),
+      \vSigma_{\vx} - \vSigma_{\vx\vy} \vSigma_{\vy}^{-1}
+      \vSigma_{\vx\vy}^{\top}
+    \right).
+  \end{equation}
+  O cale directă pentru a demonstra acest rezultat manipulează raportul definitor al densităților $p_{\vx, \vy} / p_{\vy}$. Schițăm un argument algebric concis de această formă mai jos.
+
+  \begin{enumerate}
+    \item Verificați următoarea identitate matriceală pentru covarianță:
+      \begin{equation}\label{eq:gaussian-conditional-covariance-block}
+        \begin{bmatrix}
+          \vSigma_{\vx} & \vSigma_{\vx\vy} \\
+          \vSigma_{\vx\vy}^\top & \vSigma_{\vy}
+        \end{bmatrix}
+        =
+        \begin{bmatrix}
+          \vI_D & \vSigma_{\vx\vy}\vSigma_{\vy}^{-1} \\
+          \Zero & \vI_d
+        \end{bmatrix}
+        \begin{bmatrix}
+          \vSigma_{\vx} - \vSigma_{\vx\vy} \vSigma_{\vy}^{-1}
+          \vSigma_{\vx\vy}^{\top} & \Zero \\
+          \Zero & \vSigma_{\vy}
+        \end{bmatrix}
+        \begin{bmatrix}
+          \vI_D & \Zero\\
+          \vSigma_{\vy}^{-1}\vSigma_{\vx\vy}^\top & \vI_d
+        \end{bmatrix}.
+      \end{equation}
+      Se ajunge la această identitate efectuând două runde de eliminare gaussiană (pe blocuri) pe matricea de covarianță.
+    \item Pe baza identității anterioare, arătați că
+      \begin{equation}\label{eq:gaussian-conditional-covariance-inverse-block}
+        \begin{bmatrix}
+          \vSigma_{\vx} & \vSigma_{\vx\vy} \\
+          \vSigma_{\vx\vy}^\top & \vSigma_{\vy}
+        \end{bmatrix}^{-1}
+        =
+        \begin{bmatrix}
+          \vI_D & \Zero\\
+          -\vSigma_{\vy}^{-1}\vSigma_{\vx\vy}^\top & \vI_d
+        \end{bmatrix}
+        \begin{bmatrix}
+          \left(\vSigma_{\vx} - \vSigma_{\vx\vy} \vSigma_{\vy}^{-1}
+          \vSigma_{\vx\vy}^{\top}\right)^{-1} & \Zero \\
+          \Zero & \vSigma_{\vy}^{-1}
+        \end{bmatrix}
+        \begin{bmatrix}
+          \vI_D & -\vSigma_{\vx\vy}\vSigma_{\vy}^{-1} \\
+          \Zero & \vI_d
+        \end{bmatrix}
+      \end{equation}
+      ori de câte ori inversele relevante sunt definite.\footnote{În cazurile în care termenul complement Schur nu este inversabil, același rezultat este valabil cu inversa sa înlocuită de pseudoinversa Moore-Penrose. În special, distribuția condiționată \eqref{eq:gaussian-conditional-eqn} devine o distribuție gaussiană degenerată.}
+      Concluzionați că
+      \begin{align}
+        &\begin{bmatrix}
+          \vx-\vmu_{\vx} \\
+          \vy-\vmu_{\vy}
+        \end{bmatrix}^{\top}
+        \begin{bmatrix}
+          \vSigma_{\vx} & \vSigma_{\vx\vy} \\
+          \vSigma_{\vx\vy}^\top & \vSigma_{\vy}
+        \end{bmatrix}^{-1}
+        \begin{bmatrix}
+          \vx-\vmu_{\vx} \\
+          \vy-\vmu_{\vy}
+        \end{bmatrix}
+        \\
+        &\qquad=
+        \begin{bmatrix}
+          \vx - \left(\vmu_{\vx} + \vSigma_{\vx\vy}\vSigma_{\vy}^{-1}(\vy
+          - \vmu_{\vy})\right) \\
+          \vy - \vmu_{\vy}
+        \end{bmatrix}^\top
+        \begin{bmatrix}
+          \left(\vSigma_{\vx} - \vSigma_{\vx\vy} \vSigma_{\vy}^{-1}
+          \vSigma_{\vx\vy}^{\top}\right)^{-1} & \Zero \\
+          \Zero & \vSigma_{\vy}^{-1}
+        \end{bmatrix}
+        \begin{bmatrix}
+          \vx - \left(\vmu_{\vx} + \vSigma_{\vx\vy}\vSigma_{\vy}^{-1}(\vy
+          - \vmu_{\vy})\right) \\
+          \vy - \vmu_{\vy}
+        \end{bmatrix}.
+      \end{align}
+      (\textit{Indicație: Pentru a economisi manipulări algebrice, rețineți că prima și ultima matrice din partea dreaptă a \Cref{eq:gaussian-conditional-covariance-block} sunt transpuse una a celeilalte.})
+    \item Împărțind $p_{\vx, \vy} / p_{\vy}$, demonstrați \Cref{eq:gaussian-conditional-eqn}. (\textit{Indicație: Folosind identitățile anterioare, ar trebui să fie necesară doar algebră minimă. Pentru constanta de normalizare, folosiți \Cref{eq:gaussian-conditional-covariance-inverse-block} pentru a factoriza determinantul în mod similar.})
+  \end{enumerate}
+\end{exercise}
+
+\begin{exercise}\label{exercise:sherman_morrison_woodbury_identity}
+    Arătați identitatea Sherman-Morrison-Woodbury, adică pentru matricele \(\vA\), \(\vC\), \(\vU\), \(\vV\) astfel încât \(\vA\), \(\vC\) și \(\vA + \vU\vC\vV\) sunt inversabile,
+    \begin{equation}
+        (\vA + \vU\vC\vV)^{-1} = \vA^{-1} - \vA^{-1}\vU(\vC^{-1} + \vV\vA^{-1}\vU)^{-1}\vV\vA^{-1}
+    \end{equation}
+\end{exercise}
+
+\begin{exercise}\label{exercise:generalizing_results_to_different_noise_models}
+    Rederivați următoarele, presupunând că \(\vx_{t}\) urmează modelul de zgomot generalizat \eqref{eq:gen_additive_gaussian_noise_model}.
+    \begin{itemize}
+        \item Formula lui Tweedie: \eqref{eq:gen_tweedie}.
+        \item Iterația DDIM: \eqref{eq:gen_denoising_iteration}.
+        \item Denoiserul optim Bayes pentru un model de amestec gaussian: \eqref{eq:gen_gmm_bayes_optimal_denoiser}.
+    \end{itemize}
+\end{exercise}
+
+\begin{exercise}\label{exercise:implement_denoising_processes}
+\begin{enumerate}
+    \item Implementați formulele derivate în \Cref{exercise:generalizing_results_to_different_noise_models}, construind un eșantionator pentru amestecuri gaussiene.
+    \item Reproduceți \Cref{fig:ve_forward_denoising} și \Cref{fig:vp_gmm_denoising}.
+    \item Introducem acum un proces separat numit \textit{Potrivirea Fluxului (FM)}, după cum urmează:
+    \begin{equation}
+        \alpha_{t} = 1 - t, \qquad \sigma_{t} = t.
+    \end{equation}
+    Implementați acest proces folosind același cadru și testați-l pentru eșantionare în dimensiuni înalte. Care proces pare să dea rezultate mai bune sau mai stabile?
+\end{enumerate}
+\end{exercise}
+
+\begin{exercise}
+	Vă rugăm să arătați următoarele proprietăți ale funcției $\log\det(\cdot)$.
+	\begin{enumerate}
+		\item Arătați că
+		      \begin{align*}
+			      f(\vX) = \log\det\left(\vX\right)
+		      \end{align*}
+		      este o funcție concavă. ({\bf Indicație:} Funcția $f(\vx)$ este convexă dacă și numai dacă funcția $f(\vx+t\vh)$ pentru toți $\vx$ și $\vh$.)
+
+		\item Arătați că:
+		      \begin{align*}
+			      \log\det(\vI + \vX^\top\vX) = \log\det(\vI + \vX\vX^\top)
+		      \end{align*}
+
+		\item Fie $\vA \in \R^{n\times n}$ o matrice pozitiv definită. Vă rugăm să arătați că:
+		      \begin{align}
+			      \log\det\left(\vA \right) = \sum_{i=1}^n \log(\lambda_i),
+		      \end{align}
+		      unde $\lambda_1,\lambda_2,\dots,\lambda_n$ sunt valorile proprii ale lui $\vA$.
+	\end{enumerate}
+\end{exercise}
+
+\end{document}

--- a/chapters/chapter4/deep-networks_ro.tex
+++ b/chapters/chapter4/deep-networks_ro.tex
@@ -1,0 +1,1224 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Reprezentări Profunde ca Optimizare Desfășurată}
+\label{ch:representation}
+\label{ch:unrolling}
+
+\begin{quote}
+\hfill    ``{\em Ceea ce nu pot crea, nu înțeleg}.''
+
+$~$ \hfill --- Richard Feynman   
+\end{quote}
+\vspace{5mm}
+
+
+
+
+În capitolele anterioare, am arătat cum să identificăm structuri de dimensiune redusă în spații de dimensiune înaltă, \textit{concentrându-ne în principal pe structuri liniare}. 
+De exemplu, am introdus analiza componentelor principale (PCA) pentru a învăța denoiserul liniar $\hat{\bm{U}}^{\top}$ când datele observate $\bm{x}$ urmează modelul statistic $\bm{x} = \bm{U}\bm{z} + \bm{\varepsilon}$. 
+În acest context, reprezentările învățate sunt date de intrare transformate liniar $\hat{\bm{U}}^{\top}\bm{x}$.
+Sub presupunerea modelului liniar, se poate învăța structura liniară de dimensiune redusă cu algoritmi de optimizare eficienți și garanții teoretice puternice. 
+Mai mult, presupunerea modelului liniar acoperă o gamă largă de aplicații și probleme, inclusiv recunoașterea facială, recuperarea imaginilor prin rezonanță magnetică și recuperarea texturii structurale~\cite{Wright-Ma-2022}.
+
+Pe de altă parte, modelul liniar poate fi limitat când avem de-a face cu aplicații din lumea reală, în special când datele de intrare $\bm{x}$ sunt complexe, cum ar fi vorbirea și limbajele naturale, imaginile și videoclipurile, și mișcările robotice. Distribuțiile de dimensiune redusă ale acestor date sunt de obicei neliniare. 
+Cum să tratăm neliniaritatea are o istorie îndelungată în diferite discipline precum teoria controlului, procesarea semnalelor și recunoașterea modelelor.  Au existat eforturi considerabile care încearcă să extindă metodele și soluțiile pentru modele liniare pentru a gestiona neliniaritatea, inclusiv eforturile timpurii de a extinde PCA la PCA neliniar (așa cum vom studia mai detaliat în \Cref{ch:autoencoding}).  În majoritatea cazurilor, metodele sunt proiectate pe baza anumitor presupuneri despre distribuțiile datelor și adaptate la probleme specifice. 
+
+Mai recent, rețelele neuronale profunde au obținut un succes remarcabil într-o gamă largă de date și aplicații. O rețea neuronală
+\begin{equation}
+  f(\cdot, \bm \theta) \colon \x
+  \xrightarrow{\hspace{1mm} f^0 \hspace{1mm}} \z^0 \rightarrow \cdots
+  \rightarrow \z^\ell \xrightarrow{\hspace{1mm} f^\ell \hspace{1mm}}
+  \z^{\ell+1} \rightarrow  \cdots \to \z^L = \z.
+\end{equation}
+poate învăța caracteristici/reprezentări eficace pentru aplicații ulterioare. De exemplu, o rețea neuronală profundă antrenată $f(\cdot, \bm \theta)$ poate fi aplicată pentru a mapa imaginile la vectori de caracteristici, adică $\bm{z}_i = f(\bm{x}_i,\bm \theta)$, în timp ce un clasificator liniar poate fi învățat pe baza acestor reprezentări $\{\bm{z}_i\}$. O descoperire notabilă este AlexNet~\cite{krizhevsky2012imagenet}, o rețea neuronală convoluțională profundă antrenată cu mai mult de un milion de imagini naturale, depășind toate abordările anterioare care se bazau pe caracteristici create manual. Una dintre diferențele cheie între AlexNet și abordările anterioare este că prima \textit{învață parametrii transformării neliniare din cantități masive de date} antrenate cu retropropagare (BP) \cite{Back-Prop}, așa cum este detaliat în \Cref{app:BP-section} din \Cref{app:optimization}. 
+
+
+
+Practica populară ulterioară modelează maparea $f$ cu alte rețele neuronale profunde artificiale proiectate empiric și învață parametrii $\bm \theta$ din inițializare aleatorie prin BP. Începând cu AlexNet \cite{krizhevsky2012imagenet}, arhitecturile rețelelor profunde moderne continuă să fie revizuite și îmbunătățite empiric. Arhitecturi de rețea precum VGG \cite{simonyan2014very}, ResNet \cite{he2016deep}, DenseNet \cite{dense-net}, CNN, RNN sau LSTM \cite{LSTM}, Transformer \cite{vaswani2017attention}, și un amestec de experți (MoE) \cite{MoE,Fedus-2022}, etc. au continuat să împingă limitele performanței. Ca parte a efortului de a îmbunătăți performanța rețelelor profunde, aproape fiecare componentă a rețelelor a fost examinată empiric, și au fost propuse diverse revizuiri și îmbunătățiri. Acestea nu se limitează la funcții de activare neliniare \cite{maas2013rectifier,klambauer2017self,xu2015empirical,nwankpa2018activation}, conexiuni de salt \cite{ronneberger2015u,he2016deep}, normalizări \cite{ioffe2015batch,ba2016layer,ulyanov2016instance,wu2018group,miyato2018spectral}, eșantionare ascendentă/descendentă sau pooling \cite{scherer2010evaluation}, convoluții~\cite{lecun1998gradient,krizhevsky2012imagenet}, etc.
+Cu toate acestea, aproape toate aceste modificări au fost dezvoltate prin ani de {încercare și eroare} empirică sau studii de ablație. Unele practici recente merg chiar la extrem prin căutarea structurilor de rețea eficiente și a strategiilor de antrenament prin tehnici extinse de căutare aleatorie, cum ar fi Neural Architecture Search \cite{NAS-1,Baker2017DesigningNN}, AutoML \cite{automl}, și Learning to Learn \cite{andrychowicz2016learning}. 
+
+În ciuda aplicării pe scară largă a rețelelor neuronale profunde, nu este clar care sunt principiile de proiectare de bază ale unei astfel de rețele construite. În special, nu este clar ce funcție matematică îndeplinește fiecare strat al rețelei. În acest capitol, pe baza rezultatelor din capitolele anterioare, dezvoltăm un cadru principial care va oferi o interpretare matematică complet riguroasă a rolului unei rețele profunde, inclusiv a straturilor sale individuale și a rețelei în ansamblu. 
+
+Pentru a înțelege rețelele profunde și cum ar trebui să fie mai bine proiectate, trebuie să începem cu obiectivul învățării reprezentărilor. În capitolele anterioare, am argumentat că obiectivul este de a identifica distribuția de date intrinsec de dimensiune redusă și apoi de a o transforma într-o reprezentare compactă și structurată (să zicem liniar pe bucăți). După cum am văzut în capitolul anterior, abordarea generală pentru identificarea unei distribuții de date de dimensiune redusă este printr-un proces de compresie care minimizează progresiv entropia sau rata de codare a distribuției. Cu toate acestea, până în acest moment, am folosit rețele profunde proiectate empiric pentru a modela sau aproxima operațiile care urmăresc să optimizeze aceste obiective, cum ar fi funcția de scor pentru denoising (în \Cref{sec:denoising-intro}) sau transformarea care maximizează reducerea ratei (în \Cref{sec:MCR-landscape}). 
+
+După cum am argumentat în capitolul anterior, \Cref{sec:chap4-representation-learning-problem} în special, se poate măsura calitatea reprezentării rezultate prin informația reprezentării câștigate dintr-o reprezentare „leneșă" care modelează toate datele ca un singur Gaussian mare.\footnote{pe care l-am văzut în capitolul anterior ca o alegere particulară de interpretare a setului de date eșantionat.} În special, dacă \textit{folosim un amestec de Gaussiene (subspații)\footnote{pe care le-am studiat temeinic în capitolul anterior.} ca distribuții prototipice pentru a aproxima distribuția neliniară de interes}, atunci putem măsura eficient rata de codare a unei astfel de reprezentări folosind (suma) funcțiilor de distorsiune a ratei ale Gaussienelor asociate. Apoi cantitatea de {\em informație câștigată} sau entropia (relativă) redusă cu o astfel de modelare poate fi măsurată prin diferența dintre rata de codare pentru reprezentarea leneșă și cea pentru reprezentarea mai rafinată. Apoi, obiectivul învățării reprezentărilor este de a maximiza acest câștig de informație, cunoscut și sub numele de obiectivul de reducere a ratei. 
+
+După cum vom vedea în acest capitol, odată ce obiectivul învățării reprezentărilor este clar, rolul unei rețele neuronale profunde este tocmai de a ajuta la optimizarea obiectivului iterativ. Fiecare strat al unei rețele neuronale profunde poate fi derivat în mod natural ca un pas de optimizare iterativă pentru a maximiza incremental câștigul de informație, inclusiv arhitecturile populare ResNet, CNN și Transformer, și alte variante mai avansate. În special, acest capitol urmărește să răspundă la următoarele întrebări despre rețelele profunde:
+\begin{itemize}
+    \item \Cref{sec:chap4-white-box-model-via-unrolling} --- având o măsură a calității pentru o reprezentare învățată, cum să construim maparea neliniară de la date la reprezentarea optimă prin optimizare desfășurată pentru obiectiv?
+    \item \Cref{sec:chap4-white-box-transformer} --- cum ar oferi abordarea de desfășurare de mai sus o interpretare principială a arhitecturilor transformer populare; dacă da, care sunt obiectivul asociat și mecanismele de optimizare? 
+    \item \Cref{sec:chap4-derive-white-box-transformer-variants} --- cum ne-ar ghida acest cadru să proiectăm arhitecturi profunde mai eficiente sau mai parcimonioase?
+\end{itemize}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+\section{Rețele Profunde cu Cutie Albă prin Optimizare Desfășurată}\label{sec:chap4-white-box-model-via-unrolling}
+
+
+Acum, dacă suntem de acord că maximizarea reducerii ratei sau a câștigului de informație duce la reprezentarea dorită, așa cum am discutat în \Cref{sec:chap4-representation-learning-problem}, întrebarea rămasă este cum să construim și să învățăm o mapare (neliniară) de la datele $\X$ la reprezentarea optimă $\Z^*$. Aceasta implică proiectarea unei arhitecturi de rețea și a unui algoritm de învățare care pot captura eficient structurile de bază din date și pot realiza fidel reprezentarea optimă. 
+
+
+\subsection{Rețele Profunde din Descreștere Gradient Desfășurată}
+
+În capitolul anterior, am prezentat obiectivul de reducere a ratei \eqref{eqn:maximal-rate-reduction} ca obiectiv principial pentru învățarea reprezentărilor discriminative liniare ale datelor. Cu toate acestea, nu am specificat arhitectura mapării caracteristicilor $\z = f(\x, \bm \theta)$ pentru extragerea acestor reprezentări din datele de intrare $\x$. 
+O alegere simplă este să folosim o rețea profundă convențională, cum ar fi ResNet, pentru implementarea $f(\x, \bm \theta)$. După cum am văzut în \Cref{eg:Rate-Reduction-CIFAR10}, o astfel de alegere duce adesea la performanțe decente empiric. Cu toate acestea, rămân câteva probleme fără răspuns cu adoptarea unei rețele profunde arbitrare. Deși reprezentarea caracteristicilor învățate este acum mai interpretabilă, rețeaua în sine {\em nu} este. Nu este clar de ce orice rețea „cutie neagră" aleasă este capabilă să optimizeze deloc obiectivul MCR$^2$ dorit. Rezultatele empirice bune (să zicem cu un ResNet) nu justifică neapărat alegerea particulară în arhitecturi și operatori ai rețelei: De ce este necesar un model stratificat profund; ce încearcă să îmbunătățească sau să simplifice straturile suplimentare; cât de largă și profundă este adecvată; sau există vreo justificare riguroasă pentru convoluțiile (într-o formă populară multi-canal) și operatorii neliniari (de exemplu, ReLU sau softmax) folosiți? 
+
+În acest capitol, arătăm că utilizarea ascendenței gradientului pentru a maximiza reducerea ratei $\Delta R_{\epsilon}(\Z \mid \bm \Pi)$ așa cum este definită în \eqref{eqn:maximal-rate-reduction} duce în mod natural la o rețea profundă „cutie albă" care realizează maparea dorită. Toate straturile rețelei, operatorii liniari/neliniari și parametrii sunt {\em construiți explicit într-o manieră pur de propagare înainte}. Mai mult, astfel de arhitecturi de rețea seamănă cu rețelele profunde proiectate empiric existente, oferind justificări principiale pentru proiectarea lor.
+
+\paragraph{Ascendență Gradient pentru Reducerea Ratei de Codare.} Din capitolul anterior, vedem că pentru a căuta o reprezentare discriminativă liniară (LDR), matematic, căutăm în esență o mapare continuă $f(\cdot): \x \mapsto \z$ de la datele $\X = [\x_1, \ldots, \x_N] \in \Re^{D \times N}$ (sau caracteristici inițiale extrase din date\footnote{După cum vom vedea necesitatea unei astfel de extrageri de caracteristici în secțiunea următoare.}) la o reprezentare optimă $\Z = [\z_1, \ldots, \z_N] \in \Re^{d \times N}$ care maximizează următorul obiectiv de reducere a ratei de codare:
+\begin{equation}\label{eq:mcr-formulation}
+\begin{split}
+\Delta R_{\epsilon}(\Z \mid \bm{\Pi}) \doteq \underbrace{\frac{1}{2}\log\det \Big(\I + {\alpha} \Z \Z^{\top} \Big)}_{R_{\epsilon}(\Z)} \;-\; \underbrace{\sum_{k=1}^{K}\frac{\gamma_{k}}{2} \log\det\Big(\I + {\alpha_{k}} \Z \bm{\Pi}_{k} \Z^{\top} \Big)}_{R_{\epsilon}^c(\Z \mid \bm \Pi)},
+\end{split}
+\end{equation}
+unde $\epsilon > 0$ este o eroare de cuantizare prescrisă și pentru simplitate notăm\footnote{Observați utilizarea notației ușor simplificate comparativ cu \Cref{ch:compression}.}
+\begin{align*}
+    \alpha \doteq \frac{d}{N\epsilon^2}, \qquad \alpha_{k} \doteq \frac{d}{\mathrm{tr}(\bm{\Pi}_{k})\epsilon^2}, \qquad \gamma_{k} \doteq \frac{\mathrm{tr}(\bm{\Pi}_{k})}{N}, \qquad \text{pentru}\ k = 1,\ldots, K.
+\end{align*}
+
+Întrebarea se reduce cu adevărat la dacă există o modalitate {\em constructivă} de a găsi o astfel de mapare continuă $f(\cdot,\bm \theta)$ de la $\bm x$ la $\bm z$? În acest scop, să considerăm maximizarea incrementală a obiectivului $\Delta R_{\epsilon}$ ca funcție de $\Z \subseteq \mathbb{S}^{d-1}$. Deși ar putea exista multe scheme de optimizare din care să alegem, pentru simplitate considerăm mai întâi schema de {\em ascendență gradient proiectată} (PGA) fără îndoială cea mai simplă:\footnote{Observați că folosim subscriptul $j$ pe $\Z_j$ pentru a indica caracteristicile din clasa $j$-a și superscriptul $\ell$ pe $\Z^{\ell}$ pentru a indica toate caracteristicile la iterația sau stratul $\ell$.} 
+\begin{equation}
+\bm Z^{\ell+1}   \; \propto \; \bm Z^{\ell} + \eta \cdot \frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}(\Z^{\ell})
+\quad \mbox{cu condiția ca} \quad \Z^{\ell+1} \subseteq \mathbb{S}^{d-1}, \quad \ell = 1, 2, \ldots,
+\label{eqn:gradient-descent}
+\end{equation}
+pentru o anumită dimensiune a pasului $\eta >0$ și iterația începe cu datele date $\bm Z^{0} = \bm X$.\footnote{Din nou, pentru simplitate, presupunem aici mai întâi că caracteristicile inițiale $\bm Z^{1}$ sunt datele în sine. Rețineți că aici $\ell$ denotă numărul de iterații. Prin urmare, datele și caracteristicile au aceeași dimensiune $d$. Aceasta nu trebuie să fie cazul. După cum vom vedea în secțiunea următoare, caracteristicile inițiale pot fi unele caracteristici (ridicate) ale datelor de la început și ar putea în principiu să aibă o dimensiune diferită (mult mai mare). Toate iterațiile ulterioare au aceeași dimensiune.}
+Această schemă poate fi interpretată ca modul în care ar trebui să ajustăm incremental locațiile caracteristicilor curente $\Z^\ell$, inițializate ca date de intrare $\bm X$, pentru ca $\Z^{\ell +1}$ rezultat să îmbunătățească reducerea ratei $\Delta R_{\epsilon}$, așa cum este ilustrat în \Cref{fig:gradient-flow}. 
+\begin{figure}
+\centering
+    \includegraphics[width=0.85\linewidth]{\toplevelprefix/chapters/chapter4/figs/redu_gradient_diagram.png} 
+    \caption{Deformare incrementală prin fluxul de gradient pentru a aplana atât datele din fiecare clasă într-un subspațiu și a împinge diferitele clase deoparte.} 
+    \label{fig:gradient-flow}
+\end{figure} 
+
+
+Calculul simplu arată că gradientul ${\partial \Delta R_{\epsilon}}/{\partial \bm Z}$ implică evaluarea următoarelor derivate ale celor doi termeni din $\Delta R_{\epsilon}$:
+\begin{equation}\label{eqn:expand-directions}
+    \frac{1}{2}\frac{\partial \log \det (\I \!+\! \alpha \Z \Z^{\top} )}{\partial \bm Z}(\Z^\ell) = \underbrace{\alpha(\I \!+\! \alpha\Z^\ell (\Z^\ell)^\top)^{-1}}_{\bm E^{\ell} \; \in \Re^{d\times d}}\Z^\ell,
+\end{equation}
+
+\begin{equation}\label{eqn:compress-directions}
+\frac{1}{2}\frac{\partial \left( \gamma_{k}  \log \det (\I + \alpha_{k} \Z \bm \Pi_k \Z^{\top} )  \right)}{\partial \bm Z}(\Z^\ell) = \gamma_{k}  \underbrace{ \alpha_{k}  (\I +  \alpha_{k} \Z^\ell \bm \Pi_k (\Z^\ell)^{\top})^{-1}}_{\bm C^{\ell}_k \; \in \Re^{d\times d}} \Z^{\ell} \bm \Pi_k.
+\end{equation}
+Observați că în cele de mai sus, matricea $\bm E^{\ell}$ depinde doar de $\Z^{\ell}$ și urmărește să {\em extindă} toate caracteristicile pentru a crește rata generală de codare; matricea $\bm C^{\ell}_{k}$ depinde de caracteristicile din clasa $k$ și urmărește să le {\em comprime} pentru a reduce rata de codare a fiecărei clase. 
+Apoi gradientul complet $\frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}(\Z^\ell) \in \Re^{d\times N}$ este de forma:
+\begin{equation}
+\frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}(\Z^\ell)  = \underbrace{\bm E^{\ell}}_{\text{Expansiune}} \Z^{\ell} \;-\; \sum_{k=1}^K \gamma_{k} \underbrace{\bm C_{k}^{\ell}}_{\text{Compresie}}  \Z^{\ell} \bm{\Pi}_k.
+\label{eqn:DR-gradient}
+\end{equation}
+
+\begin{remark}[Interpretarea $\bm E^\ell$ și $\bm C_j^\ell$ ca operatori liniari]\label{rem:regression-interpretation} 
+Pentru orice $\bm z^\ell \in \mathbb{R}^d$,
+\begin{gather}
+    \bm E^\ell \bm z^\ell = \alpha(\bm z^\ell - \bm Z^\ell \bm q^\ell_\star), \qquad
+    \mbox{unde} \qquad \bm q^\ell_\star \doteq \argmin_{\bm q^\ell} \big\{\alpha \|\bm z^\ell - \bm Z^\ell \bm q^\ell\|_2^2 + \|\bm q^\ell\|_2^2\big\}.
+\end{gather}
+Observați că $\bm q^\ell_\star$ este exact soluția regresiei ridge de către toate punctele de date $\bm Z^\ell$ în cauză. Prin urmare, $\bm E^\ell$ (similar pentru $\bm C^\ell_k$) este aproximativ (adică, când $N$ este suficient de mare) proiecția pe complementul ortogonal al subspațiului întins de coloanele lui $\bm Z^\ell$. Un alt mod de a interpreta matricea $\bm E^\ell$ este prin descompunerea în valori proprii a matricei de covarianță $\Z^\ell (\Z^\ell)^\top$. Presupunând că $\Z^\ell (\Z^\ell)^\top \doteq \bm U^\ell \bm \Lambda^\ell (\bm U^\ell)^\top$ unde $\bm \Lambda^\ell \doteq \diag\left(\lambda^\ell_1, \ldots, \lambda^\ell_d \right)$, avem 
+\begin{equation}
+\bm E^\ell = \alpha \bm U^\ell\, \diag\left(\frac{1}{1+\alpha\lambda^\ell_1}, \ldots, \frac{1}{1+\alpha\lambda^\ell_d}\right) \left(\bm U^\ell\right)^\top.
+\end{equation}
+Prin urmare, matricea $\bm E^\ell$ operează pe un vector $\bm z^\ell$ prin întindere într-un mod în care direcțiile de varianță mare sunt micșorate în timp ce direcțiile de varianță dispărută sunt păstrate. Acestea sunt exact direcțiile \eqref{eqn:expand-directions} în care mutăm caracteristicile astfel încât volumul general se extinde și rata de codare va crește, de aici semnul pozitiv. La efectul opus, direcțiile asociate cu \eqref{eqn:compress-directions} sunt „reziduuri" ale caracteristicilor fiecărei clase care deviază de la subspațiul căruia ar trebui să îi aparțină. Acestea sunt exact direcțiile în care caracteristicile trebuie să fie comprimate înapoi pe subspațiul lor respectiv, de aici semnul negativ (vezi \Cref{fig:regression-interpretation}). 
+
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.65\linewidth]{\toplevelprefix/chapters/chapter4/figs/expand_compress.png}
+    \caption{\small Interpretarea $\bm C^\ell_k$ și $\bm E^\ell$: $\bm C^\ell_k$ comprimă fiecare clasă prin contractarea caracteristicilor la un subspațiu de dimensiune redusă; $\bm E^\ell$ extinde toate caracteristicile prin contrastarea și respingerea caracteristicilor din diferite clase.}
+    \label{fig:regression-interpretation}
+    \vspace{-0.1in}
+\end{figure}
+
+
+În esență, operațiile liniare $\bm E^\ell$ și $\bm C_k^\ell$ în ascendența gradientului pentru reducerea ratei sunt determinate de datele de antrenament care efectuează „auto-regresii". Înțelegerea reînnoită recentă despre regresia ridge într-un cadru supra-parametrizat \cite{yang2020rethinking,Wu2020OnTO} indică faptul că utilizarea datelor aparent redundant eșantionate (din fiecare subspațiu) ca regresori nu duce la supraadaptare.
+\end{remark}
+
+\paragraph{Incrementul Hărții de Caracteristici Ghidat de Gradient.} Observați că în cele de mai sus, ascendența gradientului consideră toate caracteristicile $\Z^{\ell} = [\z^{\ell}_{1}, \dots, \z^{\ell}_{N}]$ ca variabile libere. Incrementul $\Z^{\ell+1} - \Z^{\ell} = \eta \frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}(\Z^\ell)$ nu oferă încă o transformare pe întregul domeniu al caracteristicilor $\z^\ell \in \Re^d$. Conform ecuației \eqref{eqn:DR-gradient}, gradientul nu poate fi evaluat într-un punct a cărui apartenență nu este cunoscută, așa cum este ilustrat în \Cref{fig:gradient-flow}. Prin urmare, pentru a găsi $f(\x,\bm  \theta)$ optim în mod explicit, putem considera construirea unei transformări de increment mic $g(\cdot, \bm{\theta}^{\ell})$ pe caracteristica stratului $\ell$-lea $\z^\ell$ pentru a emula schema de gradient (proiectată) de mai sus:
+\begin{equation}
+\z^{\ell + 1}   \; \propto \; \z^{\ell} + \eta\cdot  g(\z^{\ell}, \bm{\theta}^{\ell}) \quad \mbox{cu condiția ca} \quad \z^{\ell +1} \in \mathbb{S}^{d-1}
+\label{eqn:gradient-descent-transform}
+\end{equation}
+astfel încât $\big[g(\z_1^{\ell}, \bm \theta^{\ell}), \ldots, g(\z_N^{\ell}, \bm \theta^{\ell}) \big] \approx \frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}(\Z^\ell).$ Adică, trebuie să aproximăm fluxul de gradient $\frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}$ care deformează local toate caracteristicile (de antrenament) $\{\z_i^\ell\}_{i=1}^N$ cu o mapare continuă $g(\z,\bm \theta)$ definită pe întregul spațiu al caracteristicilor $\z^\ell \in \Re^d$.  
+Observați că se poate interpreta incrementul \eqref{eqn:gradient-descent-transform} ca o versiune discretizată a unei ecuații diferențiale continue:
+\begin{equation}
+\dot{\z} = g(\z, \theta).
+\end{equation}
+Prin urmare, rețeaua (profundă) astfel construită poate fi interpretată ca o anumită ODE neuronală \cite{chen2018neural}. Cu toate acestea, spre deosebire de ODE neuronală unde fluxul $g$ este ales să fie unele structuri generice, aici $g(\z, \bm\theta)$ nostru este pentru a emula fluxul de gradient al reducerii ratei pe setul de caracteristici (așa cum se arată în \Cref{fig:gradient-flow}): 
+\begin{equation*}
+    \dot{\Z} = \frac{\partial \Delta R_{\epsilon}}{\partial \bm Z},
+\end{equation*} 
+și structura sa este în întregime derivată și complet determinată din acest obiectiv, fără alte priorități sau euristici.  
+
+Prin inspecția structurii gradientului \eqref{eqn:DR-gradient}, sugerează că un candidat natural pentru transformarea de increment $g(\z^\ell, \bm \theta^\ell)$ este de forma:
+\begin{equation}
+    g(\z^\ell, \bm \theta^\ell) \; \doteq \; \bm E^\ell \z^\ell - \sum_{k=1}^K \gamma_{k} \pi_k(\z^\ell)\bm C_{k}^{\ell}  \z^{\ell}  \in \Re^d,
+    \label{eqn:DR-gradient-transform}
+\end{equation}
+unde $\pi_k(\z^\ell) \in [0,1]$ indică probabilitatea ca $\z^{\ell}$ să aparțină clasei $k$-a. Parametrii hărții de increment $\bm \theta^\ell$ depind de: În primul rând, un set de hărți liniare reprezentate de $\bm E^{\ell}$ și $\{ \bm C^{\ell}_{k}\}_{k=1}^{K}$ care depind doar de statisticile caracteristicilor antrenamentului $\Z^\ell$; În al doilea rând, apartenența $\{ \pi_k(\z^\ell)\}_{k=1}^K$ a oricărei caracteristici $\z^\ell$. 
+Observați că pe eșantioanele de antrenament $\Z^\ell$, pentru care apartenențele $\bm \Pi_k$ sunt cunoscute, $g(\z^\ell, \bm \theta)$ astfel definit oferă exact valorile pentru gradientul $\frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}(\Z^\ell)$.  
+
+
+Deoarece avem apartenența doar pentru eșantioanele de antrenament, funcția $g(\cdot)$ definită în \eqref{eqn:DR-gradient-transform} poate fi evaluată doar pe antrenament. Pentru a extrapola $g(\cdot)$ la întregul spațiu al caracteristicilor, trebuie să estimăm $\pi_k(\z^\ell)$ în al doilea său termen. În învățarea profundă convențională, această hartă este de obicei modelată ca o rețea profundă și învățată din datele de antrenament, să zicem prin {\em retropropagare}. Cu toate acestea, scopul nostru aici nu este să învățăm deja un clasificator precis $\pi_{k}(\z^\ell)$. În schimb, avem nevoie doar de o estimare suficient de bună a informațiilor clasei pentru ca $g(\cdot)$ să aproximeze bine gradientul $\frac{\partial \Delta R_{\epsilon}}{\partial \bm Z}$. 
+
+
+
+Din interpretarea geometrică a hărților liniare $\bm E^\ell$ și $\bm C_k^\ell$ dată de \Cref{rem:regression-interpretation}, termenul $\bm p_{k}^{\ell} \doteq \bm C^{\ell}_k \z^{\ell}$ poate fi privit ca (aproximativ) proiecția lui $\z^{\ell}$ pe complementul ortogonal al fiecărei clase $j$. Prin urmare, $\|\bm p_{j}^{\ell}\|_2$ este mic dacă $\z^\ell$ este în clasa $j$ și mare în caz contrar. Aceasta ne motivează să estimăm apartenența sa pe baza următoarei funcții softmax:
+\begin{equation}
+    \widehat{\vpi}(\z^\ell) \doteq \softmax\rp{-\lambda\mat{\norm{\vC^{\ell}_{1}\vz^{\ell}}_{2} \\ \vdots \\ \norm{\vC^{\ell}_{K}\vz^{\ell}}_{2}}} = \frac{1}{\sum_{k = 1}^{K}\exp(-\lambda \norm{\vC^{\ell}_{k}\vz^{\ell}}_{2})}\mat{\exp(-\lambda\norm{\vC^{\ell}_{1}\vz^{\ell}}_{2}) \\ \vdots \\ \exp(-\lambda\norm{\vC^{\ell}_{K}\vz^{\ell}}_{2})} \in [0,1]^{K}.
+\end{equation}
+Prin urmare, al doilea termen al \eqref{eqn:DR-gradient-transform} poate fi aproximat de această apartenență estimată:
+\begin{align}
+\sum_{k=1}^K \gamma_{k} \pi_k(\z^\ell)\bm C_{k}^{\ell}  \z^{\ell} 
+\; \approx \;  \sum_{k=1}^K \gamma_{k} \widehat{\pi}_k(\z^\ell)  \bm{C}^{\ell}_k  \z^{\ell} 
+\; \doteq \; \bm \sigma\Big([\bm{C}^{\ell}_{1} \z^{\ell}, \dots, \bm{C}^{\ell}_{K} \z^{\ell}]\Big),
+\label{eqn:soft-residual}
+\end{align}
+care este notată ca un operator neliniar $\bm \sigma(\cdot)$ pe ieșirile caracteristicii $\z^\ell$ prin $K$ grupuri de filtre: $[\bm{C}^{\ell}_{1}, \dots, \bm{C}^{\ell}_{K}]$. Observați că neliniaritatea apare datorită unei atribuiri „moi" a apartenenței la clasă pe baza răspunsurilor caracteristicilor de la aceste filtre.  
+
+În general, combinând \eqref{eqn:gradient-descent-transform}, \eqref{eqn:DR-gradient-transform}, și \eqref{eqn:soft-residual}, 
+transformarea caracteristicii de increment de la $\z^{\ell}$ la $\z^{\ell+1}$ devine acum
+\begin{equation}\label{eqn:layer-approximate}
+\begin{aligned}
+\z^{\ell+1}  &\propto \; \z^\ell +  \eta \cdot  \bm E^{\ell} \z^{\ell} - \eta\cdot  \bm \sigma\big([\bm{C}^{\ell}_{1} \z^{\ell}, \dots, \bm{C}^{\ell}_{K} \z^{\ell}]\big)  \\
+&= \; \z^\ell +  \eta \cdot g(\z^\ell, \bm \theta^\ell) \qquad \mbox{cu condiția ca} \quad \z^{\ell +1} \in \mathbb{S}^{d-1},
+\end{aligned}
+\end{equation}
+cu funcția neliniară $\bm \sigma(\cdot)$ definită mai sus și $\bm \theta^\ell$ colectând toți parametrii pe straturi. Adică $\bm \theta^\ell =\left\{\bm E^\ell, \bm{C}^{\ell}_{1}, \dots, \bm{C}^{\ell}_{K}, \gamma_{k}, \lambda\right\}$. Notați că caracteristicile la fiecare strat sunt întotdeauna „normalizate" prin proiectarea pe sfera unitară $\mathbb S^{d-1}$, notată ca $\mathcal P_{\mathbb S^{d-1}}$. Forma incrementului în \eqref{eqn:layer-approximate} poate fi ilustrată printr-o diagramă în \Cref{fig:arch-ReduNet}(a).
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.35\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/redunet_layer.png}
+        \caption{\textbf{ReduNet}}
+    \end{subfigure}
+    \hfill 
+    \begin{subfigure}[t]{0.6\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/resnet_resnext.pdf}
+        \caption{\textbf{ResNet} și \textbf{ResNeXt}.}
+    \end{subfigure}
+    \caption{\small Arhitecturi de rețea ale ReduNet și comparație cu altele. \textbf{(a)}: Structura stratului \textbf{ReduNet} derivată dintr-o iterație de ascendență gradient pentru optimizarea reducerii ratei. \textbf{(b)} (stânga): Un strat de ResNet~\cite{he2016deep}; și \textbf{(b)} (dreapta): Un strat de ResNeXt~\cite{ResNEXT}. După cum vom vedea în \Cref{sec:shift-invariant}, operatorii liniari $\bm E^\ell$ și $\bm{C}_k^\ell$ ai ReduNet devin în mod natural convoluții (multi-canal) când se impune invarianța la deplasare.}
+    \label{fig:arch-ReduNet}
+\end{figure}
+
+\begin{algorithm}[t]
+    \caption{Algoritm de antrenament pentru ReduNet}
+    \label{alg:redunet_training}
+    \begin{algorithmic}[1]
+        \Require{$\vX = [\vx_1, \ldots, \vx_N]\in \Re^{D \times N}$, $\bm{\Pi} = \{\bm \Pi_k\}_{k=1}^K$, $\epsilon > 0$, $\lambda$, și o rată de învățare $\eta$.}
+        \Ensure{Parametrii învățați \(\{\vE^{\ell}\}_{\ell = 1}^{L}, \{\{\vC^{\ell}_{k}\}_{k = 1}^{K}\}_{\ell = 1}^{L}, \{\gamma_{k}\}_{k = 1}^{k}\)}
+
+        \Procedure{ReduNetTraining}{$\vX, \vPi, \epsilon, \lambda, \eta$}
+            \Statex{\quad\ \texttt{\# Definirea constantelor}}
+
+            \State{\(\alpha \gets d/(N\epsilon^{2})\)}
+            \For{\(k \in \{1, \dots, K\}\)}
+            \State{\(\alpha_{k} \gets D/(\tr(\vPi_{k})\epsilon^{2})\)}
+            \State{\(\gamma_{k} \gets \tr(\vPi_{k})/D\)}
+            \EndFor
+            \Statex{}
+
+            \Statex{\quad\ \texttt{\# Iterația strat cu strat ReduNet}}
+            \State{\(\vZ^{1} = \mat{\vz_{1}^1, \dots, \vz_{N}^1} \gets \vX\)} \Comment{Inițializează iterația pe strat ReduNet}
+            \For{\(\ell \in \{1, \dots, L\}\)}
+                \Statex{\quad\ \texttt{\# Pasul 1: Calculează parametrii rețelei} \(\vE^{\ell}, \{\vC^{\ell}_{k}\}_{k = 1}^{K}\)}
+                \State{\(\vE^{\ell} \gets \alpha\left(\vI + \alpha \vZ^{\ell}(\vZ^{\ell})^{\top}\right)^{-1} \in \R^{d \times d}\)}
+                \For{\(k \in \{1, \dots, K\}\)}
+                    \State{\(\vC^{\ell}_{k} \gets \alpha_{k}\left(\vI + \alpha_{k}\vZ^{\ell}\vPi_{k}(\vZ^{\ell})^{\top}\right)^{-1} \in \R^{d \times d}\)}
+                \EndFor
+                \Statex{}
+                \Statex{\qquad\quad\texttt{\# Pasul 2: Actualizează caracteristicile \(\vZ^{\ell}\)}}
+                \For{\(i \in \{1, \dots, N\}\)}
+                    \State{\(\hat{\vpi}(\vz^{\ell}_i) \gets \displaystyle \softmax(-\lambda[\norm{\vC^{\ell}_{1}\vz^{\ell}_i}_{2}, \dots, \norm{\vC^{\ell}_{K}\vz^{\ell}_i}_{2}]) \in [0, 1]^{K}\)} \Comment{Calculează atribuirile moi \(\hat{\vpi}(\vz^{\ell}_i)\)}
+                    \State{\(\displaystyle\vz^{\ell + 1}_i \gets \cP_{\bS^{d - 1}}\rp{\vz^{\ell}_i + \eta \bp{\vE^{\ell}\vz^{\ell}_i - \sum_{k = 1}^{K}\gamma_{k}\hat{\pi}_{k}(\vz^{\ell}_i) \vC^{\ell}_{k}\vz^{\ell}_i}} \in \R^{d}\)} \Comment{Actualizează caracteristicile \(\vz^{\ell + 1}_i\) din \(\vz^{\ell}_i\)}
+                \EndFor
+            \EndFor
+            \State{\Return{\(\{\vE^{\ell}\}_{\ell = 1}^{L}, \{\{\vC^{\ell}_{k}\}_{k = 1}^{K}\}_{\ell = 1}^{L}, \{\gamma_{k}\}_{k = 1}^{K}\)}} \Comment{Returnează toți parametrii rețelei.}
+        \EndProcedure
+    \end{algorithmic}
+\end{algorithm}
+
+
+\paragraph{Rețea Profundă pentru Optimizarea Reducerii Ratei.} Observați că incrementul este construit pentru a emula ascendența gradientului pentru reducerea ratei $\Delta R_\epsilon$. Prin urmare, prin transformarea caracteristicilor iterativ prin procesul de mai sus, ne așteptăm ca reducerea ratei să crească, așa cum vom vedea în secțiunea experimentală. Acest proces iterativ, odată conversat să zicem după $L$ iterații, oferă harta de caracteristici dorită $f(\x, \bm \theta)$ pe intrarea $\x = \z^0$, exact în forma unei {\em rețele profunde}, în care fiecare strat are structura prezentată în \Cref{fig:arch-ReduNet} stânga:
+\begin{equation}\label{eqn:ReduNet}
+\begin{aligned}
+f(\x, \bm \theta)\; =&  \;\;f^L \circ f^{L-1} \circ  \cdots \circ f^1 \circ
+    f^0(\z^0),  \\ 
+f^\ell(\z^\ell, \bm \theta^\ell) \; \doteq & \;\; \z^{\ell+1} = \mathcal{P}_{\mathbb{S}^{n-1}}[\z^{\ell} + \eta\cdot g(\z^{\ell}, \bm \theta^{\ell})], \\
+g(\z^{\ell}, \bm \theta^{\ell}) \; =&\;\; \bm E^{\ell} \z^{\ell} -  \bm \sigma\big([\bm{C}^{\ell}_{1} \z^{\ell}, \dots, \bm{C}^{\ell}_{K} \z^{\ell}]\big).
+\end{aligned}
+\end{equation}
+Deoarece această rețea profundă este derivată din maximizarea \textbf{redu}cerii ratei, o numim \textbf{ReduNet}. Comparând arhitectura ReduNet cu cele ale rețelelor populare proiectate empiric, \textbf{ResNet} și \textbf{ResNeXt} prezentate în \Cref{fig:arch-ReduNet}, similitudinea este oarecum uimitoare. Conceptual, ReduNet ar putea fi folosit și pentru a justifica arhitectura populară mixtură de experți (\textbf{MoE}) \cite{MoE} deoarece fiecare canal paralel, $\bm{C}^{\ell}_k$, poate fi privit ca un „expert" antrenat pentru fiecare clasă de obiecte.
+
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.45\linewidth]{\toplevelprefix/chapters/chapter4/figs/MoE.png} \hspace{5mm}
+    \includegraphics[width=0.45\linewidth]{\toplevelprefix/chapters/chapter4/figs/switched-transformer.png}
+    \caption{Stânga: o rețea profundă mixtură de experți (MoE) \cite{MoE}. Dreapta: un Switch Transformer care promovează sparsitatea \cite{Fedus-2022}, folosit pentru a implementa MoE cu 1,7 trilioane de parametri.}
+    \label{fig:enter-label}
+\end{figure}
+
+Rezumăm antrenamentul și evaluarea ReduNet în \Cref{alg:redunet_training} și \Cref{alg:redunet_evaluation}, respectiv. Observați că toți parametrii rețelei sunt construiți explicit strat cu strat într-o manieră de {\em propagare înainte}. Construcția nu are nevoie de nicio retropropagare! Caracteristicile astfel învățate pot fi folosite direct pentru clasificare, să zicem printr-un clasificator de cel mai apropiat subspațiu. 
+
+
+
+\begin{algorithm}[!htbp]
+    \caption{Algoritm de evaluare pentru ReduNet}
+    \label{alg:redunet_evaluation}
+    \begin{algorithmic}[1]
+        \Require{Intrare \(\vx \in \R^{D}\), parametrii rețelei \(\{\vE^{\ell}\}_{\ell = 1}^{L}, \{\{\vC^{\ell}_{k}\}_{k = 1}^{K}\}_{\ell = 1}^{L}, \{\gamma_{k}\}_{k = 1}^{K}\), rata de învățare \(\lambda\)}
+        \Ensure{caracteristica \(\vz^{L + 1}\)}
+
+        \Procedure{ReduNetEvaluation}{$\vx$}
+        \State{\(\vz^{1} \gets \vx \in \R^{D}\)} \Comment{Inițializează iterația pe strat ReduNet}
+        \For{\(\ell \in \{1, \dots, L\}\)}
+        \State{\(\hat{\vpi}(\vz^{\ell}) \gets  \softmax(-\lambda\mat{\norm{\vC^{\ell}_{1}\vz^{\ell}}_{2}, \dots, \norm{\vC^{\ell}_{K}\vz^{\ell}}_{2}}) \in [0, 1]^{K}\)} \Comment{Calculează atribuirile moi \(\hat{\vpi}(\vz^{\ell})\)}
+        \State{\(\vz^{\ell + 1} \gets \cP_{\bS^{d - 1}}\rp{\vz^{\ell} + \eta \bp{\vE^{\ell}\vz^{\ell} - \sum_{k = 1}^{K}\gamma_{k}\hat{\pi}_{k}(\vz^{\ell}) \vC^{\ell}_{k}\vz^{\ell}}} \in \R^{d}\)} \Comment{Actualizează caracteristica \(\vz^{\ell + 1}\) folosind \(\vz^{\ell}\)}
+        \EndFor
+        \State{\Return{\(\vz^{L + 1}\)}} \Comment{Returnează caracteristicile de ieșire}
+        \EndProcedure
+    \end{algorithmic}
+\end{algorithm}
+
+
+\begin{example}
+Pentru a oferi o intuiție despre cum ReduNet transformă caracteristicile, oferim un exemplu simplu cu Gaussiene 3D amestecate și vizualizăm cum sunt transformate caracteristicile în \Cref{fig:redu-3d-gaussian-diagram}. 
+Considerăm un amestec de trei distribuții Gaussiene în $\R^{3}$ care este proiectat pe $\mathbb{S}^2$. Mai întâi generăm puncte de date pentru 3 clase: pentru $k=1,2,3$, $\bm{X}_{k}=[\bm{x}_{k,1}, \ldots, \bm{x}_{k,m}] \in \R^{3\times m}$, $\bm{x}_{k,i} \sim \mathcal{N}(\bm{\mu}_{k}, \sigma_{k}^{2} \I)$, și ${\pi}(\x_{k,i}) = k$.
+Setăm $m=500, \sigma_{1}=\sigma_{2}=\sigma_{3}=0.1$, și $\bm{\mu}_{1}, \bm{\mu}_{2}, \bm{\mu}_{3} \in \mathbb{S}^2$. 
+Apoi proiectăm toate punctele de date pe $\mathbb{S}^{2}$, adică $\bm{x}_{k,i}/\|\bm{x}_{k,i}\|_{2}$. 
+Pentru a construi rețeaua (calculând $\bm{E}^{\ell}, \bm{C}^{\ell}_{k}$ pentru stratul $\ell$-lea), setăm numărul de iterații/straturi $L=2.000$, dimensiunea pasului $\eta=0.5$, și precizia $\epsilon=0.1$. 
+Facem aceasta doar pentru a demonstra că cadrul nostru duce la rețele profunde stabile chiar și cu mii de straturi. 
+În practică, mii de straturi ar putea să nu fie necesare și se poate opri ori de câte ori adăugarea de noi straturi oferă randamente în scădere. 
+Pentru acest exemplu, câteva sute de straturi sunt suficiente. Prin urmare, obiectivul clar de optimizare oferă un criteriu natural pentru adâncimea rețelei necesare.
+
+După cum se arată în \Cref{fig:redu-3d-gaussian-diagram}, putem observa că după maparea $f(\cdot, \bm{\theta})$, eșantioanele din aceeași clasă sunt foarte comprimate și converg la un singur cluster și unghiul dintre două clustere diferite este aproximativ $\pi/2$, care este bine aliniat cu soluția optimă $\Z^{\star}$ a pierderii MCR$^2$ în $\mathbb{S}^2$. 
+Pierderea MCR$^2$ a caracteristicilor pe diferite straturi poate fi găsită în \Cref{fig:redu-3d-gaussian-diagram}(\textbf{c}). Empiric, constatăm că ReduNet-ul construit este capabil să maximizeze pierderea MCR$^2$ și converge stabil și eșantioanele din aceeași clasă converg la un cluster și clusterele diferite sunt ortogonale unul față de celălalt. 
+Mai mult, când eșantionăm noi puncte de date din aceleași distribuții, constatăm că noile eșantioane din aceeași clasă converg în mod consistent la același centru de cluster ca și eșantioanele de antrenament. 
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.32\textwidth}
+        \centering 
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/scatter3d-X_train.pdf}\vspace{-0.1in}
+        \caption{$\bm{X}_{\text{antrenament}}$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.32\textwidth}
+        \centering 
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/scatter3d-Z_train.pdf}\vspace{-0.1in}
+        \caption{$\bm{Z}_{\text{antrenament}}$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.32\textwidth}
+        \centering 
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/scatter3d-loss-traintest.pdf}\vspace{-0.1in}
+        \caption{Pierdere (antrenament/validare)}
+    \end{subfigure}
+    \vspace{-0.1in}
+    \caption{\small Eșantioane originale și reprezentări învățate pentru Amestec de Gaussiene 3D. Vizualizăm punctele de date $\bm{X}$ (înainte de maparea $f(\cdot, \bm{\theta})$) în (\textbf{a}) și caracteristicile învățate $\bm{Z}$ (după maparea $f(\cdot, \bm{\theta})$) în (\textbf{b}) prin grafic de dispersie. În fiecare grafic de dispersie, fiecare culoare reprezintă o clasă de eșantioane. În (\textbf{c}), arătăm și graficele pentru progresia valorilor funcțiilor obiectiv.}
+    \label{fig:redu-3d-gaussian-diagram}
+\end{figure}
+
+\end{example}
+
+\subsection{Rețele Convoluționale din Reducerea Ratei Invariante}\label{sec:shift-invariant}
+
+În secțiunea anterioară, am derivat arhitectura pe straturi a unei rețele profunde, ReduNet, folosind optimizarea desfășurată pentru obiectivul de reducere a ratei. 
+În mod specific, termenul de compresie $R^c_\epsilon(\Z \mid\bm \Pi)$ în \eqref{eq:mcr-formulation} este proiectat pentru a comprima reprezentările din aceeași clasă. Cu toate acestea, această formulare nu ia în considerare posibila transformare sau deformare a domeniului datelor de intrare. De exemplu, deplasarea unui obiect ușor spre dreapta nu schimbă eticheta semantică a unei imagini. În această secțiune, vom demonstra cum straturile convoluționale pot fi derivate prin maximizarea unui obiectiv de reducere a ratei care este invariant la anumite deformări de domeniu, cum ar fi rotațiile și translațiile imaginilor. 
+
+
+Pentru multe sarcini de clustering sau clasificare (cum ar fi detectarea obiectelor în imagini), considerăm două eșantioane ca fiind {\em echivalente} dacă diferă prin anumite clase de deformări sau augmentări de domeniu $\cT = \{\tau \}$. Prin urmare, suntem interesați doar de structuri de dimensiune redusă care sunt {\em invariante} la astfel de deformări~(adică, $\x \in \mathcal{M}$ dacă și numai dacă $\tau(\x) \in \mathcal{M}$ pentru toate $\tau \in \cT$\,), 
+care sunt cunoscute a avea structuri geometrice și topologice sofisticate și pot fi dificil de învățat precis în practică, chiar și cu CNN-uri riguros proiectate \cite{Cohen-ICML-2016}. 
+În acest cadru, aceasta poate fi formulată într-un mod foarte natural: toate instanțele echivariante trebuie să fie înglobate în același subspațiu, astfel încât subspațiul în sine să fie invariant la transformările luate în considerare.
+
+În multe aplicații, cum ar fi datele seriale sau datele de imagini, semnificația semantică (etichetele) datelor sunt {\em invariante} la anumite transformări $\mathfrak{g} \in \mathbb{G}$ (pentru un anumit grup $\mathbb{G}$) \cite{CohenW16,deep-sets-NIPS2017}. De exemplu, semnificația unui semnal audio este invariantă la deplasarea în timp; și identitatea unui obiect într-o imagine este invariantă la translația în planul imaginii. Prin urmare, preferăm ca maparea caracteristicilor $f(\x,\bm \theta)$ să fie riguros invariantă la astfel de transformări:
+\begin{equation}
+\mbox{\em Invarianță de Grup:}\;   f(\x\circ \mathfrak{g}, \bm \theta) \sim f(\x,\bm \theta),\ \forall \mathfrak{g} \in \mathbb{G},
+\end{equation}
+unde „$\sim$" indică două caracteristici aparținând aceleiași clase echivalente. Deși pentru a asigura invarianța sau echivariența, operatorii convoluționali au fost o practică comună în rețelele profunde \cite{CohenW16}, rămâne dificil în practică să antrenezi o rețea de convoluție (proiectată empiric) de la zero care poate {\em garanta} invarianța chiar și la transformări simple precum translația și rotația \cite{azulay2018deep,engstrom2017rotation}. O abordare alternativă este să proiectezi cu atenție filtrele de convoluție ale fiecărui strat pentru a asigura invarianța translațională pentru o gamă largă de semnale, să zicem folosind wavelets ca în ScatteringNet \cite{scattering-net} și lucrări ulterioare \cite{Wiatowski-2018}. Cu toate acestea, pentru a asigura invarianța la semnale generice, numărul de convoluții necesare crește de obicei exponențial cu adâncimea rețelei. Acesta este motivul pentru care acest tip de rețea nu poate fi construit atât de profund, de obicei doar câteva straturi. 
+
+Acum, arătăm că principiul MCR$^2$ este compatibil cu invarianța într-un mod natural și precis: trebuie doar să atribuim toate versiunile transformate $\{\x\circ \mathfrak{g} \mid \mathfrak{g} \in \mathbb G\}$ în aceeași clasă ca datele $\x$ și să mapăm caracteristicile lor $\z$ toate în același subspațiu $\mathcal S$. Prin urmare, toate informațiile echivariante de grup sunt codificate doar în interiorul subspațiului, și orice clasificator definit pe setul rezultat de subspații va fi automat invariant la astfel de transformări de grup. Vezi \Cref{fig:ortho-invariance-diagram} pentru o ilustrare a exemplelor de rotație 1D și translație 2D. În continuare, vom arăta riguros că atunci când grupul $\mathbb G$ este deplasarea circulară 1D, rețeaua profundă rezultată devine în mod natural o {\em rețea de convoluție multi-canal}. 
+Deoarece rețeaua astfel construită trebuie să asigure invarianța doar pentru datele date $\X$ sau caracteristicile lor $\Z$, numărul de convoluții necesare rămâne de fapt constant printr-o rețea foarte profundă, spre deosebire de ScatteringNet. 
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.4\textwidth}
+        \centering 
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/ortho_diagram_1d.pdf}
+    \end{subfigure}
+    \hfill 
+    \begin{subfigure}[t]{0.4\textwidth}
+        \centering 
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/ortho_diagram_2d.pdf}
+    \end{subfigure}
+    \caption{Ilustrarea reprezentării căutate care este echivariantă/invariantă la rotația imaginii (stânga) sau translație (dreapta): toate imaginile transformate ale fiecărei clase sunt mapate în același subspațiu care este incoerent cu alte subspații. Caracteristicile înglobate în fiecare subspațiu sunt echivariante la grupul de transformare, în timp ce fiecare subspațiu este invariant la astfel de transformări.}\label{fig:ortho-invariance-diagram} 
+\end{figure}
+
+\paragraph{Date Seriale 1D și Invarianță la Deplasare} Pentru a clasifica datele unidimensionale $\bm x = [x(0), x(1), \ldots, x(D-1)] \in \Re^D$ invariante sub deplasare, luăm $\mathbb{G}$ să fie grupul tuturor deplasărilor circulare. Fiecare observație $\bm x_i$ generează o familie $\{ \x_i \circ \mathfrak{g} \, | \, \mathfrak{g} \in \mathbb G \}$ de copii deplasate, care sunt coloanele matricei circulante $\circm(\bm x_i) \in \Re^{D \times D}$ dată de
+\begin{equation}
+\circm(\x) \,\doteq\, \left[ \begin{array}{ccccc} x(0) & x(D-1) & \dots & x(2) & x(1) \\ x(1) & x(0) & x(D-1) & \cdots & x(2) \\ \vdots & x(1) & x(0) &\ddots & \vdots \\ x(D-2) &  \vdots & \ddots & \ddots & x(D-1) \\ x(D-1) & x(D-2) & \dots & x(1) & x(0)   \end{array} \right]  \in \Re^{D \times D}.
+\end{equation}
+Trimitem cititorul la \cite{Kra2012OnCM} pentru proprietățile matricelor circulante. Pentru simplitate, fie $\bm Z^1 \doteq [ \z_{1}^1, \dots, \z_{N}^1 ] = \X \in \Re^{d \times N}$.\footnote{Din nou, pentru a simplifica discuția, presupunem deocamdată că caracteristicile inițiale $\Z^1$ sunt $\X$ înseși, prin urmare au aceeași dimensiune $d$, adică $D=d$. Dar aceasta nu trebuie să fie cazul, deoarece vom vedea în curând că trebuie să ridicăm $\X$ la o dimensiune mai mare.} Atunci ce se întâmplă dacă construim ReduNet din familiile lor circulante $\circm(\bm Z^1) = \left[ \circm(\z_{1}^1), \dots, \circm(\z_{N}^1) \right] \in \Re^{d \times (dN)}$? Adică, vrem să comprimăm și să mapăm toate acestea în același subspațiu prin ReduNet. 
+
+Observați că acum matricea de covarianță a datelor: 
+\begin{eqnarray}
+\circm(\bm Z^1) \circm(\bm Z^1)^\top 
+&=& \left[ \circm(\z_{1}^1), \dots, \circm(\z_{N}^1) \right] \left[ \circm(\z_{1}^1), \dots, \circm (\z_{N}^1) \right]^\top \nonumber \\
+&=& \sum_{i =1}^N \circm(\z_{i}^1) \circm(\z_{i}^1)^\top \;\in \Re^{d\times d} 
+\end{eqnarray}
+asociată cu această familie de eșantioane este {\em automat} o matrice circulantă (simetrică). Mai mult, deoarece proprietatea circulantă este păstrată sub sume, inverse și produse, matricele $\bm E^1$ și $\bm C^1_k$ sunt, de asemenea, automat matrice circulante, a căror aplicare la un vector de caracteristici $\bm z \in \Re^d$ poate fi implementată folosind convoluția circulară „$\circledast$".
+În mod specific, avem următoarea propoziție. 
+
+\begin{proposition}[Structuri de convoluție ale $\bm E^1$ și $\bm C^1_k$]
+Matricea 
+\begin{equation}
+    \bm E^1 = \alpha\big(\bm I + \alpha \circm(\bm Z^1) \circm(\bm Z^1)^\top \big)^{-1}
+\end{equation}
+este o matrice circulantă și reprezintă o convoluție circulară: 
+$$\bm E^1 \z = \bm e_1 \circledast \z,$$ 
+unde $\bm e_1 \in \Re^d$ este primul vector coloană al $\bm E^1$ și „$\circledast$" este convoluția circulară definită ca
+\begin{equation*}
+    (\bm e_1 \circledast \bm z)_{i} \doteq \sum_{j=0}^{d-1} e_1(j) x(i+ d-j \,\, \textsf{mod} \,\,d).
+\end{equation*}
+În mod similar, matricele $\bm C^1_k$ asociate cu orice subseturi ale $\bm Z^1$ sunt, de asemenea, convoluții circulare. 
+\label{prop:circular-conv-1}
+\end{proposition}
+
+Această propoziție arată că, sub presupunerea invarianței la deplasare, operatorii derivați $\bm E^1$ și $\bm C^1_k$ devin în mod natural {\em convoluții circulare}. Din pacate, semnalele $\bm x_i \in \Re^D$ sunt de obicei de dimensiune prea mică pentru ca construcția de mai sus să funcționeze bine în practică---până și numerele cu cifre unice MNIST au dimensiune $D = 784$, ceea ce nu lasă prea mult loc de manevră pentru clustering: cel mult ar putea fi doar câțiva subspații liniare independente în $\Re^{784}$, departe de a fi suficient pentru a distinge cele zece cifre. Așa cum am sugerat în \Cref{subsec:lifting}, trebuie să {\em ridicăm} mai întâi semnalele (sau de fapt, măcar transformarea lor în domeniul frecvenței) la o reprezentare de dimensiune mai mare pentru ca obiectivul MCR$^2$ să funcționeze. Din punct de vedere conceptual, ridicarea poate fi văzută ca aplicarea unei măsuri netede de core (de exemplu, sinus și cosinus) la semnalul de intrare. 
+
+O modalitate naturală de a realiza o astfel de ridicare este de a utiliza {\em măsuri ridicate circulante} ale semnalului. În analiză, măsuri ridicate sunt adesea asociate cu transformările semnalului cu nuclee, $\bm K \bm x$, unde $\bm K$ este o matrice Toeplitz bandată. De exemplu, pentru $D=3$ și $p=5$, cu $\bm x = [x(0), x(1), x(2)]^\top$, măsurarea ridicată circulantă ar fi:
+\begin{equation}
+    \mathcal{L}(\bm x) \doteq
+    \begin{bmatrix}
+        x(0) & x(2) & x(1) & 0 & 0\\
+        x(1) & x(0) & x(2) & x(1) & 0\\
+        x(2) & x(1) & x(0) & x(2) & x(1)\\
+        0 & x(2) & x(1) & x(0) & x(2)\\
+        0 & 0 & x(2) & x(1) & x(0)
+    \end{bmatrix}
+    \in \mathbb{R}^{p \times p}.
+\end{equation}
+
+\paragraph{Caracteristici Ridicate Multi-Canal și Invarianță la Deplasare.} 
+Când semnalele sunt de dimensiune scăzută, ridicarea nu doar că facilitează învățarea structurilor multi-subspații, dar poate fi, de asemenea, realizată prin tehnici populare existente din învățarea profundă. Măsurarea ridicată circulantă generalizată, aplicată la un semnal de intrare $\bm x_i \in \Re^D$, poate fi reformulată și rescrisă ca mai multe aplicații de convoluții (ca \textit{filtre} sau \textit{canale}) cu dimensiuni diferite de nucleu, urmate de zero-padding.\footnote{Deși poate părea confuz matematic, ``zero-padding'' este deja o practică standard în straturile de convoluție ale rețelelor profunde moderne. Zero-padding-ul pur și simplu corespunde transformării observațiilor circulante într-o matrice Toeplitz. Cu toate acestea, aici zero-padding este aplicat \textit{după} convoluție pentru a menține diferitele canale la aceeași dimensiune, care diferă de aplicațiile obișnuite în rețelele profunde moderne \citep{he2016deep} unde se aplică \textit{înainte} de convoluție pentru a menține dimensiunea intrării.} Mai precis, măsurarea ridicată poate fi reprezentată ca aplicarea a $S$ filtre de convoluție $\{\bm{w}_s \in \Re^{d_s}\}_{s=1}^S$ la semnalul 1D $\bm x$, urmată de o operație de zero-padding. Aceasta rezultă într-o matrice ridicată $\bm M \in \Re^{S \times d}$, unde fiecare rând $\bm{m}_s^\top \in \Re^{d}$ reprezintă semnalul filtrat și umplut cu zero:
+\begin{equation}
+    \bm{m}_s^\top = \text{ZeroPad}\Big( \bm{w}_s * \bm{x} \Big) \in \Re^{d},
+\end{equation}
+și stivuind toate aceste măsuri ridicate: $\bm M = [\bm{m}_1, \ldots, \bm{m}_S ] \in \Re^{S \times d}$, care poate fi interpretată ca o hartă de caracteristici 1D cu $S$ canale. Avantajul nostru este că nu sunt necesare \textit{două} copii ale datelor în matrice (așa cum se arată în ecuația de mai sus).
+
+Alegerea măsurilor ridicate nu este unică. Tehnici precum transformata Fourier rapidă (FFT), transformata cosinus discretă (DCT) sau transformata wavelet (DWT) servesc ca alternative bune. Ele pot fi văzute ca aplicarea de filtre de convoluție sinusoidale, cosinus sau wavelet ortogonale la semnalul de intrare. Atât timp cât măsurarea ridicată este invariantă la deplasare, structura convoluțională a $\bm E^1$ și $\bm C^1_k$ este păstrată. Aceasta este esența multor metode clasice de procesare a semnalelor digitale, precum și a multor rețele populare anterioare, cum ar fi ScatteringNet, care folosește wavelets \cite{scattering-net}.
+
+\paragraph{Caracteristici Ridicate Rare pentru Reprezentare Separabilă.}
+O modalitate alternativă de a vedea de ce ar trebui să ridicăm semnalele de dimensiune scăzută la o dimensiune mai mare este prin perspectiva sparsității în loc de separabilitatea subspațiului. De obicei, un semnal sau o imagine este generat dintr-un proces puternic neliniar care poate fi văzut ca transformare a unui cod rar de dimensiune mai mare în spațiul de observație de dimensiune mai scăzută. Dacă semnalele (sau imaginile) din aceeași clasă partajează anumite motive sau nuclee generatoare comune, atunci ele sunt susceptibile de a fi reprezentate ca convoluții ale acestor motive cu unele coduri rare. Mai precis, pentru semnale $\bm x = [x(1), x(2), \ldots, x(D)]^\top \in \Re^D$ din clasa $k$, presupunem că există un set de dicționare convoluționale $\bm D_k = [\bm d_{k,1}, \ldots, \bm d_{k,c}] \in \Re^{D\times c}$ unde $c$ este numărul de nuclee în dicționar, astfel încât
+\begin{equation}
+    \x = \bm d_{k,1} \circledast z_1 + \ldots + \bm d_{k,c} \circledast z_c = \circm(\bm{D}_k)\z,
+\end{equation}
+pentru un anumit vector rar $\z$. Semnalele din clase diferite sunt apoi generate de dicționare diferite ale căror atomi (sau motive) sunt incoerente unul față de celălalt. Datorită incoerenței, semnalele dintr-o clasă este puțin probabil să fie reprezentate rar de atomii din orice altă clasă. Prin urmare, toate semnalele pot fi reprezentate ca
+\begin{equation}
+\x = \big[\circm(\bm{D}_1), \circm(\bm{D}_2), \ldots, \circm(\bm{D}_K)\big] \bar \z,
+\end{equation}
+unde $\bar \z$ este rar.\footnote{Observați că modele similare de reprezentare rară au fost propuse și folosite de mult timp în scopuri de clasificare în aplicații precum recunoașterea facială, demonstrând o eficacitate excelentă \cite{Wright:2009,wagner2012toward}. Recent, modelul de codare rară convoluțională a fost propus de \cite{papyan2017convolutional} ca un cadru pentru interpretarea structurilor rețelelor convoluționale profunde.} Există o vastă literatură despre cum să învățăm cele mai compacte și optime dicționare de rarefiere din datele eșantion, de exemplu \cite{li2019multichannel,qu2019nonconvex} și ulterior să rezolvăm problema inversă și să calculăm codul rar asociat $\z$ sau $\bar \z$. Studii recente ale \cite{qu2020nonconvex,Qu2020Geometric} arată chiar că în condiții largi problema învățării dicționarului convoluțional poate fi rezolvată efectiv și eficient. 
+
+Cu toate acestea, pentru sarcini precum clasificarea, nu suntem neapărat interesați de dicționarul optim precis, nici de codul rar precis pentru fiecare semnal individual. Suntem în principal interesați dacă în mod colectiv setul de coduri rare pentru fiecare clasă sunt adecvat separabile de cele ale altor clase. Sub presupunerea modelului generativ rar, dacă nucleele de convoluție $\{\bm k_c\}_{c=1}^C$ se potrivesc bine cu „transpusa" sau „inversa" dicționarelor de rarefiere de mai sus $\bm D = [\bm D_1, \ldots, \bm D_K]$, cunoscute și sub numele de {\em filtre de analiză} \cite{Cosparse-Nam,Analysis-Filter}, semnalele dintr-o clasă vor avea doar răspunsuri ridicate la un subset mic de astfel de filtre și răspunsuri scăzute la altele (datorită presupunerii de incoerență). Cu toate acestea, în practică, adesea un număr suficient de mare de, să zicem $C$, filtre aleatorii $\{\bm k_c\}_{c=1}^C$ este suficient pentru a asigura că caracteristicile extrase cu $C$-canale
+\begin{equation}
+\big[\bm k_1 \circledast \x, \bm k_2 \circledast \x, \ldots, \bm k_C \circledast \x\big]^\top = \big[\circm(\bm k_1) \x, \ldots, \circm(\bm k_C) \x \big]^\top \in \Re^{C\times d}
+\end{equation}
+pentru clase diferite au modele de răspuns diferite la filtre diferite, făcând astfel diferite clase separabile \cite{chan2015pcanet}. 
+
+Prin urmare, în cadrul nostru, într-o mare măsură numărul de canale (sau lățimea rețelei) joacă cu adevărat rolul de {\em resursă statistică}, în timp ce numărul de straturi (adâncimea rețelei) joacă rolul de {\em resursă computațională}. Teoria detectării comprimate caracterizează precis câte măsurători sunt necesare pentru a păstra structurile intrinseci de dimensiune redusă (inclusiv separabilitatea) ale datelor \cite{Wright-Ma-2021}.
+
+\begin{figure}[t]
+	\centerline{
+\includegraphics[width=0.95\textwidth]{\toplevelprefix/chapters/chapter4/figs/sparse-lifting.pdf}}
+\caption{Estimarea codului rar $\bar{\bm z}$ al unui semnal de intrare $\bm x$ (o imagine aici) prin luarea convoluțiilor cu nuclee multiple $\bm k_c$ și apoi rarefiere.}
+		\label{fig:multi-channel-sparse-lifting}
+\end{figure}
+Răspunsurile multi-canal $\bar \z$ ar trebui să fie rare. Deci, pentru a aproxima codul rar $\bar \z$, putem lua o {\em prag neliniar de promovare a sparsității} pe intrări, să zicem $\bm \tau(\cdot)$, pe ieșirile filtrului de mai sus prin setarea răspunsurilor scăzute (să zicem valoarea absolută sub $\epsilon$) sau negative la zero:
+\begin{equation}
+\bar \z \doteq \bm \tau \left( \big[\circm(\bm k_1) \x, \ldots, \circm(\bm k_C) \x \big]^\top \right) \in \Re^{C \times d}.
+\label{eqn:sparse-lifting}
+\end{equation} 
+\Cref{fig:multi-channel-sparse-lifting} ilustrează ideile de bază. Se poate referi la \cite{Analysis-Filter} pentru un studiu mai sistematic asupra proiectării operatorului de prag de rarefiere. Cu toate acestea, aici nu suntem atât de interesați să obținem cele mai bune coduri rare atât timp cât codurile sunt suficient de separabile. Prin urmare, operatorul neliniar $\bm \tau$ poate fi ales simplu să fie un prag moale sau un ReLU. 
+Aceste caracteristici presupus rare $\bar \z$ pot fi presupuse a se afla pe o subvarietate (neliniară) de dimensiune mai mică a $\mathbb{R}^{dC}$, care poate fi linearizată și separată de celelalte clase prin straturile ReduNet ulterioare, așa cum este ilustrat mai târziu în \Cref{fig:learn-to-classify-diagram}. 
+
+ReduNet-ul construit din versiunea circulantă a acestor caracteristici multi-canal $\bar\Z \doteq [\bar \z_1, \ldots, \bar \z_N] \in \Re^{C \times d \times N}$, adică $\circm(\bar\Z) \doteq [ \circm(\bar\z_1), \dots, \circm(\bar\z_N)] \in \Re^{dC \times dN}$, păstrează proprietățile bune de invarianță descrise mai sus: operatorii liniari, acum notați ca $\bar{\bm E}$ și $\bar{\bm C}_k$, rămân bloc circulante și reprezintă {\em convoluții circulare 1D multi-canal.}
+În mod specific, avem următorul rezultat.
+\begin{proposition}[Structuri de convoluție multi-canal ale $\bar{\bm E}$ și $\bar{\bm C}_k$]
+Matricea 
+\begin{equation}
+\label{eq:def-E-bar}
+\bar{\bm E} \doteq \alpha\left(\bm I + \alpha\, \circm(\bar\Z) \circm(\bar\Z)^\top \right) ^{-1}  
+\end{equation}
+este bloc circulantă, adică,
+\begin{equation*}
+    \bar{\bm E} = 
+    \left[\begin{matrix}
+        \bar{\bm E}_{1, 1} & \cdots & \bar{\bm E}_{1, C}\\
+        \vdots & \ddots & \vdots \\
+        \bar{\bm E}_{C, 1} & \cdots & \bar{\bm E}_{C, C}\\
+    \end{matrix}\right] \in \Re^{dC \times dC},
+\end{equation*}
+unde fiecare $\bar{\bm E}_{c, c'}\in \Re^{d \times d}$ este o matrice circulantă. Mai mult, $\bar{\bm E}$ reprezintă o convoluție circulară multi-canal, adică, pentru orice semnal multi-canal $\bar\z \in \Re^{C \times n}$ avem 
+$$\bar{\bm E} \cdot \textsf{vec}(\bar\z) = \textsf{vec}( \bar{\bm e} \circledast \bar\z).$$ 
+În cele de mai sus, $\bar{\bm e} \in \Re^{C \times C \times d}$ este un nucleu convoluțional multi-canal cu $\bar{\bm e}[c, c'] \in \Re^{d}$ fiind primul vector coloană al $\bar{\bm E}_{c, c'}$, și $\bar{\bm e} \circledast \bar\z \in \Re^{C \times d}$ este convoluția circulară multi-canal definită ca
+\begin{equation*}
+    (\bar{\bm e} \circledast \bar\z)[c] \doteq \sum_{c'=1}^C \bar{\bm e}[c, c'] \circledast \bar{\z}[c'], \quad \forall c = 1, \ldots, C.
+\end{equation*}
+În mod similar, matricele $\bar{\bm C}_k$ asociate cu orice subseturi ale $\bar{\bm Z}$ sunt, de asemenea, convoluții circulare multi-canal. 
+\label{prop:multichannel-circular-conv-1}
+\end{proposition}
+Din \Cref{prop:multichannel-circular-conv-1}, ReduNet invariant la deplasare este o rețea convoluțională profundă pentru semnale 1D multi-canal prin construcție. Observați că chiar dacă nucleele de ridicare inițiale sunt separate \eqref{eqn:sparse-lifting}, inversa matricei în \eqref{eq:def-E-bar} pentru calcularea $\bar{\bm E}$ (similar pentru $\bar{\bm C_k}$) introduce „comunicare încrucișată" între toate cele $C$ canale.
+Prin urmare, aceste convoluții multi-canal în general {\em nu} sunt separabile în adâncime, spre deosebire de rețelele Xception~\cite{Xception} care au fost odată sugerate pentru a simplifica rețelele neuronale convoluționale multi-canal.\footnote{Rămâne deschis ce structuri suplimentare asupra datelor ar duce la convoluții separabile în adâncime.} 
+
+\begin{remark}[Reducerea Complexității Computaționale în Domeniul Frecvenței] 
+Calculul $\bar{\bm E}$ în \eqref{eq:def-E-bar} necesită inversarea unei matrice de dimensiune $dC \times dC$, care în general are complexitatea $O(d^3C^3)$. Cu toate acestea, folosind faptul că o matrice circulantă poate fi diagonalizată de matricea Transformatei Fourier Discrete (DFT), complexitatea poate fi redusă semnificativ. După cum este arătat în \cite{chan2021redunet}, pentru a calcula $\bar{\bm E}$ și $\bar{\bm C}_k \in \Re^{dC \times dC}$, trebuie doar să calculăm în domeniul frecvenței inversa blocurilor $C\times C$ de $d$ ori, prin urmare complexitatea generală devine $O(dC^3)$.
+    
+\end{remark}
+
+
+
+
+\paragraph{Arhitectura Generală a Rețelei și Comparație.} 
+Urmând derivarea de mai sus, vedem că pentru a găsi o reprezentare discriminativă liniară (LDR) pentru mai multe clase de semnale/imagini care este invariantă la translație, codarea rară, o arhitectură multi-strat cu convoluții multi-canal, diferite activări neliniare și calculul spectrului devin toate componente {\em necesare} pentru atingerea obiectivului în mod efectiv și eficient. \Cref{fig:learn-to-classify-diagram} ilustrează procesul general de învățare a unei astfel de reprezentări prin reducerea ratei invariante pe codurile rare de intrare. 
+
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.98\linewidth]{\toplevelprefix/chapters/chapter4/figs/learn_to_classify_diagram_updated.png}
+    \caption{Procesul general pentru clasificarea semnalelor multi-clasă cu invarianță la deplasare: Ridicare multi-canal, codare rară, urmată de un ReduNet de convoluție multi-canal pentru reducerea ratei invariante. Aceste componente sunt {\em necesare} pentru a mapa semnale multi-clasă invariante la deplasare la subspații (liniare) incoerente ca LDR. Notați că arhitecturile majorității rețelelor neuronale profunde moderne seamănă cu acest proces. LDR-ul astfel învățat facilitează sarcinile ulterioare precum clasificarea.}
+    \label{fig:learn-to-classify-diagram}
+\end{figure}
+
+
+\begin{example}[Clasificarea Invariantă a Cifrelor]
+Prezentăm în continuare performanța empirică a ReduNet-ului pe învățarea caracteristicilor invariante la \textit{rotație} pe setul de date real MNIST cu 10 clase. 
+Impunem o grilă polară pe imaginea $\bm{x}\in\mathbb{R}^{H\times W}$, cu centrul său geometric fiind centrul grilei polare 2D (așa cum este ilustrat în \Cref{fig:samples-invariant-1d-mnist-diagram}). 
+Pentru fiecare rază $r_i$, $i \in [C]$, putem eșantiona $\Gamma$ pixeli cu privire la fiecare unghi $\gamma_l =l\cdot({2\pi}/\Gamma)$ cu $l \in [\Gamma]$. 
+Apoi, dat o imagine eșantion $\bm{x}$ din setul de date, reprezentăm imaginea în coordonata polară (eșantionată) ca un semnal multi-canal $\bm{x}_p \in\R^{\Gamma\times C}$.  
+Scopul aici este să învățăm o reprezentare invariantă la rotație, adică ne așteptăm să învățăm $f(\cdot, \bm{\theta})$ astfel încât $\{f(\bm{x}_p \circ \mathfrak{g}, \bm{\theta})\}_{\mathfrak{g} \in\mathbb{G}}$ să se afle în același subspațiu, unde $\mathfrak{g}$ este deplasarea ciclică în unghiul polar.  
+Folosim $N=100$ eșantioane de antrenament ($10$ din fiecare clasă) și setăm $\Gamma=200$, $C=15$ pentru eșantionarea polară. 
+Efectuând eșantionarea de mai sus în coordonate polare, putem obține matricea de date $\bm{X}_p \in \mathbb{R}^{(\Gamma\cdot C) \times N}$. 
+Pentru ReduNet, setăm numărul de straturi/iterații $L=40$, precizia $\epsilon=0.1$, dimensiunea pasului $\eta=0.5$. Înainte de primul strat, efectuăm ridicarea intrării prin convoluție circulantă 1D cu 20 de nuclee Gaussiene aleatorii de dimensiune 5.   
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/1d-rotation.pdf}
+        \caption{$\bm{X}_{\text{rotație}}$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/mnist1d_img0.pdf}
+        \caption{$\bm{Z}_{\text{rotație}}$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/mnist1d_img1.pdf}
+        \caption{Pierdere}
+    \end{subfigure}
+    \caption{\small Exemple de imagini rotite ale cifrelor MNIST, fiecare cu 18$^{\circ}$. (\textbf{Stânga}) Diagramă pentru reprezentarea în coordonate polare; (\textbf{Dreapta}) Imagini rotite ale cifrei '0' și '1'.}
+    \label{fig:samples-invariant-1d-mnist-diagram}
+\end{figure}
+
+
+Pentru a evalua reprezentarea învățată, fiecare eșantion de antrenament este augmentat cu 20 de versiuni rotite ale sale, fiecare deplasată cu pas=10. Calculăm similaritățile cosinus între intrările de antrenament augmentate $m \times 20$ $\bm{X}_{\text{rotație}}$ și rezultatele sunt prezentate în \Cref{fig:redu-invariant-1d-mnist-diagram} (\textbf{a}). 
+Comparăm similaritățile cosinus între caracteristicile învățate ale tuturor versiunilor augmentate, adică $\bar{\bm{Z}}_{\text{rotație}}$ și rezumăm rezultatele în \Cref{fig:redu-invariant-1d-mnist-diagram} (\textbf{b}). 
+După cum vedem, ReduNet-ul invariant la rotație astfel construit este capabil să mapeze datele de antrenament (precum și toate versiunile sale rotite) din cele 10 clase diferite în 10 subspații aproape ortogonale. Adică, subspațiile învățate sunt cu adevărat invariante la transformarea de deplasare în unghiul polar. În continuare, extragem aleatoriu alte $100$ de eșantioane de test urmate de aceeași procedură de augmentare. 
+În \Cref{fig:redu-invariant-1d-mnist-diagram} (\textbf{c}), vizualizăm pierderea MCR$^{2}$ pe reprezentarea stratului $\ell$-lea a ReduNet-ului pe setul de date de antrenament și test. Din aceste rezultate, putem constata că ReduNet-ul construit este într-adevăr capabil să maximizeze pierderea MCR$^{2}$ și să generalizeze la datele de test.
+
+
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/mnist1d-heatmap-X_translate_train_all.pdf}
+        \caption{$\bm{X}_{\text{rotație}}$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/mnist1d-heatmap-Z_translate_train_all.pdf}
+        \caption{$\bm{Z}_{\text{rotație}}$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.32\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/mnist1d-loss-traintest.pdf}
+        \caption{Pierdere}
+    \end{subfigure}
+    \caption{\small (a)(b) sunt hărți de căldură ale similarității cosinus între datele de antrenament rotite $\bm{X}_{\text{rotație}}$ și caracteristicile învățate $\bar{\bm{Z}}_{\text{rotație}}$ pentru invarianța la rotație. (d) vizualizează pierderile MCR$^2$ de antrenament/validare pe straturi.}
+    \label{fig:redu-invariant-1d-mnist-diagram}
+\end{figure}
+
+\end{example}
+
+
+
+
+
+
+
+
+\section{Rețele Profunde pentru Reprezentări Parcimonioase prin Optimizare Desfășurată}\label{sec:deep-sparse-coding}
+
+În secțiunea anterioară, am văzut cum putem construi o rețea profundă prin desfășurarea optimizării pentru obiectivul de reducere a ratei de codare pentru subspații de dimensiune redusă. 
+Aceasta poate gestiona eficient structuri (liniare) de dimensiune redusă. 
+Cu toate acestea, în multe scenarii, semnalele cu care avem de-a face pot fi mai bine caracterizate prin reprezentări rare într-un dicționar supracomplet, așa cum a fost discutat în \Cref{ch:classic}. În această secțiune, ne concentrăm pe învățarea reprezentărilor pentru date care sunt generate rar de un dicționar și extindem cadrul nostru de compresie pentru a acomoda astfel de structuri rare.
+
+\subsection{Sparse Lifting și Ridicare Spațială}
+\label{subsec:lifting}
+
+Ideea de bază este că ne putem ridica sau mapa datele în spațiul în care ele sunt reprezentate rar și apoi să aplicăm obiectivul de reducere a ratei pe reprezentările rare pentru a le separa în subspații mai coerente între diferite clase. Aceasta este de fapt o practică extrem de comună în învățarea profundă și procesarea imaginilor, cunoscută adesea sub diferite denumiri precum {\em extragerea caracteristicilor}, sau {\em înglobarea spațială} a tokenurilor. În mod specific, presupunem că există o transformare a domeniului $\varphi(\cdot)$ care mapează datele $\x$ în reprezentări de dimensiune mai mare (rare):
+\begin{equation}
+    \varphi: \x \in \Re^D \mapsto \z \in \Re^p, \quad p \gg D.
+\end{equation}
+
+Designul transformării de ridicare este strâns legat de asumpția modelului generativ sau proprietățile datelor. De exemplu, pentru imagini naturale, transformările comune includ patch-uri de imagine (ferestre glisante), wavelets sau alte baze multi-rezoluție. Pentru date secvențiale, aceasta ar putea fi transformări Fourier sau codificări poziționale. 
+
+În cadrul învățării profunde moderne, ridicarea este adesea realizată prin straturi convoluționale învățate sau straturi de embedding. Totuși, pentru analiza noastră principială, considerăm mapări de ridicare mai interpretabile care conservă structura de grup a datelor, menținând în același timp sparsitatea reprezentării.
+
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.9\linewidth]{\toplevelprefix/chapters/chapter4/figs/sparse-representation.pdf}
+    \caption{Ilustrarea ridicării rare: datele originale $\x$ sunt transformate într-o reprezentare rară de dimensiune înaltă $\z$ prin transformarea de ridicare $\varphi(\cdot)$. Reprezentarea rară facilitează separarea între diferite clase prin maximizarea reducerii ratei de codare.}
+    \label{fig:sparse-lifting-illustration}
+\end{figure}
+
+\subsection{Optimizare Desfășurată pentru Codare Rară}
+
+Presupunem că datele noastre $\x$ pot fi reprezentate ca o combinație rară de atomi dintr-un dicționar $\bm D \in \Re^{D \times p}$:
+\begin{equation}
+    \x = \bm D \z + \bm \varepsilon,
+\end{equation}
+unde $\z \in \Re^p$ este un vector rar (majoritatea intrărilor sunt zero) și $\bm \varepsilon$ este zgomot. Problema de a găsi cea mai rară reprezentare poate fi formulată ca:
+\begin{equation}\label{eq:sparse-coding}
+    \min_{\z} \frac{1}{2}\|\x - \bm D \z\|_2^2 + \lambda \|\z\|_1,
+\end{equation}
+unde $\|\z\|_1 = \sum_{i=1}^p |z_i|$ este norma $\ell_1$ care promovează sparsitatea.
+
+Pentru a rezolva această problemă de optimizare, putem folosi algoritmul de prag iterativ de contracție (ISTA), care alternează între pași de gradient și operații de prag moale:
+\begin{equation}\label{eq:ista}
+    \z^{\ell+1} = \mathcal{S}_{\lambda\eta}\left(\z^\ell - \eta \bm D^\top(\bm D \z^\ell - \x)\right),
+\end{equation}
+unde $\mathcal{S}_{\tau}(\cdot)$ este operatorul de prag moale definit ca:
+\begin{equation}
+    \mathcal{S}_{\tau}(z) = \text{sign}(z) \cdot \max(|z| - \tau, 0).
+\end{equation}
+
+Desfășurând iterațiile ISTA, obținem o rețea profundă în care fiecare strat efectuează o operație de codare rară. Aceasta seamănă cu arhitectura Learned ISTA (LISTA), unde parametrii algoritmului sunt învățați din date prin retropropagare în loc să fie fixați. Reprezentarea finală rară poate fi apoi utilizată pentru sarcinile ulterioare.
+
+
+
+
+
+
+
+
+\section{Transformatoare cu Cutie Albă din Optimizare Desfășurată}\label{sec:chap4-white-box-transformer}
+După cum am văzut în secțiunea anterioară, folosim problema clasificării pentru a oferi o interpretare riguroasă pentru caracteristicile arhitecturale principale ale rețelelor profunde populare precum ResNet și CNN: fiecare strat al acestor rețele poate fi văzut ca imitând un pas de gradient care crește obiectivul de reducere a ratei (sau câștigul de informație). Această perspectivă duce, de asemenea, la un fapt oarecum surprinzător: parametrii și operatorii straturilor unei astfel de rețele profunde, ReduNet, pot fi calculați într-o manieră pur înainte.
+
+În ciuda importanței teoretice și conceptuale a ReduNet, mai mulți factori o limitează să fie foarte practică. În primul rând, așa cum am discutat mai sus, costul computațional al calculării operatorilor matriciali în fiecare strat într-o manieră înainte poate fi foarte mare. În al doilea rând, operatorii astfel calculați pot să nu fie atât de eficienți în optimizarea obiectivului și ar putea dura mii de iterații (deci straturi). După cum am văzut în \Cref{sec:LISTA} pentru LISTA, aceste două probleme pot fi abordate permițând optimizarea acelor operatori și făcându-i învățabili prin retropropagare.\footnote{Sau, poate, printr-un amestec de optimizare înainte și înapoi.}
+
+Setarea de clasificare supervizată în care a fost derivat ReduNet este, de asemenea, oarecum limitativă. În practică, o imagine ar putea să nu aparțină unei singure clase, deoarece poate conține mai multe obiecte. Prin urmare, ar fi mai general să presupunem că diferite regiuni ale imaginii aparțin unor modele diferite de dimensiune redusă (să zicem un Gaussian sau un subspațiu). După cum vom vedea, o astfel de generalizare ar duce la o arhitectură atât simplă, cât și generală, care unifică operațiile de reducere a ratei și de denoising pe care le-am văzut în capitolul anterior. Mai mult, arhitectura astfel obținută seamănă cu arhitectura populară Transformer.
+
+
+
+\subsection{Optimizare Desfășurată pentru Reducerea Ratei Rare}
+
+
+
+Considerăm o configurare generală de învățare asociată cu semnale din lumea reală. Fie \(\X = \mat{\x_{1}, \dots, \x_{N}} \in \bR^{D \times N}\) variabile aleatoare care reprezintă sursa noastră de date. În sarcinile de viziune, fiecare \(\x_{i} \in \bR^{D}\) este interpretat ca un \textit{token}, de obicei corespunzând unei petice de imagine. În sarcinile de limbaj, fiecare \(\x_{i} \in \bR^{D}\) este interpretat ca o \textit{înglobare de token}, adică o reprezentare vectorială continuă a unui token discret, cum ar fi un cuvânt sau subcuvânt.\footnote{Cu un ușor abuz de terminologie, ne referim atât la tokeni discreți, cât și la înglobările lor asociate, pur și simplu ca tokeni pe parcursul acestui capitol pentru comoditate.}
+\(\x_{i}\)-urile pot avea structuri de corelație arbitrare. Folosim \(\Z = \mat{\z_{1}, \dots, \z_{N}} \in \bR^{d \times N}\) pentru a denota variabilele aleatoare care definesc reprezentările noastre, unde \(\z_{i} \in \bR^{d}\) este reprezentarea tokenului corespunzător \(\x_i \in \bR^{D}\).
+
+\begin{remark}
+    În transformatoare, fiecare eșantion de intrare este de obicei convertit într-o secvență de {\em tokeni}. Un token este o unitate de bază de informație derivată din intrarea brută: în procesarea limbajului natural, tokenii sunt de obicei cuvinte sau subcuvinte; în viziunea computerizată, ei corespund petelor de imagine; și în alte modalități, pot reprezenta pași de timp, locații spațiale sau alte unități specifice domeniului. O {\em înglobare de token} este o reprezentare vectorială continuă a unui token care servește ca intrare pentru un transformer. Ea mapează fiecare token la un punct într-un spațiu de dimensiune înaltă, permițând modelului să proceseze intrări simbolice folosind calcul numeric.
+    O {\em reprezentare de token} este un vector care codifică informația semantică sau structurală a unui token, de obicei produs de straturile intermediare sau finale ale unui transformer. Aceste reprezentări sunt concepute pentru a captura caracteristici semnificative ale intrării care sunt utile pentru sarcini ulterioare, cum ar fi clasificarea, generarea sau regresia. Vă rugăm să consultați \Cref{sec:contrastive_learning} pentru mai multe detalii despre aceste concepte în implementări. 
+\end{remark}
+
+
+ 
+\paragraph{Obiectiv pentru Învățarea unei Reprezentări Structurate și Compacte.}
+Urmând cadrul reducerii ratei \Cref{sec:chap4-white-box-model-via-unrolling}, susținem că scopul învățării reprezentărilor este de a găsi o mapare de caracteristici \(f
+\colon \X \in \bR^{D \times N} \to \Z\in \bR^{d \times N}\) care transformă tokenii de intrare \(\{\bm x_i\}_{i=1}^N \subset \R^D\) cu o distribuție potențial neliniară și multi-modală în reprezentări de tokeni \textit{linearizate și compacte} (pe bucăți) \(\{\bm z_i\}_{i=1}^N \subset \bR^{d}\). În timp ce distribuția comună a reprezentărilor tokenilor \(\{\z_{i}\}_{i = 1}^{N}\) poate fi sofisticată (și specifică sarcinii), susținem în continuare că este rezonabil și practic să cerem ca distribuția marginală țintă a reprezentărilor individuale de tokeni să fie foarte comprimată și structurată, potrivită pentru codare compactă. În special, cerem ca distribuția să fie \textit{un amestec de distribuții Gaussiene de dimensiune redusă (să zicem \(K\))}, astfel încât Gaussiana \(k\)-a să aibă media \(\Zero \in \bR^{d}\), covarianța \(\vSigma_{k} \succeq \Zero \in \bR^{d \times d}\) și suport întins de baza ortonormată \(\vU_{k} \in \bR^{d \times p}\). 
+Notăm $\vU_{[K]} = \{\vU_k\}_{k=1}^K$ ca fiind setul de baze ale tuturor Gaussienelor. Prin urmare, pentru a maximiza \textit{câștigul de informație} \cite{ma2022principles} pentru reprezentările finale de tokeni, dorim să maximizăm reducerea lor de rată (vezi \Cref{subsec:MCR2}), adică 
+\begin{align}\label{eq:rate reduction}
+    \mathrm{max}_{\bm Z \in \R^{d\times N}}\ \Delta R_{\epsilon}(\Z \mid \vU_{[K]}) \doteq R_{\epsilon}(\Z) - R^c_{\epsilon}(\Z \mid \vU_{[K]}).
+\end{align}
+Aici, primul termen $R_{\epsilon}$ este o estimare a ratei de codare cu pierderi pentru întregul set de reprezentări de tokeni. Mai specific, dacă vedem reprezentările de tokeni $\{\bm z_i\}_{i=1}^N$ ca eșantioane i.i.d. dintr-un singur Gaussian cu medie zero, rata lor de codare cu pierderi supusă unei precizii de cuantizare $\epsilon > 0$ este dată ca
+\begin{equation}\label{eq:coding_rate}
+    R_{\epsilon}(\Z) \doteq \frac{1}{2}\textrm{logdet}\left(\I + \frac{d}{N\epsilon^{2}}\Z^{\top}\Z\right) = \frac{1}{2}\textrm{logdet}\left(\I + \frac{d}{N\epsilon^{2}}\Z\Z^{\top}\right).
+\end{equation}
+Al doilea termen $R_{\epsilon}^c$ este o estimare a ratei de codare cu pierderi sub cartea de cod $\bm U_{[K]}$, care este dată ca 
+\begin{equation}
+\begin{aligned}
+    R_{\epsilon}^c(\Z \mid \vU_{[K]}) &\doteq \sum_{k=1}^{K}R_{\epsilon}(\vU_k^{\top} \Z) = \frac{1}{2}\sum_{k=1}^{K}\log\det\left(\I +
+    \frac{p}{N\epsilon^{2}}(\vU_k^{\top}\Z)^{\top}(\vU_k^{\top}\Z)\right).
+\end{aligned}
+\label{eq:def-mcr-Rc}
+\end{equation}
+
+\begin{figure}[t]
+    \centering
+        \includegraphics[width=0.95\textwidth]{\toplevelprefix/chapters/chapter4/figs/coding-transform.png}
+    \caption{\small\textbf{Compararea a trei seturi de reprezentări prin reducerea ratei și raritate.} Fiecare $S_i$ reprezintă un subspațiu liniar, iar numărul de bile albastre reprezintă diferența dintre ratele de codare $\Delta R_{\epsilon}(\vZ \mid \vU_{[K]}) = R_\epsilon(\vZ) - R^c_\epsilon(\vZ \mid \vU_{[K]})$.}
+    \label{fig:sparse-rate-reduction-diagram}
+\end{figure}
+
+\paragraph{Reducerea Ratei Rare.} Observăm că obiectivul de reducere a ratei \eqref{eq:rate reduction} este invariant la rotații arbitrare comune ale reprezentărilor și subspațiilor. În particular, optimizarea obiectivului de reducere a ratei poate să nu conducă în mod natural la reprezentări aliniate pe axe (adică, \textit{rare}). {De exemplu, considerați cele trei seturi de reprezentări învățate din \Cref{fig:sparse-rate-reduction-diagram}. Reducerea ratei de codare crește de la (a) la (b), dar deoarece este invariantă la rotații, rămâne aceeași de la (b) la (c).} Prin urmare, am dori să transformăm reprezentările (și subspațiile lor suport) astfel încât reprezentările $\vZ$ să devină în cele din urmă rare\footnote{Concret, având puține intrări nenule.} în raport cu coordonatele standard ale spațiului de reprezentare rezultat {ca în \Cref{fig:sparse-rate-reduction-diagram}(c)}. Prin urmare, pentru a ne asigura că reprezentările finale sunt potrivite pentru o codare mai compactă, am dori să transformăm reprezentările (și subspațiile lor suport) astfel încât să devină \textit{rare} în raport cu coordonatele standard ale spațiului de reprezentare rezultat.\footnote{Adică, având cele mai puține intrări nenule.} Computațional, putem combina cele două obiective de mai sus într-un obiectiv unificat pentru optimizare:
+\begin{equation}
+   \max_{f \in \mathcal{F}}\ [\Delta R_{\epsilon}(\Z \mid \vU_{[K]}) - \lambda \|\bm{Z}\|_0] \qquad \text{s.c.}\ \Z = f(\X),
+   \label{eq:sparse-rr}
+\end{equation}
+unde $\mathcal{F}$ denotă o clasă generală de funcții și norma $\ell_0$ $\|\Z\|_0$ promovează raritatea reprezentărilor finale ale token-urilor \(\Z = f(\X)\).%
+
+
+În practică, norma $\ell_0$ este adesea relaxată la norma $\ell_1$ pentru a îmbunătăți tractabilitatea computațională și a permite tehnici de optimizare convexă \cite{Wright-Ma-2022}. Motivați de aceasta, relaxăm Problema \eqref{eq:sparse-rr} în consecință, conducând la o formulare care rămâne fidelă obiectivului original de raritate, fiind în același timp mai potrivită pentru algoritmi eficienți, după cum urmează:
+\begin{equation}
+\begin{aligned}
+   \max_{f \in \mathcal{F}}\ [\Delta R_{\epsilon}(\Z \mid \vU_{[K]}) - \lambda \|\bm{Z}\|_1]  \qquad \text{s.c.}\ \Z = f(\X),
+   \label{eq:sparse-rr-1}
+\end{aligned}
+\end{equation}
+Cu un ușor abuz de terminologie, ne referim adesea la această funcție obiectiv și ca \textit{reducere rară a ratei}.
+
+\paragraph{Arhitectură de Rețea cu Cutie Albă prin Optimizare Desfășurată.}
+
+
+Deși ușor de enunțat, fiecare termen din obiectivul de mai sus este provocator din punct de vedere computațional de optimizat \cite{Wright-Ma-2022}. Prin urmare, este natural să adoptăm o abordare de aproximare care realizează transformarea globală $f$ pentru a optimiza 
+\eqref{eq:sparse-rr} printr-o concatenare a multiple, să zicem $L$, operațiuni simple \textit{incrementale și locale} $f^\ell$ care împing distribuția reprezentării către distribuția parsimonioasă dorită a modelului:
+\begin{equation}
+f\colon \X = \bm Z^0 \xrightarrow{\hspace{1mm} f^0 \hspace{1mm}} \Z^1 \rightarrow \cdots \rightarrow \Z^\ell \xrightarrow{\hspace{1mm} f^{\ell} \hspace{1mm}} \Z^{\ell+1} \rightarrow  \cdots \xrightarrow{\hspace{1mm} f^{L-1}} \Z^L = \Z,
+\label{eq:incremental}
+\end{equation}
+unde $f^0: \bR^{D} \rightarrow \bR^{d}$ este maparea de pre-procesare care transformă fiecare token de intrare $\x_{i} \in \bR^{D}$ în reprezentările inițiale ale token-ului $\z_{i}^{1} \in \bR^{d}$.
+Fiecare \textit{mapare directă} incrementală $\Z^{\ell + 1} = f^\ell(\Z^\ell)$, sau un „strat", transformă distribuția token-ului pentru a \textit{optimiza} obiectivul de reducere rară a ratei de mai sus \eqref{eq:sparse-rr}, condiționat de distribuția intrării sale $\Z^\ell$.
+
+\begin{remark}
+    În contrast cu alte abordări de optimizare desfășurată, cum ar fi ReduNet (vezi \Cref{sec:chap4-white-box-model-via-unrolling}), noi \textit{modelăm explicit} distribuția lui $\Z^\ell$ la fiecare strat, să zicem ca un amestec de subspații liniare sau generat rar dintr-un dicționar. Parametrii modelului sunt învățați din date (să zicem prin \textit{propagare înapoi} cu antrenament de la capăt la capăt). Această separare între „optimizarea" directă și
+„învățarea" înapoi clarifică rolul matematic al fiecărui strat ca un operator
+care transformă distribuția intrării sale, în timp ce distribuția de intrare este la rândul ei modelată (și ulterior învățată) de parametrii stratului.
+\end{remark}
+
+Acum, arătăm cum să derivăm aceste operațiuni incrementale și locale printr-o perspectivă de optimizare desfășurată pentru a rezolva Problema \eqref{eq:sparse-rr-1}. Odată ce decidem să folosim o abordare incrementală pentru optimizarea Problemei
+\eqref{eq:sparse-rr-1}, există o varietate de alegeri posibile pentru a realiza optimizarea. Dat fiind un model pentru $\Z^\ell$, să zicem un amestec de subspații $\vU_{[K]}$, optăm pentru o metodă de \textit{minimizare alternantă} în doi pași cu o bază conceptuală puternică. Mai întâi, \textit{comprimăm} token-urile $\vZ^{\ell}$ printr-o coborâre pe gradient pentru a minimiza termenul ratei de codare $R^c_\epsilon (\vZ \mid \vU_{[K]}^\ell)$. Specific, facem un pas de gradient pe $R^c_\epsilon$ cu o rată de învățare $\kappa$ după cum urmează:
+\begin{align}\label{eq:Z l+1/2}
+    \bm Z^{\ell+1/2} = \bm Z^\ell - \kappa \nabla_{\bm Z} R^c_\epsilon (\vZ \mid \vU_{[K]}^\ell). 
+\end{align}
+Apoi, \textit{rarefiem} token-urile comprimate, generând \(\vZ^{\ell + 1}\) printr-un pas de gradient proximal relaxat corespunzător pentru a minimiza termenul rămas $\lambda \norm{\vZ}_{1} - R_{\epsilon}(\vZ)$. După cum vom argumenta în detaliu mai târziu, putem găsi un astfel de $\bm Z^{\ell+1}$ rezolvând o problemă de prezentare rară în raport cu un dicționar $\bm D^\ell$:
+\begin{equation}\label{eq:Z l+1}
+  \vZ^{\ell+1} = \argmin_{{\vZ}}  \bigg\{\lambda \norm{\vZ}_1 + \frac{1}{2}\norm{\vZ^{\ell + 1/2} - \vD^{\ell} {\vZ}}_F^2\bigg\}.
+\end{equation}
+În continuare, oferim detalii tehnice pentru fiecare dintre cei doi pași de mai sus și derivăm actualizări eficiente pentru implementarea lor.
+
+
+
+
+\paragraph{Auto-Atenție ca Coborâre pe Gradient pe Rata de Codare a Reprezentărilor Token.} Pentru primul pas \eqref{eq:Z l+1/2}, gradientul ratei de codare \(\nabla_{\bm Z} R^c_\epsilon\) este costisitor de calculat, deoarece implică \(K\) inverse de matrice separate, câte una pentru fiecare dintre cele \(K\) subspații cu baza \(\vU_{k}^{\ell}\):
+\begin{equation}
+    \nabla_{\bm Z} R_{\epsilon}^c(\vZ \mid \vU_{[K]})
+    = \frac{p}{N\epsilon^2}\sum_{k=1}^K \vU_k\vU_k^\top\vZ\Big(\I +
+    \frac{p}{N\epsilon^2}(\vU_k^\top\vZ)^\top(\vU_k^\top\vZ)\Big)^{-1}.
+    \label{eq:rate-gradient}
+\end{equation}
+Acum, demonstrăm că acest gradient poate fi aproximat în mod natural folosind un așa-numit operator de auto-atenție pe subspații multi-cap (MSSA), care are o formă funcțională similară cu operatorul de auto-atenție multi-cap \citep{vaswani2017attention} cu \(K\) capete (adică, unul pentru fiecare subspațiu, provenind din fiecare inversă de matrice). Aici, aproximăm gradientul \eqref{eq:rate-gradient} folosind seria Neumann de ordinul întâi (vezi \Cref{ex:neumannn}):
+\begin{align}\label{eq:gd_rc_neumann}
+    \nabla_{\bm Z} R_{\epsilon}^{c}(\vZ \mid \vU_{[K]}) 
+    &\approx \frac{p}{N\epsilon^2} \sum_{k = 1}^{K}\vU_{k}\vU_{k}^\top\vZ\left(\vI - \frac{p}{N\epsilon^2} (\vU_{k}^\top\vZ)^\top(\vU_{k}^\top\vZ)\right) \notag \\
+    &{= \frac{p}{N\epsilon^2} \left(\sum_{k = 1}^{K} \vU_{k}\vU_{k}^\top\right)\vZ -  \left( \frac{p}{N\epsilon^2}\right)^2\sum_{k = 1}^{K} \vU_{k}(\vU_{k}^\top\vZ)(\vU_{k}^\top\vZ)^\top(\vU_{k}^\top\vZ)}.
+\end{align}
+În această aproximare, calculăm similaritatea între reprezentările de token proiectate $\{\bm U_k^\top\bm z_i\}$ printr-o auto-corelație între caracteristicile proiectate ca $(\vU_{k}^\top\vZ)^\top(\vU_{k}^\top\vZ)$ și o convertim într-o distribuție de apartenență cu un softmax, și anume $\softmax{(\vU_{k}^\top\vZ)^\top(\vU_{k}^\top\vZ)}$.
+Să presupunem că o uniune de subspații $\bm U_{[K]}$ acoperă întregul spațiu. Atunci, avem $\sum_{k = 1}^{K} \vU_{k}\vU_{k}^\top = \bm I$. Prin urmare, \eqref{eq:gd_rc_neumann} devine
+\begin{align}\label{eq:grad Rc}
+    \nabla_{\bm Z} R_{\epsilon}^{c}(\vZ \mid \vU_{[K]}) 
+     \approx  \frac{p}{N\epsilon^2} \vZ -  \left( \frac{p}{N\epsilon^2}\right)^2 \MSSA\left(\vZ^{\ell} \mid \vU_{[K]}^{\ell}\right),
+\end{align}
+unde MSSA este definit printr-un operator SSA după cum urmează:
+\begin{align}
+    & \mathrm{SSA}\left(\vZ \mid \vU_{k}\right) 
+    \doteq (\vU_{k}^\top \vZ)\mathrm{softmax}\left((\vU_{k}^\top\vZ)^\top(\vU_{k}^\top\vZ)\right), \ \forall k \in [K], \label{eq:SSA} \\
+    & \mathrm{MSSA}\left(\vZ \mid \vU_{[K]}\right) 
+    \doteq \frac{p}{N\epsilon^2} \mat{\vU_{1}, \dots, \vU_{K}}\mat{\mathrm{SSA}({\vZ \mid \vU_{1}}) \\ \vdots \\ \mathrm{SSA}({\vZ \mid \vU_{K}})}.\label{eq:Multi-Head-SSA}
+\end{align}
+Substituind \eqref{eq:grad Rc} în \eqref{eq:Z l+1/2} rezultă că poate fi aproximat în mod natural prin
+\begin{equation}
+    \vZ^{\ell + 1/2} = \left(1 - \frac{\kappa p}{N\epsilon^2}\right) \vZ^{\ell} + \frac{\kappa p}{N\epsilon^2} \mathrm{MSSA}\left(\vZ^{\ell}\ \middle|\ \vU_{[K]}^{\ell}\right).  \label{eq:gd-mcr-parts} 
+\end{equation}
+
+
+
+\begin{remark}
+    Operatorul SSA din \eqref{eq:SSA} seamănă cu \textit{operatorul de atenție} dintr-un transformer tipic \citep{vaswani2017attention}, cu excepția că aici operatorii liniari de valoare, cheie și interogare sunt toți setați să fie \textit{aceiași} ca baza subspațiului, adică $\vV_{k} = \vK_{k} = \bm{Q}_{k} = \vU_k^*$. Prin urmare, numim $\mathrm{SSA}({\spcdot\mid\vU_k}): \bR^{d\times n} \rightarrow \bR^{p\times n}$ operatorul de \textbf{A}uto-\textbf{A}tenție pe \textbf{S}ubspații (SSA). Apoi, întregul operator MSSA din \eqref{eq:Multi-Head-SSA}, definit formal ca \(\mathrm{MSSA}({\spcdot \mid \vU_{[K]}}) \colon \bR^{d \times n} \to \bR^{d \times n}\) și numit operatorul de \textbf{A}uto-\textbf{A}tenție pe \textbf{S}ubspații \textbf{M}ulti-\textbf{C}ap (MSSA), agregă ieșirile capetelor de atenție prin medierea folosind ponderi dependente de model, similar în concept cu popularul operator de auto-atenție multi-cap din rețelele transformer existente. Pasul general de gradient \eqref{eq:gd-mcr-parts} seamănă cu auto-atenția multi-cap implementată cu o conexiune de salt în transformatoare.
+\end{remark}
+
+
+
+
+\paragraph{MLP ca Coborâre pe Gradient Proximal pentru Codarea Rară a Reprezentărilor Token.} Pentru al doilea pas al minimizării alternante, trebuie să minimizăm $\lambda \norm{\vZ}_{1} - R_{\epsilon}(\vZ)$. Observăm că gradientul \(\nabla R_{\epsilon}(\vZ)\) implică o inversă de matrice și, prin urmare, gradientul proximal naiv (vezi \Cref{subsec:pgd}) pentru a optimiza această problemă devine intractabil pentru probleme la scară largă. %
+Prin urmare, adoptăm o abordare diferită, simplificatoare, pentru a face compromis între diversitatea reprezentațională și rarefiere: postulăm un dicționar (complet) incoerent sau ortogonal $\vD^{\ell} \in \bR^{d \times d}$ și cerem să rarefiem iterațiile intermediare $\vZ^{\ell + 1/2}$ în raport cu \(\vD^{\ell}\). Adică, $\vZ^{\ell + 1/2} \approx \vD^{\ell} \vZ^{\ell + 1}$ unde $\vZ^{\ell + 1}$ este mai rar; adică, este o \textit{codare rară} a lui \(\vZ^{\ell + 1/2}\). Dicționarul \(\vD^{\ell}\) este folosit pentru a rarefia toate token-urile simultan.
+Prin ipoteza de incoerență, avem $(\vD^{\ell})^\top(\vD^{\ell}) \approx \vI$. Astfel din \eqref{eq:coding_rate} avem
+\begin{equation}
+    R_{\epsilon}(\vZ^{\ell + 1/2}) \approx R_{\epsilon}(\vD^{\ell}\vZ^{\ell + 1}) \approx R_{\epsilon}(\vZ^{\ell + 1}).
+\end{equation}
+Pentru a rezolva $\lambda \norm{\vZ}_{1} - R_{\epsilon}(\vZ)$, optimizăm următoarea problemă
+\begin{align*}
+       \vZ^{\ell + 1} \approx \argmin_{\vZ}  \norm{\vZ}_1 \quad \mbox{sub condiția} \quad \vZ^{\ell + 1/2} = \vD^{\ell}\vZ.
+\end{align*}
+{Programul de reprezentare rară de mai sus este de obicei rezolvat prin relaxarea lui la un program convex neconstrâns, cunoscut ca LASSO \citep{Wright-Ma-2022}:}
+\begin{equation}
+    \vZ^{\ell + 1} \approx \argmin_{\vZ} \left[\lambda \norm{\vZ}_1 + \frac{1}{2}\norm{\vZ^{\ell + 1/2} - \vD^{\ell} \vZ}_F^2 \right].
+\end{equation}
+În implementarea noastră, adăugăm și o constrângere nenegativă la $\vZ^{\ell + 1}$ și rezolvăm LASSO nenegativ corespunzător:
+\begin{equation}
+    \vZ^{\ell + 1} \approx \argmin_{\vZ \geq \bm 0} \left[\lambda\norm{\vZ}_1 + \frac{1}{2}\norm{\vZ^{\ell + 1/2} - \vD^{\ell} \vZ}_{F}^{2}\right].
+    \label{eq:sparse-nonnegative}
+\end{equation}
+Apoi, optimizăm incremental \Cref{eq:sparse-nonnegative} efectuând un pas de {\em coborâre pe gradient proximal} desfășurat, cunoscut ca un pas ISTA \citep{beck2009fast}, pentru a da actualizarea:
+\begin{align}\label{eq:ista-block}
+    \vZ^{\ell + 1} 
+    &= \mathrm{ISTA}({\vZ^{\ell + 1/2} \mid \vD^{\ell}}), \\
+    \text{unde} \quad \mathrm{ISTA}({\vZ \mid \vD}) 
+    &\doteq \operatorname{ReLU}(\vZ - \eta \vD^\top(\vD\vZ - \vZ) - \eta \lambda \bm{1}).
+\end{align}
+
+
+
+
+
+
+\begin{figure}
+     \centering
+     \includegraphics[width=0.75\textwidth]{\toplevelprefix/chapters/chapter4/figs/crate_encoder_architecture.pdf}
+    \caption{\small \textbf{Un strat al arhitecturii encoder CRATE.} Arhitectura completă este pur și simplu o concatenare a unor astfel de straturi, cu un tokenizator inițial, un cap de pre-procesare și un cap final specific sarcinii (adică, un cap de clasificare).}
+    \label{fig:crate_backbone}
+\end{figure}
+
+
+
+\subsection{Arhitectura Generală de Transformer cu Cutie Albă: CRATE}
+
+Acum proiectăm o arhitectură de transformer cu cutie albă, numită Transformatorul RATE de Codare (\textsc{crate}), prin desfășurarea actualizărilor de mai sus. Combinând cei doi pași de mai sus \eqref{eq:gd-mcr-parts} și \eqref{eq:ista-block}:
+\begin{enumerate}[leftmargin=0.7cm]
+    \item Compresia locală a token-urilor într-un eșantion către o structură de amestec de subspații, conducând la blocul de auto-atenție pe subspații multi-cap -- \texttt{MSSA};
+    \item Rarefierea globală a seturilor de token-uri pe toate eșantioanele prin codare rară, conducând la blocul de rarefiere -- \texttt{ISTA};
+\end{enumerate}
+putem obține următorul strat de transformer bazat pe reducerea ratei, ilustrat în \Cref{fig:crate_backbone},
+\begin{equation}
+    \vZ^{\ell+1/2} \doteq \vZ^{\ell} + \texttt{MSSA}(\vZ^{\ell} \mid \vU_{[K]}^{\ell}), 
+    \qquad 
+    \vZ^{\ell+1}\doteq \texttt{ISTA}(\vZ^{\ell+1/2} \mid \bm D^\ell).
+\end{equation}
+Compunând mai multe astfel de straturi urmând construcția incrementală a reprezentării noastre din \eqref{eq:incremental}, obținem o arhitectură de transformer cu cutie albă care transformă token-urile de date către o uniune compactă și rară de subspații incoerente, unde $f^{\pre}: \bR^{D \times N} \rightarrow \bR^{d \times N}$ este maparea de pre-procesare care transformă token-urile de intrare $\vX \in \bR^{D \times N}$ în reprezentări de prim strat $\vZ^{1} \in \bR^{d \times N}$. Un flux general al acestei arhitecturi a fost arătat în \Cref{fig:crate-diagram}.
+
+\begin{figure}[t!]
+     \centering
+         \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/CRATE_fig1_patches.pdf}
+     \vspace{-0.1in}
+     \caption{
+     \textbf{„Bucla principală" a proiectării rețelei profunde cu cutie albă \textsc{crate}.}
+     După codarea datelor de intrare ca o secvență de token-uri $\vZ^0$, \textsc{crate} construiește o rețea profundă care transformă datele într-o configurație canonică de subspații de dimensiune mică prin {\textit{\textbf{compresie}}} succesivă
+     împotriva unui model local pentru distribuție, generând $\vZ^{\ell+1/2}$, și {\textit{\textbf{rarefiere}}}
+     împotriva unui dicționar global, generând $\vZ^{\ell+1}$.
+     Stivuirea repetată a acestor blocuri și antrenarea parametrilor modelului prin propagare înapoi produce o reprezentare puternică și interpretabilă a datelor.
+     }
+        \label{fig:crate-diagram}
+\end{figure}
+
+
+\begin{remark}[\textbf{Rolurile pasului înainte și propagării înapoi}]\label{sub:forward_backward}
+    În contrast cu alte abordări de optimizare desfășurată, cum ar fi ReduNet \cite{chan2021redunet}, noi \textit{modelăm explicit} distribuția fiecărui $\vZ^\ell$ și $\vZ^{\ell + 1/2}$ la fiecare strat, fie printr-un amestec de subspații liniare, fie generat rar dintr-un dicționar. Am introdus interpretarea că la fiecare strat \(\ell\), bazele învățate pentru subspații \(\vU_{[K]}^{\ell}\) și dicționarele învățate \(\vD^{\ell}\) servesc împreună ca un \textit{codebook} sau \textit{filtru de analiză} care codifică și transformă reprezentările intermediare la fiecare strat \(\ell\). Deoarece distribuția de intrare la stratul \(\ell\) este mai întâi modelată de \(\vU_{[K]}^{\ell}\) apoi transformată de \(\vD^{\ell}\), distribuția de intrare la fiecare strat este diferită și astfel necesităm un codebook separat la fiecare strat pentru a obține cea mai parsimonioasă codare. Parametrii acestor codebook-uri (adică bazele subspațiilor și dicționarele), presupuși până acum ca fiind perfect cunoscuți, sunt de fapt învățați din date (să zicem prin \textit{propagare înapoi} în cadrul antrenării de la capăt la capăt).
+    
+    Prin urmare, metodologia noastră prezintă o separare conceptuală clară între „optimizarea" directă și „învățarea" înapoi pentru rețeaua neuronală profundă cu cutie albă astfel derivată. Și anume, în pasul său înainte, interpretăm fiecare strat ca un operator care, condiționat de un model învățat (adică un codebook) pentru distribuția intrării sale, transformă această distribuție către o reprezentare mai parsimonioasă. În propagarea sa înapoi, codebook-ul acestui model, pentru distribuția intrării la fiecare strat, este actualizat pentru a se potrivi mai bine unei anumite relații (supervizate) intrare-ieșire, așa cum este ilustrat în \Cref{fig:forward-backward}. Această interpretare conceptuală implică un anumit agnosticism al reprezentărilor modelului față de sarcina și pierderea particulare; în special, multe tipuri de sarcini și pierderi vor asigura că modelele la fiecare strat sunt potrivite, ceea ce asigură că modelul produce reprezentări parsimonioase.
+\end{remark}
+
+
+
+
+
+
+Acum prezentăm performanța empirică a rețelelor propuse \textsc{crate} măsurând acuratețea lor de clasificare top-1 pe ImageNet-1K, precum și performanța de învățare prin transfer pe mai multe seturi de date downstream utilizate pe scară largă.
+Rezumăm rezultatele în \Cref{tab:crate_comparison_with_sota}. Metodologia de învățare prin transfer este de a face ajustare fină folosind pierderea de entropie încrucișată inițializând din rețelele pre-antrenate.
+Deoarece arhitectura de transformer cu cutie albă proiectată folosește partajarea parametrilor atât în blocul de atenție (\texttt{MSSA}) cât și în blocul de neliniaritate (\texttt{ISTA}), modelul \textsc{crate}{-Base} (22,80 milioane)
+are un număr similar de parametri cu ViT-Small (22,05 milioane)~\cite{dosovitskiy2020image} și mai puțin de 30% din parametrii unui ViT-Base configurat identic (86,54 milioane).
+Din \Cref{tab:crate_comparison_with_sota}, constatăm că, cu un număr similar de parametri ai modelului, rețeaua noastră propusă obține performanțe similare pe ImageNet-1K și de învățare prin transfer ca ViT, având în același timp un design simplu și principial. Mai mult, cu același set de hiperparametri de antrenare, observăm un comportament promițător de scalare în \textsc{crate}---îmbunătățim în mod constant performanța prin creșterea dimensiunii modelului. Pentru a rezuma, \textsc{crate} obține performanțe promițătoare pe seturi de date la scară largă din lumea reală prin implementarea directă a arhitecturii noastre principiale. Vom oferi mai multe detalii despre implementare și analiza rezultatelor experimentale privind clasificarea imaginilor în aplicația finală \Cref{ch:applications}.
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.48\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/forward.png}
+        \caption{\bf Pasul înainte}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.48\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/backward.png}
+        \caption{\bf Propagarea înapoi}
+    \end{subfigure}
+    \caption{\small {\bf Rolurile pasului înainte și propagării înapoi în rețelele profunde}. (a) Date fiind subspații și dicționare fixe $\{(\bm U_{[K]}^{\ell}, \bm D^{\ell})\}_{\ell=1}^L$, fiecare strat efectuează compresie și rarefiere asupra reprezentărilor în pasul înainte; (b) Propagarea înapoi învață subspații și dicționare $\{(\bm U_{[K]}^{\ell}, \bm D^{\ell})\}_{\ell=1}^L$ din datele de antrenare.}
+    \label{fig:forward-backward}
+\end{figure}
+
+
+\begin{table*}[t!]
+\centering
+\caption{\small Acuratețea de clasificare top-1 a \textsc{crate} pe diferite seturi de date cu diferite scale de model
+când este pre-antrenat pe ImageNet-1K. Pentru ImageNet-1K/ImageNet-1K ReaL, evaluăm direct acuratețea top-1. Pentru alte seturi de date, folosim modele care sunt pre-antrenate pe ImageNet ca inițializare și evaluăm performanța de învățare prin transfer prin ajustare fină.}
+\label{tab:crate_comparison_with_sota}
+\small
+    \setlength{\tabcolsep}{13.6pt}
+\resizebox{0.98\textwidth}{!}{\begin{tabular}{@{}lcccc|cc@{}}
+\toprule
+\textbf{Model} & \textsc{crate}{-T}  &  \textsc{crate}{-S} & \textsc{crate}{-B} & \textsc{crate}{-L} & { \color{gray} ViT-T} &  { \color{gray}ViT-S } \\ 
+\midrule
+\midrule
+ \# parametri & 6,09M & 13,12M & 22,80M & 77,64M & { \color{gray} 5,72M} & { \color{gray} 22,05M} \\
+\midrule
+ ImageNet-1K & 66,7 & 69,2 & 70,8 & 71,3 & { \color{gray} 71,5} & { \color{gray} 72,4} \\
+ ImageNet-1K ReaL & 74,0 & 76,0 & 76,5 & 77,4 & { \color{gray} 78,3 } & { \color{gray} 78,4} \\
+ \midrule
+ CIFAR10 & 95,5 & 96,0 & 96,8 & 97,2 & { \color{gray} 96,6} & { \color{gray} 97,2} \\
+ CIFAR100 & 78,9 & 81,0 & 82,7 & 83,6 & { \color{gray} 81,8} & { \color{gray} 83,2}\\
+ Oxford Flowers-102 & 84,6 & 87,1 & 88,7 & 88,3 & { \color{gray} 85,1} & { \color{gray} 88,5}\\
+ Oxford-IIIT-Pets & 81,4 & 84,9 & 85,3 & 87,4 & { \color{gray} 88,5} & { \color{gray} 88,6} \\
+ \bottomrule
+\end{tabular}}
+\end{table*}
+
+
+
+\section{Variante de Arhitecturi Profunde prin Design} \label{sec:chap4-derive-white-box-transformer-variants}
+
+Până acum, sperăm că am oferit dovezi convingătoare că rolul rețelelor profunde (populare) este de a realiza anumite algoritmi de optimizare pentru minimizarea ratei de codare (sau maximizarea câștigului de informație) a reprezentărilor învățate. Cu toate acestea, cititorii care sunt familiarizați cu metodele de optimizare ar fi putut observa că arhitecturile de mai sus (ReduNet sau CRATE) corespund unor tehnici de optimizare destul de de bază. Ele ar putea avea mult spațiu pentru îmbunătățire în eficiență sau eficacitate. Mai mult, dacă credem că cadrul teoretic propus pentru interpretarea rețelelor profunde este corect, acesta nu ar trebui doar să ajute la explicarea arhitecturilor existente, ci ar trebui să ne ghideze în dezvoltarea unor arhitecturi mai eficiente și eficace. În această secțiune, arătăm că acest lucru ar putea fi cazul: noile arhitecturi rezultate nu sunt doar complet interpretabile, ci și cu corectitudine garantată și eficiență îmbunătățită.
+
+
+
+
+\subsection{Arhitectură de Transformer Doar cu Atenție} \label{sub:aot}
+
+În această subsecțiune, propunem o arhitectură minimalistă de transformer constând din straturi interpretabile bazate pe operatorul MSSA. Pentru a deriva o arhitectură de transformer complet interpretabilă cu doar componentele necesare,
+susținem că obiectivul învățării reprezentării este de a comprima un set de reprezentări inițiale zgomotoase ale token-urilor către un amestec de subspații de dimensiune mică. %
+Aici, presupunem că reprezentările inițiale ale token-urilor $\bm Z^{(1)}$ sunt eșantionate dintr-un amestec de gaussiene de rang mic perturbate de zgomot după cum urmează:
+\begin{definition}\label{def:MoG}
+Fie $C_1,\dots,C_K$ o partiție a setului de indici $[N]$ și $\bm U_k \in \mathcal{O}^{d \times p_k}$ să denoteze baza ortonormală a celui de-al $k$-lea subspațiu pentru fiecare $k \in [K]$. Spunem că reprezentările token-urilor $\{\bm z_i \}_{i=1}^N \subseteq \R^d$ sunt eșantionate dintr-un amestec de distribuții gaussiene zgomotoase de rang mic dacă pentru fiecare $k \in [K]$,
+\begin{align}\label{eq:MoG}
+    \bm z_i = \underbrace{\bm U_{k} \bm a_i}_{\bf semnal} + \underbrace{\sum_{j \neq k}^K \bm U_j \bm e_{i,j}}_{\bf zgomot},\ \forall i \in C_k, 
+\end{align}
+unde $\bm{a}_i \overset{i.i.d.}{\sim} \mathcal{N}(\bm{0},\bm{I}_{p_k})$ și $\bm{e}_{i,j} \overset{i.i.d.}{\sim} \mathcal{N}(\bm{0},\delta^2\bm{I}_{p_j})$ pentru toți $i \in C_k$ și $k \in [K]$, $\{\bm{a}_i\}$ și $\{\bm{e}_{i,j}\}$ sunt respectiv mutual independente, și $\{\bm{a}_i\}$ este independent de $\{\bm{e}_{i,j}\}$.
+\end{definition}
+Acest model servește ca un cadru idealizat pentru aproximarea reprezentărilor token-urilor în LLM-urile pre-antrenate din lumea reală. Acesta presupune că reprezentările token-urilor sunt eșantionate dintr-un amestec de distribuții gaussiene multiple de rang mic cu zgomot. În plus, acest model se aliniază bine cu două ipoteze bine stabilite despre structura reprezentărilor token-urilor în modelele de limbaj mari pre-antrenate: „ipoteza reprezentării liniare" \citep{jiang2024origins,park2023linear} și „ipoteza suprapunerii" \citep{elhage2022toy,yun2021transformer}.
+
+\begin{remark}
+    Ipoteza reprezentării liniare postulează că reprezentările token-urilor în LLM-uri se află în subspații liniare de dimensiune mică care codifică caracteristici semantice. Similar, ipoteza suprapunerii sugerează că aceste reprezentări pot fi exprimate aproximativ ca o combinație liniară rară a acestor vectori de caracteristici. În \Cref{def:MoG}, fiecare bază $\bm U_k$ a subspațiilor poate fi interpretată ca un set de caracteristici semantice, unde fiecare caracteristică corespunde unui aspect specific al sensului token-ului. Reprezentările token-urilor sunt apoi exprimate aproximativ ca combinații liniare rare ale acestor baze de subspații, capturând componentele semantice esențiale ale token-ului în timp ce ignoră dimensiunile irelevante.
+\end{remark}
+
+\paragraph{Operator de Eliminare a Zgomotului pentru Reprezentările Token.} Acum, arătăm că operatorul MSSA (vezi \eqref{eq:Multi-Head-SSA}) poate elimina incremental zgomotul din reprezentările token-urilor generate din modelul de mai sus. Specific, considerăm pentru fiecare $\ell =1 ,\dots,L$,
+\begin{align}\label{eq:MSSA}
+    \bm Z^{(\ell+1)} =  \bm Z^{(\ell)} + \eta \sum_{k=1}^K \bm U_k\bm U_k^T \bm Z^{(\ell)} \varphi \left(\bm Z^{(\ell)^T}\bm U_k\bm U_k^T\bm Z^{(\ell)} \right),
+\end{align}
+unde $\{\bm U_k\}_{k=1}^K$ este definit în \Cref{def:MoG}, $\eta > 0$ este dimensiunea pasului, și $\varphi$ este un operator element cu element, cum ar fi softmax, ReLU, sau alte funcții. Pentru a simplifica dezvoltarea noastră, presupunem că subspațiile din \Cref{def:MoG} sunt ortogonale între ele, adică $\bm U_k^T\bm U_j = \bm 0$ pentru toți $k \neq j$. Observăm că această presupunere nu este restrictivă, deoarece în spații cu dimensiune mare, subspațiile aleatoare de dimensiune mică sunt incoerente între ele cu probabilitate mare, adică $\bm U_k^T\bm U_j \approx \bm 0$ \citep{Wright-Ma-2021}.\footnote{Se poate generaliza direct rezultatele noastre la subspații ne-ortogonale, cu o analiză ușor mai sofisticată.}
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.45\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/SNR1.png}
+        \caption{Nivel de zgomot $\delta = 0,2$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.45\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter4/figs/SNR2.png}
+        \caption{Nivel de zgomot $\delta = 0,5$}
+    \end{subfigure}
+    \caption{{\bf Performanța de eliminare a zgomotului a transformatorului doar cu atenție.} Aici, eșantionăm reprezentări inițiale ale token-urilor dintr-un amestec de gaussiene de rang mic din \Cref{def:MoG}. Apoi, aplicăm \eqref{eq:MSSA} pentru a actualiza reprezentările token-urilor și raportăm SNR-ul la fiecare strat.} \label{fig:MSSA}
+\end{figure}
+
+
+Acum, fie coloanele lui $\bm Z_k^{(\ell)}$ să denoteze reprezentările token-urilor din al $k$-lea subspațiu la al $\ell$-lea strat. Pentru a cuantifica capacitatea de eliminare a zgomotului, definim raportul semnal-zgomot (SNR) pentru fiecare bloc al reprezentărilor token-urilor la al $\ell$-lea strat după cum urmează:
+\begin{align}\label{def:SNR}
+\mathrm{SNR}(\bm Z_k^{(\ell)}) \doteq  \frac{\|\bm U_k\bm U_k^T\bm Z_k^{(\ell)} \|_F}{\|(\bm I - \bm U_k\bm U_k^T)\bm Z_k^{(\ell)} \|_F},\quad \forall k \in [K].
+\end{align}
+Pentru a simplifica analiza noastră, presupunem că $p=p_1=\dots=p_K$, $N_1=\dots=N_K=N/K$, și
+\begin{align}\label{eq:orth}
+\begin{bmatrix}
+\bm U_1 & \dots & \bm U_K
+\end{bmatrix} \in \mathcal{O}^{d\times Kp}.
+\end{align}
+
+Cu configurația de mai sus, acum caracterizăm performanța de eliminare a zgomotului a operatorului MSSA.
+
+\begin{figure*}[t]
+\begin{center}
+        \includegraphics[width=0.75\textwidth]{\toplevelprefix/chapters/chapter4/figs/MSSA.png}
+    \caption{\textbf{Detalii ale arhitecturii transformatorului doar cu atenție.} Fiecare strat constă din operatorul MSSA și o conexiune de salt. În plus, LayerNorm este inclus doar pentru sarcini de limbaj. În practică, propagarea înapoi este aplicată pentru a antrena parametrii modelului folosind eșantioane de antrenare. %
+    }\label{fig:transformer}
+\end{center}
+\end{figure*}
+
+\begin{theorem}\label{thm:1}
+Fie $\bm Z^{(1)}$ definit în \Cref{def:MoG} și $\varphi(\cdot)$ din \eqref{eq:MSSA} să fie
+$\varphi(\bm x) = h\left(\sigma(\bm x)\right)$,
+unde $\sigma:\R^N \to \R^N$ este funcția softmax și $h:\R^N \to \R^N$ este o funcție de prag element cu element cu $h(x) = \tau \mathbb{I}\left\{x > \tau\right\}$ pentru fiecare $i \in [N]$. Să presupunem că $p \gtrsim \log N$, $\delta \lesssim \sqrt{\log N}/\sqrt{p}$, și
+\begin{align*}
+\tau \in \left( \frac{1}{2},  \frac{1}{1+N\exp(-9p/32)} \right].
+\end{align*}
+Pentru $N$ suficient de mare, avem cu probabilitate cel puțin $1-KLN^{-\Omega(1)}$ că pentru fiecare $\ell \in [L]$,
+    \begin{align}\label{eq:SNR}
+        \mathrm{SNR}(\bm Z_k^{(\ell+1)}) = (1+\eta\tau) \mathrm{SNR}(\bm Z_k^{(\ell)}),\ \forall k \in [K].
+    \end{align}
+\end{theorem}
+Această teoremă demonstrează că atunci când reprezentările inițiale ale token-urilor sunt eșantionate dintr-un amestec de distribuții gaussiene de rang mic cu un nivel de zgomot $O(\sqrt{\log N}/\sqrt{p})$, arătăm că fiecare strat al transformatorului propus elimină zgomotul din reprezentările token-urilor la o rată liniară. Aceasta indică eficiența operatorului MSSA în reducerea zgomotului pe straturi. În mod notabil, rezultatele noastre teoretice sunt bine susținute de observațiile experimentale din \Cref{fig:MSSA}. Această teoremă oferă o fundație teoretică pentru capacitatea practică de eliminare a zgomotului a arhitecturii de transformer derivate prin desfășurarea (\ref{eq:MSSA}).
+
+\begin{remark}
+    Sub acest model, obiectivul învățării reprezentării este de a comprima un set de prezentări inițiale zgomotoase ale token-urilor în subspațiul corespunzător. Cu toate acestea, ar trebui să subliniem că în aplicațiile din lumea reală, unde reprezentările token-urilor prezintă structuri mai complicate, obiectivul învățării reprezentării este de a găsi o reprezentare compactă și structurată prin comprimarea seturilor de token-uri.
+\end{remark}
+
+
+\paragraph{Transformer Doar cu Atenție.} Acum, propunem formal o arhitectură de transformer doar cu atenție. Specific, prin desfășurarea pașilor de optimizare iterativă (\ref{eq:MSSA}) ca straturi ale unei rețele profunde, construim o arhitectură de transformer în \Cref{fig:transformer}. Fiecare strat al arhitecturii propuse constă doar din operatorul MSSA și o conexiune de salt. Pentru sarcini de limbaj, încorporăm suplimentar LayerNorm înainte de operatorul MSSA pentru a îmbunătăți performanța. Arhitectura completă este construită prin stivuirea unor astfel de straturi, împreună cu pași esențiali de pre-procesare și post-procesare specifici sarcinii, cum ar fi codarea pozițională, încorporarea token-urilor și capul final specific sarcinii pentru a se adapta la diferite aplicații.
+
+
+
+
+În general, arhitectura standard de transformer doar-decodor este compusă din următoarele componente cheie \cite{vaswani2017attention}: (1) codare pozițională, (2) mecanisme de auto-atenție QKV multi-cap, (3) rețele MLP feed-forward, (4) normalizare pe straturi și (5) conexiuni reziduale. În contrast, arhitectura noastră de transformer propusă adoptă un design simplificat prin încorporarea mai multor simplificări cheie. Specific, folosește mecanisme de auto-atenție pe subspații cu QKV partajat, exclude straturile MLP și reduce frecvența LayerNorm.
+
+
+
+
+
+
+
+
+\subsection{Atenție cu Timp Liniar: Transformer cu Statistici de Token}\label{sub:tost}
+
+În această subsecțiune, propunem un nou operator de atenție transformer a cărui complexitate computațională scalează liniar cu numărul de token-uri pe baza obiectivului de reducere a ratei de codare. Specific, derivăm o nouă formă variațională a obiectivului MCR$^2$ și arătăm că arhitectura care rezultă din coborârea pe gradient desfășurată a acestui obiectiv variațional conduce la un nou modul de atenție numit Auto-Atenție cu Statistici de Token (\texttt{TSSA}). \texttt{TSSA} are {\em complexitate computațională și de memorie liniară} și se îndepărtează radical de arhitectura tipică de atenție care calculează similarități perechi între token-uri. Reamintim din \eqref{eq:pi} că $\bm \Pi = [\bm \pi_1, \ldots, \bm \pi_K] \in \R^{N \times K}$ denotă o matrice stocastică de „atribuire de grup" (adică, $\bm \Pi \bm 1 = \bm 1$ și $\Pi_{ik} \geq 0, \  \forall (i,k) \in [N] \times [K]$), unde $\Pi_{ik}$ denotă probabilitatea de a atribui al $i$-lea token grupului $k$.
+
+
+\paragraph{O Nouă Formă Variațională pentru Ratele de Codare.} Pentru a începe, considerăm o formă generală de obiective de tip MCR$^2$ bazate pe funcții concave ale spectrului unei matrice. Și anume, pentru o matrice PSD dată $\bm M \in \PSD(d)$ și orice scalar $c \geq 0$ avem că $\log \det (\I + c \bm M) = \sum_{i=1}^{d} \log( 1 + c \lambda_i(\bm M))$, unde $\lambda_i (\bm M)$ este a $i$-a cea mai mare valoare proprie a lui $\bm M$. Mai mult, observăm că $\log(1 + c \sigma)$ este o funcție concavă necrescătoare a lui $\sigma$. Astfel, descriem rezultatele noastre în termenii unei forme mai generale de MCR$^2$ bazată pe funcții spectrale generale ale matricelor PSD de forma $F(\bm M) = \sum_{i=1}^{d} f(\lambda_i(\bm M))$, unde $f$ este concavă și necrescătoare. În particular, reamintim din discuția noastră de mai sus că mecanismul de atenție apare din desfășurarea componentei de compresie a MCR$^2$, așa că considerăm o funcție de compresie de stil MCR$^2$ mai generală:
+\vspace{-2mm}
+\begin{equation}
+    R_{c,f}(\bm Z, \bm \Pi) \doteq \frac{1}{2}\sum_{k=1}^K \frac{N_k}{N} F\left( \frac{1}{N_k}\Z \mathrm{Diag}(\bm \pi_k) \Z^{\top} \right).
+    \label{eq:mcr_c_gen}
+\end{equation}
+
+
+
+Pentru obiectivul de mai sus, observăm acum următorul rezultat:
+\begin{theorem}
+\label{thm:var_concave}
+    Fie \(f \colon [0, \infty) \to \R\) necrescătoare, concavă și care respectă \(f(0) = 0\), și fie \(F \colon \PSD(d) \to \R\) având forma \(F(\bm M) = \sum_{i = 1}^{d}f(\lambda_{i}(\bm M))\). Atunci pentru fiecare \(\bm M \in \PSD(d)\) și \(\bm Q \in \O(d)\), avem
+    \begin{equation}
+        \label{eq:U_bound}
+        F(\bm M) \leq  \sum_{i=1}^{d} f\left( (\bm Q^{\top} \bm M \bm Q)_{ii} \right).
+    \end{equation}
+    Mai mult, inegalitatea din \eqref{eq:U_bound} este atinsă cu egalitate pentru orice $\bm Q$ care diagonalizează $\bm M$, și dacă $f$ este strict concavă atunci inegalitatea din \eqref{eq:U_bound} este atinsă cu egalitate \textit{dacă și numai dacă} $\bm Q$ diagonalizează $\bm M$.
+\end{theorem}
+
+Folosind rezultatul de mai sus, putem înlocui \eqref{eq:mcr_c_gen} cu un obiectiv variațional echivalent cu forma
+\vspace{-2mm}
+\begin{equation}
+    \label{eq:var_comp}
+    R^{\rm var}_{c,f} (\Z,\bm \Pi \mid \bm U_{[K]}) \doteq \frac{1}{2}\sum_{k=1}^K \frac{N_k}{N} \sum_{i=1}^{d} f\left(\frac{1}{N_k} (\bm U_{k}^{\top} \Z \mathrm{Diag}(\bm \pi_k) \bm Z^{\top} \bm U_{k})_{ii} \right),
+\end{equation}
+unde echivalența este în sensul că pentru o alegere optimă a matricelor $\{ \bm U_k \in \O(d)\}_{k=1}^K$ așa cum este descris în \Cref{thm:var_concave} (adică, matrice ortogonale care diagonalizează fiecare $\Z \mathrm{Diag}(\bm \pi_k) \Z^\top $) vom atinge o limită strânsă cu $ R^{\rm var}_{c,f} (\Z,\bm \Pi \mid \bm U_{[K]}) = R_{c,f} (\Z,\bm \Pi)$. Observăm că în general, atingerea acestei limite ar necesita selectarea, pentru fiecare instanță eșantionată a lui $\Z$, a unui nou set optim de matrice parametru $\bm U_{k}$ care diagonalizează fiecare $\Z\mathrm{Diag}(\bm \pi_{k})\Z^{\top}$, ceea ce este clar impracticabil pentru arhitectura rețelei.
+În schimb, ca un punct de vedere alternativ, în loc să considerăm datele ($\Z$) ca fixe și să încercăm să optimizăm parametrii $\bm U_k$ pentru a atinge limita variațională strânsă, putem în schimb să luăm principiul de design de desfășurare algoritmică descris mai sus și să proiectăm un operator pentru a perturba $\Z$ pentru a minimiza incremental $R_{c, f}^{\rm var}(\cdot \mid \bm U_{[K]})$. Pentru a face acest punct explicit, fiecare limită variațională devine strânsă când spațiile proprii ale $\Z \mathrm{Diag}(\bm \pi_k) \Z
+^\top$ se aliniază cu coloanele lui $\bm U_k$, așa că prin rotirea coloanelor corespunzătoare ale lui $\Z$ (și anume, cele care corespund intrărilor mari din $\bm \pi_k$) pentru a se alinia cu $\bm U_k$ putem aborda o limită variațională strânsă. Adică, în loc să rotim $\bm U_k$ pentru a se alinia cu datele pentru fiecare instanță a lui $\Z$, putem în schimb să rotim caracteristicile token-urilor din fiecare $\Z$ pentru a se alinia cu $\bm U_k$.
+
+Urmând această abordare, calculăm un pas de coborâre pe gradient pe $R_{c,f}^{\rm var}$ în raport cu $\Z$.
+Pentru a începe acest calcul, mai întâi fie $\bm \pi \in \Re^N$ orice vector nenegativ element cu element. Atunci avem
+\begin{equation}\label{eq1:grad Rcf}
+\nabla_{\Z} \ \frac{1}{2} \sum_{i = 1}^{d} f(  (\Z \mathrm{Diag}(\bm \pi) \Z^{\top} )_{ii}) %
+= \; \mathrm{Diag}(\nabla f[ \Z^{\hada 2} \bm \pi] ) \Z \mathrm{Diag}(\bm \pi),
+\end{equation}
+unde $\nabla f$ este gradientul lui $f$, și (reamintim) $\nabla f[\cdot]$ aplică $\nabla f$ la fiecare element al vectorului din paranteză. În particular, pentru $ f(x) = \log(1 + (d/\epsilon^{2}) x)$, $\nabla f(x) = (d / \epsilon^{2}) (1+ (d / \epsilon^{2}) x)^{-1}$ este pur și simplu o activare neliniară. De asemenea, (reamintim) $N_{k} = \langle \bm \pi_{k}, \bm 1\rangle$. Astfel, gradientul lui $R^{\rm var}_{c,f}$ în raport cu $\Z$ este:
+\begin{align}\label{eq2:grad Rcf}
+    \nabla_{\Z} R^{\rm var}_{c,f}(\Z,\bm \Pi \mid \bm U_{[K]}) =  \frac{1}{n}
+    \sum_{k=1}^K \bm U_{k} \underbrace{\mathrm{Diag} \left( \nabla f\left[ (\bm
+    U_{k}^{\top} \Z)^{\hada 2}  \frac{\bm \pi_k}{\langle \bm \pi_{k}, \bm 1\rangle} \right] \right)}_{\doteq \bm D(\Z, \bm \pi_{k} \mid \bm U_{k})} \bm U_{k}^{\top} \Z \mathrm{Diag}(\bm \pi_k).
+\end{align}
+(Observăm că constanta $1/N$ apare dintr-o constantă $(N_{k}/N)\cdot (1/N_{k}) = 1/N$ în fiecare termen al sumei.) Dacă acum considerăm un pas de gradient în raport cu al $j$-lea token $\z_j$
+, ajungem la operatorul nostru de compresie incrementală propus, adică surogatorul nostru pentru un operator de \textit{auto-atenție} + rezidual:
+\vspace{-2mm}
+\begin{equation}\label{eq:layer-operation-orig}
+    \z_j^+ = \z_{j} - \tau \nabla_{\z_{j}}R_{c, f}^{\rm var}(\Z, \bm \Pi \mid \bm U_{[K]}) = \z_j - \frac{\tau}{N} \sum_{k=1}^K \Pi_{jk} \bm U_{k} \bm D(\Z, \bm \pi_{k} \mid \bm U_{k}) \bm U_{k}^{\top} \z_j
+\end{equation}
+pentru fiecare \(j \in [n]\), unde $\tau > 0$ este un parametru de dimensiune a pasului pentru optimizarea incrementală. Apoi, putem construi un strat de TOST în \Cref{fig:vcrate-architecture}.
+
+\begin{figure}[t]
+    \centering \includegraphics[width=1\textwidth,trim={0 5.0cm 0 0},clip]{\toplevelprefix/chapters/chapter4/figs/V-CRATE.pdf}
+    \vspace{-1mm}
+    \caption{\small \textbf{Un strat $\ell$ al Transformatorului cu Statistici de Token (ToST) propus.} În mod notabil, auto-atenția ToST transformă eficient token-urile $\Z^{\ell}$ în $\Z^{\ell+1}$, prin înmulțirea fiecărei linii a token-ului proiectat cu \textit{doar un scalar}. Aceasta conduce la complexitate redusă a atenției: are complexitate spațială $O(p)$ și complexitate temporală $O(pn)$, unde $p$ este dimensiunea token-urilor proiectate ale fiecărui cap, și $n$ este numărul de token-uri.
+    }
+    \label{fig:vcrate-architecture}
+\end{figure}
+
+\paragraph{Interpretarea modelului.} Dat fiind operatorul de atenție propus în \eqref{eq:layer-operation-orig}, mai întâi reamintim că liniile lui $\bm\Pi$ sunt nenegative și însumează la 1
+, astfel încât operatorul nostru ia o medie ponderată a $K$ operatori de tip „cap de atenție" și apoi adaugă o conexiune reziduală. Folosind că \(\sum_{k = 1}^{K}\Pi_{jk} = 1\), putem rescrie \eqref{eq:layer-operation-orig} ca: %
+\vspace{-2mm}
+\begin{equation}
+\label{eq:z_up}
+    \z_j^+ = \sum_{k=1}^K \Pi_{jk} \Big[ \z_j \underbrace{- \frac{\tau}{n} \bm U_{k} \bm D(\Z, \bm \pi_{k} \mid \bm U_{k}) \bm U_{k}^{\top}}_{\text{acțiunea unui cap de atenție}} \z_j \Big].
+\end{equation}
+Adică, putem vedea fiecare cap de atenție ca mai întâi proiectând caracteristicile token-ului
+pe baza $\bm U_{k}$ prin înmulțirea cu $\bm U_k^\top$, înmulțind cu
+matricea diagonală $\bm D(\Z, \bm \pi_{k} \mid \bm U_{k})$ (abreviată ca \(\bm
+D_{k}\)), proiectând înapoi în baza standard prin înmulțirea cu $\bm
+U_{k}$, și scăzând aceasta din caracteristicile originale ale token-ului prin
+conexiunea reziduală. Aspectul central al stratului nostru de atenție este calculul lui $\bm
+D_{k}$. Și anume, \(\Pi_{jk} \geq 0\), astfel încât $\bm \pi_k / \langle \bm \pi_{k}, \bm
+1\rangle \in \Re^N$ formează o distribuție de probabilitate asupra cărora token-uri aparțin
+grupului $k$. Ca rezultat, $(\bm U^\top_k \Z)^{\hada 2} \bm \pi_k / \langle \bm \pi_{k}, \bm 1\rangle$ estimează al doilea moment al $\bm U_k^\top \Z$ sub distribuția dată de $\bm \pi_k / \langle \bm \pi_{k}, \bm 1\rangle$. Mai mult, deoarece $f$ este o funcție concavă necrescătoare, $\nabla f(x)$ descrește monoton către $0$ pe măsură ce $x$ crește, astfel încât intrările lui $\bm D_{k}$ (care au forma $\nabla f(x)$) ating maximul lor la $x=0$ %
+și descresc monoton la $0$ pe măsură ce $x$ crește.
+
+Din aceasta, ajungem la interpretarea de bază a operatorilor noștri cap de atenție + rezidual
+$[\I - (\tau/n)\bm U_{k}\bm D_{k}\bm U_{k}^{\top}]$. Și anume, acest
+operator face o proiecție aproximativă de rang mic dependentă de date, unde
+direcțiile care au o cantitate mare de „putere" după proiecția $\bm
+U_k^\top \Z$ (adică, direcții care au un al doilea moment mare $(\bm
+U_{k}^{\top}\Z)^{\hada 2}\bm \pi_k / \langle \bm \pi_{k}, \bm 1\rangle$) sunt păstrate, în timp ce direcțiile care nu sunt suprimate. Pentru a vedea aceasta, reamintim că intrările lui $\bm D_k$ descresc monoton la 0 pe măsură ce al doilea moment crește, astfel încât pentru direcții cu momente secunde mari, operatorul de atenție + rezidual acționează în mare parte ca operatorul identitate. Invers, pentru direcții cu un al doilea moment mic, operatorul nostru scade o proiecție a token-urilor de-a lungul acelor direcții, rezultând în suprimarea acelor direcții. Comparativ cu operatorul standard de auto-atenție, metoda noastră în mod clar nu calculează nicio similaritate pereche între token-uri. Mai degrabă, interacțiunile dintre token-urile din $\Z$ impactează operatorul doar prin contribuția lor la statistica de al doilea moment folosită pentru a construi $\bm D_{k}$-urile. Cu toate acestea, similar cu operatorul standard de auto-atenție, metoda noastră are încă o interpretare clară ca efectuând o formă de compresie către o structură de rang mic dependentă de date, în sensul că efectuează o proiecție aproximativă de rang mic, unde direcțiile specifice care sunt suprimate sunt cele care nu sunt puternic aliniate cu alte token-uri din grup.
+
+\paragraph{Detalii Practice de Implementare.} După ce am introdus operatorul nostru de atenție propus, discutăm acum considerații practice suplimentare. Mai întâi, până în acest punct al prezentării, am evitat discuția despre cum token-urile sunt „grupate" în diferite capete de atenție prin matricea $\bm\Pi$, dar clar este nevoie de un mijloc de construire a lui $\bm\Pi$ pentru a implementa metoda noastră. În plus, forma noastră variațională din \Cref{thm:var_concave} necesită ca matricele $\bm U$ să fie pătrate și ortogonale, dar s-ar dori în mod ideal să se folosească matrice mai mici (adică, să se reducă numărul de coloane din $\bm U$) pentru eficiență, precum și să se renunțe la constrângerile de ortogonalitate.
+
+În practică, nu impunem constrângerile de ortogonalitate. Pentru a reduce numărul de coloane din matricele $\bm U$, observăm că similar cu CRATE \citep{yu2023white}, dacă presupunem că caracteristicile $\bm Z$ din grupul \(k\) sunt (aproximativ) grupate în jurul unui subspațiu de dimensiune mică --- să zicem de dimensiune \(p\) --- atunci covarianța în interiorul grupului-\(k\) \(\Z\mathrm{Diag}(\bm \pi_{k})\Z^{\top}\) este de rang mic, unde reamintim că \cite{yu2020learning} arată că geometria optimă a lui $\Z$ va fi ca fiecare grup să fie un subspațiu de rang mic, ortogonal pe celelalte grupuri. Putem astfel găsi explicit o bază ortonormală de dimensiune mică pentru imaginea acestei covarianțe, adică extinderea liniară a datelor din grupul \(k\). Dacă dimensiunea este $p \leq d$, baza poate fi reprezentată de o matrice ortogonală $d\times p$ $\bm U_k \in \O(d, p)$. În acest caz, putem limita superior mai eficient \(R_{c,f}\) folosind aceste matrice de bază ortogonale de rang mic. Pentru a arăta aceasta, folosim o versiune mai generală a \Cref{thm:var_concave} pentru a produce următorul corolar.
+\begin{corollary}\label{cor:var_concave_logdet}
+    Fie \(f \colon [0, \infty) \to \R\) necrescătoare, concavă și care respectă \(f(0) = 0\), și fie \(F \colon \PSD(p) \to \R\) având forma \(F(\bm M) = \sum_{i = 1}^{p}f(\lambda_{i}(\bm M))\). Fie \(\Z\), \(\bm \Pi\) fixe. Atunci, pentru toți \(\bm U_{1}, \dots, \bm U_{K} \in \O(d, p)\) astfel încât \(\mathrm{image}(\Z\diag(\bm \pi_{k})\Z^{\top}) \subset \mathrm{image}(\bm U_{k})\) pentru toți \(k \in [K]\), avem
+    \begin{equation}
+        R_{c, f}(\Z, \bm\Pi) \leq R_{c, f}^{\rm var}(\Z, \bm\Pi \mid \bm U_{[K]}), 
+    \end{equation}
+     unde \(R_{c, f}^{\rm var}\) este definit formal în \eqref{eq:var_comp}. Egalitatea este valabilă dacă \(\bm U_{k}\) diagonalizează \(\Z\diag(\bm \pi_{k})\Z^{\top}\) pentru fiecare \(k \in [K]\), și dacă \(f\) este puternic concavă atunci această condiție de egalitate devine un „dacă și numai dacă."
+\end{corollary}
+
+Pasul final pentru a defini operatorul nostru de atenție este să estimăm apartenența la grup $\bm\Pi$. Pentru aceasta postulăm un model simplu despre cum fiecare caracteristică \(\z_{j}\) deviază de la subspațiul său suport și apoi găsim atribuirea optimă de subspațiu. \cite{yu2023white} arată că dacă modelăm independent fiecare \(\z_{j}\) ca aparținând unui model de amestec gaussian de dimensiune mică, unde fiecare gaussiană are o matrice de covarianță cu spectru identic și este susținută pe un subspațiu cu bază ortonormală \(\bm U_{k}\), plus zgomot gaussian independent cu covarianță \(\eta \I\), atunci probabilitatea posterioară că fiecare token \(\z_{j}\) aparține fiecărui subspațiu este dată de matricea de atribuire \(\bm \Pi = \bm \Pi(\bm Z \mid \bm U_{[K]})\) după cum urmează:
+\begin{align}\label{eq:pi}
+    \bm \Pi = \begin{bmatrix} \boldsymbol{\nu}(\z_1 \mid \bm U_{[K]})^\top \\ \vdots \\ \boldsymbol{\nu}(\z_n \mid \bm U_{[K]})^\top \end{bmatrix}, \quad
+\text{unde} \quad 
+\boldsymbol{\nu}(\z_j \mid \bm U_{[K]}) \doteq \operatorname{softmax}\left( \frac{1}{2\eta} \begin{bmatrix} \|  \bm U_{1}^{\top} \z_j \|_2^2 \\ \vdots \\ \| \bm U_{K}^{\top} \z_j \|_2^2 \end{bmatrix} \right), \quad \forall j \in [n],
+\end{align}
+unde $\eta$ devine un parametru de temperatură învățabil. Astfel, dată fiind o caracteristică de intrare \(\Z\), estimăm \(\bm\Pi\) folosind \eqref{eq:pi} și apoi calculăm operatorul de atenție. Combinând construcția lui $\bm\Pi$ din \eqref{eq:pi} cu
+\eqref{eq:layer-operation-orig}, obținem operatorul {\em Auto-Atenție cu Statistici de Token}:
+\begin{equation}
+    \label{eq:tssa}
+   \texttt{TSSA}(\Z \mid \bm U_{[K]}) \doteq -\frac{\tau}{n}\sum_{k = 1}^{K}\bm U_{k}\bm D(\Z, \bm\pi_{k} \mid \bm U_{k})\bm U_{k}^{\top}\Z\diag(\bm \pi_{k}),
+\end{equation}
+unde \(\bm\pi_{k}\) sunt coloanele lui \(\bm\Pi = \bm\Pi(\Z \mid \bm U_{[K]})\) definit în \eqref{eq:pi} și \(\bm D\) este definit în \eqref{eq2:grad Rcf}.
+
+
+
+
+\section{Rezumat și Note}
+
+
+
+
+Materialele prezentate în acest capitol se bazează pe o serie de lucrări recente pe această temă, inclusiv \cite{chan2021redunet, wang2024global, wang2025attention, wu2025token, yu2023white}. Aceste contribuții cuprind atât progrese teoretice, cât și metodologii practice pentru construirea rețelelor profunde interpretabile prin optimizare desfășurată. Multe dintre rezultatele și demonstrațiile cheie discutate în acest capitol sunt derivate direct din, sau inspirate de, aceste lucrări fundamentale.
+
+
+Ideea de a desfășura un algoritm de optimizare pentru a construi o rețea neuronală datează de la lucrarea seminală \cite{gregor2010learning}. În această lucrare, autorii au demonstrat că algoritmii de codare rară—cum ar fi Algoritmul de Prag de Micșorare Iterativă (ISTA)—pot fi desfășurați pentru a forma perceptroni multistrat (MLP-uri), făcând efectiv legătura între optimizarea iterativă și designul rețelelor neuronale. În mod notabil, \cite{monga2019algorithm} a demonstrat că astfel de rețele desfășurate sunt mai interpretabile, mai eficiente din punct de vedere al parametrilor și mai eficace comparativ cu rețelele generice. În acest capitol, ne bazăm pe această perspectivă pentru a dezvolta arhitecturi de rețele profunde cu cutie albă principiale prin desfășurarea algoritmilor de optimizare care sunt proiectați să minimizeze obiective bine motivate—cum ar fi obiectivul de reducere a ratei (rare) introdus anterior. Această abordare nu numai că clarifică rolul fiecărui strat din rețea, dar oferă și o fundamentare teoretică pentru alegerile arhitecturale, depășind încercarea și eroarea empirică către un design interpretabil și orientat spre obiective. În continuare, comparăm DNN-urile convenționale, care sunt de obicei construite prin design empiric și ajustare euristică, cu arhitecturile noastre ReduNet fundamentate matematic:
+
+\begin{center}
+\begin{tabular}{| l || c | c |}
+\hline
+  & DNN-uri Convenționale & ReduNets\\ [0.5ex]
+  \hline \hline
+Obiective & potrivire intrare/ieșire & câștig de informație\\ [0.5ex]
+  \hline
+Arhitecturi profunde & încercare și eroare & optimizare iterativă \\  [0.5ex]
+\hline
+Operatori de strat & empirici & gradient proiectat \\  [0.5ex]
+\hline
+Invarianță la deplasare & CNN-uri+augmentare & ReduNets invariante \\  [0.5ex]
+\hline
+Inițializări & aleatorii/pre-proiectate & desfășurate înainte \\ [0.5ex]
+\hline
+Antrenare/ajustare fină & propagare înapoi & propagare înainte/înapoi\\ [0.5ex]
+\hline
+Interpretabilitate & cutie neagră & cutie albă \\ [0.5ex]
+\hline
+Reprezentări & ascunse/latente & subspații incoerente \\ [0.5ex]
+\hline
+\end{tabular}
+\end{center}
+
+
+
+
+\section{Exerciții și Extensii}
+
+
+\begin{exercise}
+    Fie $\bm Z = [\bm Z_1,\dots,\bm Z_K] \in \R^{d\times m}$ cu $\bm Z_k \in \R^{d\times m_k}$ pentru fiecare $k \in [K]$. Pentru un anumit $\alpha > 0$, fie
+    \begin{align*}
+        R(\bm Z) = \log\det\left(\bm I + \alpha\bm Z\bm Z^T \right).
+    \end{align*}
+1. Dată fiind orice direcție $\bm D \in \R^{d\times m}$, vă rugăm să arătați că $\nabla R(\bm Z) = \alpha\bm X^{-1}\bm Z$ și
+    \begin{align*}
+ \nabla^2 R(\bm Z)[\bm D, \bm D] =\alpha \mathrm{Tr}\left( \bm X^{-1}\bm D\bm D^T\right) - \frac{\alpha^2}{2}\mathrm{Tr}\left(\bm X^{-1}\left( \bm Z\bm D^T+\bm D\bm Z^T\right) \bm X^{-1}\left( \bm Z\bm D^T+\bm D\bm Z^T\right)\right),
+    \end{align*}
+    unde $\bm X \doteq \bm I + \alpha\bm Z\bm Z^T$. {\em Indiciu:} Observați că
+    \begin{align*}
+        \nabla^2 R(\bm Z)[\bm D, \bm D] \doteq \left\langle \lim_{t \to 0} \frac{\nabla R(\bm Z+ t\bm D) - \nabla R(\bm Z)}{t}, \bm D \right\rangle. 
+    \end{align*}
+
+\noindent
+2. Vă rugăm să arătați că
+\begin{align*}
+    R(\bm Z) \le \sum_{k=1}^K \log\det\left(\bm I + \alpha\bm Z_k\bm Z_k^T \right),
+\end{align*}
+unde egalitatea este valabilă dacă și numai dacă $\bm Z_k^T\bm Z_l = \bm 0$ pentru toți $k \neq l \in [K]$.
+\medskip 
+
+\noindent 
+3. Dat fiind un anumit $\alpha >0$, fie $\alpha_k=m\alpha/m_k$ pentru fiecare $k \in [K]$. Vă rugăm să derivați forma închisă pentru punctul critic de ordinul întâi al următoarei funcții:
+\begin{align*}
+    f(\bm Z_k) = \frac{1}{2}\log\det\left(\bm I + \alpha\bm Z_k\bm Z_k^T \right) - \frac{m_k}{2m}\log\det\left(\bm I + \alpha_k \bm Z_k\bm Z_k^T \right) - \frac{\lambda}{2}\|\bm Z_k\|_F^2. 
+\end{align*}
+{\em Indiciu:} Fie $r_k=\mathrm{rank}(\bm Z_k)$. Considerați următoarea descompunere în valori singulare a lui $\bm Z_k$:
+\begin{align*}
+    \bm Z_k = \bm P_k\bm \Sigma_k\bm Q_k^T = \begin{bmatrix}
+        \bm P_{k,1} & \bm P_{k,2}
+    \end{bmatrix} \begin{bmatrix}
+        \tilde{\bm \Sigma}_{k} & \bm 0 \\
+        \bm 0 & \bm 0
+    \end{bmatrix} 
+    \begin{bmatrix}
+        \bm Q_{k,1}^T \\ \bm Q_{k,2}^T
+    \end{bmatrix}, 
+\end{align*}
+unde $\bm P_k \in \mathcal{O}^d$ cu $\bm P_{k,1} \in \R^{d\times r_k}$ și $\bm P_{k,2} \in \R^{d\times (d-r_k)}$, $\bm \Sigma_k \in \R^{d\times m_k}$ cu $\tilde{\bm \Sigma}_{k} \in \R^{r_k\times r_k}$ fiind o matrice diagonală, și $\bm Q_k \in \mathcal{O}^{m_k}$ cu $\bm Q_{k,1} \in \R^{m_k\times r_k}$ și $\bm P_{k,2} \in \R^{m_k \times (m_k-r_k)}$.
+\medskip 
+
+\end{exercise}
+
+
+\begin{exercise}[Seria Neumann pentru inversa matricei]\label{ex:neumannn}
+Fie $\bm A \in \mathbb{R}^{n\times n}$. Dacă $\|\bm A\| < 1$, vă rugăm să arătați
+\begin{align}\label{eq:neumann}
+    \left( \bm I - \bm A\right)^{-1} = \sum_{k=1}^\infty \bm A^k.  
+\end{align}
+{\em Indiciu:} Demonstrația constă din doi pași. \\
+(i) {\bf Pasul 1}: Vă rugăm să arătați că seria infinită $\sum_{k=1}^\infty \bm A^k$ converge când $\bm A < 1$ folosind $\|\bm A^k\| \le \|\bm A\|^k$. \\
+(ii) {\bf Pasul 2}: Calculați produsul matriceal $(\bm I - \bm A) \sum_{k=1}^\infty \bm A^k$.
+\end{exercise}
+
+
+\begin{exercise}
+    Vă rugăm să calculați gradienții din \eqref{eq1:grad Rcf} și \eqref{eq2:grad Rcf}.
+\end{exercise}
+
+
+\begin{exercise}
+    Vă rugăm să arătați \Cref{cor:var_concave_logdet} când $Kp \le d$.
+\end{exercise}
+
+\end{document>

--- a/chapters/chapter5/consistent_ro.tex
+++ b/chapters/chapter5/consistent_ro.tex
@@ -1,0 +1,1444 @@
+\providecommand{\toplevelprefix}{../..}
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Reprezentări Consistente și Auto-Consistente}
+\label{ch:consistent}\label{ch:autoencoding}
+\label{ch:self-consistent}\label{ch:closed-loop}
+
+\begin{quote}
+\hfill  ``{\em Totul ar trebui să fie făcut cât mai simplu posibil, dar nu mai simplu}.''
+
+$~$\hfill -- Albert Einstein
+\end{quote}
+
+
+
+\vspace{5mm}
+
+
+În capitolele anterioare, am stabilit un fapt fundamental că
+obiectivul fundamental al învățării este să învețe o distribuție
+de date cu suport de dimensiune redusă și să o transforme într-o
+reprezentare compactă și structurată. O astfel de reprezentare dezvăluie
+structurile intrinseci de dimensiune redusă ale distribuției datelor și facilitează
+sarcinile ulterioare precum clasificarea și generarea.
+
+O abordare fundamentală pentru învățarea unei reprezentări bune a unei astfel de
+distribuții este prin {\em compresie}. Pentru a face
+obiectivul compresiei măsurabil și calculabil, poate fi realizat
+explicit prin învățarea unei scheme de codare care minimizează rata de codare (entropia) sau maximizează câștigul de informație (reducerea
+ratei de codare). În acest context, rolul fundamental al unei rețele neuronale
+profunde este de a realiza un anumit algoritm de optimizare iterativ care
+optimizează incremental reprezentările învățate în termenii acestor măsuri:
+\begin{equation}
+  f\colon \X
+  \xrightarrow{\hspace{1mm} f^0 \hspace{1mm}} \Z^0 \rightarrow \cdots
+  \rightarrow \Z^\ell \xrightarrow{\hspace{1mm} f^\ell \hspace{1mm}}
+  \Z^{\ell+1} \rightarrow  \cdots \to \Z^L = \Z.
+\end{equation}
+În capitolul precedent, am arătat că principalele caracteristici arhitecturale
+ale aproape tuturor rețelelor profunde populare (ResNet, CNN și
+Transformer) pot fi derivate și interpretate din această perspectivă.
+
+Cu toate acestea, când încercăm să atingem un anumit obiectiv prin
+optimizare, nu există nicio garanție că soluția $\Z$ găsită
+în final prin optimizare incrementală este soluția corectă. De fapt, chiar dacă
+procesul de optimizare reușește să găsească soluția
+optimă global $\Z^*$, nu există nicio garanție că soluția corespunde
+unei reprezentări complete a distribuției datelor.\footnote{Aceasta s-ar putea datora multor motive: de exemplu, datele disponibile pentru învățarea distribuției ar putea să nu fie suficiente, sau formularea programului de optimizare eșuează în a lua în considerare unele constrângeri sau condiții suplimentare.} Prin urmare, o întrebare importantă este: cum putem asigura că reprezentarea învățată a distribuției datelor este
+corectă sau suficient de bună?
+
+Desigur, singura modalitate de a verifica acest lucru este să vedem dacă există o hartă de decodare, să zicem $g$, care poate decoda reprezentarea învățată pentru a reproduce distribuția originală a datelor suficient de bine:
+\begin{equation}
+  \X
+  \xrightarrow{\hspace{1mm} \mathcal{E} = f \hspace{1mm}} \Z
+  \xrightarrow{\hspace{1mm} \mathcal{D} = g \hspace{1mm}} \hat{\X}
+\end{equation}
+în termenii unei măsuri de similaritate:
+\begin{equation}
+  d(\X, \hat \X).
+\end{equation}
+Aceasta conduce la conceptul de {\em reprezentare consistentă}. După cum am menționat pe scurt în
+\Cref{ch:intro} (vezi \Cref{fig:autoencoder}), {\em autocodarea}, care integrează
+procesele de codare și decodare, este un cadru natural pentru învățarea unei astfel de reprezentări. Am studiat câteva cazuri speciale importante în \Cref{ch:classic}. În
+acest capitol, \Cref{sec:consistent-representation}, vom studia cum să extindem autocodarea la clase mai generale de distribuții prin impunerea consistenței între $\X$ și $\hat \X$.
+
+În multe scenarii practice și naturale de învățare, poate fi dificil sau chiar imposibil să comparăm distribuțiile datelor $\X$ și $\hat \X$. Suntem lăsați cu singura opțiune de a compara caracteristica învățată $\Z$ cu imaginea sa $\hat \Z$ sub codificatorul $f$:
+\begin{equation}
+ \X
+\xrightarrow{\hspace{1mm} \mathcal{E} = f \hspace{1mm}} \Z  \xrightarrow{\hspace{1mm} \mathcal{D} = g \hspace{1mm}} \hat{\X} \xrightarrow{\hspace{1mm} \mathcal{E} = f \hspace{1mm}} \hat \Z?
+\end{equation}
+Aceasta conduce la noțiunea de {\em reprezentare auto-consistentă}. În \Cref{sec:self-consistency}, vom studia când și cum putem învăța o reprezentare consistentă prin impunerea auto-consistenței între $\Z$ și $\hat \Z$ doar prin intermediul unui cadru de transcriere în buclă închisă.
+
+Mai mult, în multe scenarii practice și naturale de învățare, în mod normal nu avem eșantioane suficiente ale distribuției datelor disponibile toate deodată. De exemplu, animalele și oamenii își dezvoltă memoria vizuală prin preluarea continuă a incrementelor de observații pe parcursul vieții lor. În \Cref{sec:continuous}, vom studia cum să extindem cadrul de transcriere în buclă închisă pentru a învăța o reprezentare auto-consistentă într-un cadru de {\em învățare continuă}.
+
+Desigur, o motivație fundamentală pentru care vrem vreodată să identificăm
+structurile de dimensiune redusă dintr-o distribuție de date și să găsim o reprezentare
+bună este de a facilita utilizarea datelor pentru diverse sarcini
+de inteligență, precum clasificarea, completarea și predicția.
+Prin urmare, reprezentarea comună rezultată $(\x, \z)$ trebuie să fie
+structurată în așa fel încât să fie cel mai potrivită pentru aceste sarcini. În
+capitolul următor, vom
+vedea cum reprezentarea învățată poate fi structurată pentru a facilita
+sarcinile de completare sau generare condiționate.
+
+\section{Învățarea Reprezentărilor Consistente}\label{sec:consistent-representation}
+
+Aici oferim o definiție formală a reprezentărilor consistente, care
+sunt strâns legate de conceptul de autocodare.
+\begin{definition}[Reprezentări Consistente]\label{def:bidirectional_rep}
+  Date fiind datele \(\vX\), o \textit{reprezentare consistentă} este o pereche
+  de funcții \((f \colon \cX \to \cZ, g \colon \cZ \to \cX)\), astfel
+  încât \textit{caracteristicile} \(\vZ = f(\vX)\) sunt compacte și
+  structurate, iar \textit{autocodarea}
+  \begin{equation}
+    \hat{\vX} \doteq g(\vZ) = g(f(\vX))
+  \end{equation}
+  este \textit{apropiată} de \(\vX\) conform uneia dintre
+  următoarele două măsuri:
+  \begin{enumerate}
+    \item Spunem că este \textit{consistentă pe eșantioane} dacă \(\vX
+      \approx \hat{\vX}\) într-o anumită normă cu probabilitate mare.
+    \item Spunem că reprezentarea este \textit{consistentă
+      distributional} dacă \(\Law(\vX) \approx \Law(\hat{\vX})\).
+  \end{enumerate}
+\end{definition}
+
+Cititorii atenți ar fi putut observa că dacă nu impunem anumite
+cerințe asupra reprezentării $\Z$ căutate, problema de mai sus are
+o soluție banală: se pot alege pur și simplu funcțiile $f$ și $g$
+să fie harta identitate! Prin urmare, adevăratul scop al căutării unei
+autocodări este să ne asigurăm că $\Z$ astfel obținut este atât mai
+compact, cât și mai structurat decât $\X$. În primul rând, pentru compactitate, $\Z$
+ar trebui să dezvăluie mai bine dimensionalitatea intrinsecă redusă a $\X$.
+Prin urmare, reprezentarea ar trebui să maximizeze un anumit câștig
+de informație, să zicem, măsurat prin reducerea ratei
+\begin{equation}
+  \Delta R_{\epsilon}(\Z)
+\end{equation}
+introdusă în \Cref{subsec:MCR2}. În al doilea rând, scopul principal al
+învățării unei reprezentări bune a distribuției datelor este de a
+facilita sarcinile care exploatează dimensionalitatea redusă a
+distribuției sale. Prin urmare, distribuția lui $\Z$ ar trebui să fie mai bine
+structurată. De exemplu, distribuția lui $\Z$ este liniar pe bucăți
+sau gaussiană, iar componentele sale sunt în mare parte incoerente sau independente. Aceste componente independente pot reprezenta diferite clustere sau
+clase și pot fi, de asemenea, ușor utilizate ca condiții pentru decodarea
+datelor corespunzătoare $\x$.
+
+Din definiția reprezentării consistente, este necesar ca
+reprezentarea $\Z$ să fie suficientă pentru a recupera distribuția originală
+a datelor $\X$ cu un anumit grad de precizie. Pentru consistența
+pe eșantioane, o alegere tipică este minimizarea erorii de reconstrucție așteptate:
+\begin{equation}
+  d(\X, \hat \X) = \mathbb{E}[\|\X - \hat\X\|_2^2].
+\end{equation}
+Pentru consistența în distribuție, o alegere tipică este minimizarea unei
+anumite distanțe distribuitionale precum divergența
+KL\footnote{Rețineți că pentru distribuții fără suport comun,
+  ceea ce este tipic pentru distribuțiile degenerate, divergența KL
+  poate să nu fie nici măcar bine definită. De fapt, o mare parte din literatura
+  învățării distribuțiilor încearcă să abordeze această dificultate tehnică prin
+  înlocuirea sau aproximarea ei cu ceva bine definit și
+calculabil eficient.}:
+\begin{equation}
+  d(\X, \hat \X) = \mathcal{D}_{KL}(\X\|\hat\X).
+\end{equation}
+
+Prin urmare, punând deoparte calculul, când căutăm o autocodare bună pentru o distribuție
+de date $\X$, conceptual încercăm să găsim un codificator $f$ și
+decodificator $g$ astfel încât
+\begin{equation}
+  \min_{f, g} [- \Delta R_{\epsilon}(\Z) + d(\X, \hat \X)].
+  \label{eqn:autoencode-objective-ch5}
+\end{equation}
+Pentru restul acestui capitol, vom studia cum să rezolvăm astfel de
+probleme de autocodare în condiții diferite, de la cazuri simple și
+ideale la condiții din ce în ce mai dificile și realiste.
+
+
+\subsection{Autocodare Liniară prin PCA}
+Conform \cite{Baldi2011}, expresia „autocodor" a fost introdusă pentru prima dată
+de Hinton și Rumelhart \cite{Rumelhart1986} astfel încât o
+reprezentare profundă să poată fi învățată prin propagare înapoi (BP) într-un mod auto-supravegheat---reconstruirea datelor originale este sarcina de auto-supraveghere. Cu toate acestea, exact același concept de căutare a unei reprezentări compacte și consistente își are rădăcinile în multe studii clasice. După cum am văzut deja în \Cref{ch:classic}, PCA clasică, ICA și învățarea rară a dicționarului împărtășesc toate un obiectiv similar. Singura diferență este că atunci când distribuția de bază a datelor este simplă (liniară și
+independentă), mapările de codare sau decodare devin ușor de reprezentat și
+învățat: nu trebuie să fie profunde și adesea pot fi calculate în formă închisă sau
+cu un algoritm explicit.
+
+Este instructiv să vedem cum noțiunea de consistență pe care am
+definit-o se manifestă în cazul simplu al PCA:
+aici, mapările consistente de codare și decodare sunt date de o transformare
+liniară cu un singur strat:
+\begin{equation}
+  \X \xrightarrow{\hspace{2mm} \mathcal{E} = \vU^\top \hspace{2mm}}
+  \Z \xrightarrow{\hspace{2mm} \mathcal{D} = \vU \hspace{2mm}}   \hat{\X},
+  \label{eqn:autoencoding-PCA-2}
+\end{equation}
+unde $\vU \in \mathbb{R}^{D\times d}$ de obicei cu $d\ll D$. Prin urmare,
+$\vU^\top $ reprezintă o proiecție dintr-un spațiu de dimensiune superioară
+$\mathbb{R}^{D}$ într-unul inferior $\mathbb{R}^{d}$, așa cum este ilustrat în
+\Cref{fig:AE}.
+\begin{figure}
+  \centering \includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter5/figs/autoencoder.png}
+  \caption{Ilustrarea unui autocodor tipic precum PCA, căutând
+  o reprezentare de dimensiune redusă $\bm{z}$ a datelor de dimensiune înaltă $\vx$.}
+  \label{fig:AE}
+\end{figure}
+
+După cum am văzut în \Cref{ch:classic}, când distribuția lui $\vx$ este într-adevăr
+suportată pe un subspațiu de dimensiune redusă $\vU_o$, compactitatea
+reprezentării
+$\vz$ produsă de $\mathcal{E}$ este o consecință directă a estimării corecte
+(și impunerii) dimensiunii acestui subspațiu. În final,
+amintiți-vă că coborârea gradientului pe criteriul de reconstrucție produce exact
+aceste mapări consistente pe eșantioane: într-adevăr, soluția optimă
+la problema
+\begin{equation}\label{eq:pca-reconstruction-ch5}
+  \min_{\vU^\top \vU = \vI}\, \bE_{\vx}\left[\norm*{\vx
+  - \vU\vU^\top \vx}_2^2\right]
+\end{equation}
+coincide precis cu $\vU_o$ când dimensiunea reprezentării este
+suficient de mare. În acest caz, obținem consistența pe eșantioane
+gratuit, deoarece aceasta garantează că $\vU_o\vU_o^\top \vx = \vx$.
+Observați că în cazul PCA, termenul de reducere a ratei din
+\eqref{eqn:autoencode-objective-ch5} devine nul deoarece regularizarea
+asupra reprezentării $\Z$ căutate este explicită: Ea acoperă întregul
+subspațiu de dimensiune inferioară\footnote{Se poate considera $\Delta R = 0$ în acest caz.}.
+
+\paragraph{PCA Online.} Observați că în construcția de mai sus, transformarea
+liniară $\vU$
+utilizată pentru codare și decodare este calculată „offline" din toate
+datele de intrare în prealabil. O întrebare este dacă această transformare
+poate fi învățată „online" pe măsură ce datele de intrare vin în ordine. Această
+întrebare a fost răspunsă de lucrarea lui Oja în 1982 \cite{Oja1982SimplifiedNM}.
+\begin{example}[Schema de învățare hebbiană normalizată pentru PCA] Considerăm o
+  secvență de vectori aleatori i.i.d. $\x_1, \ldots, \x_i, \ldots \in
+  \mathbb{R}^n$ cu covarianța $\boldsymbol{\Sigma} \in
+  \mathbb{R}^{n\times n}$. Fie $\vu_0 \in \mathbb{R}^n$ și definim
+  răspunsul unui vector de intrare $\x_i$ față de un vector de ponderi
+  $\vu_i$ ca fiind produsul lor scalar:
+  \begin{equation}
+    \eta_i = \vu_i^T \x_i
+  \end{equation}
+  și actualizăm vectorul de ponderi conform următoarei scheme:
+  \begin{equation}
+    \vu_{i+1} = \frac{\vu_i + \gamma \eta_i \x_i}{\|\vu_i + \gamma
+    \eta_i \x_i\|_2}
+    \label{eqn:Hebbian}
+  \end{equation}
+  pentru un câștig mic $\gamma >0$. Această schemă de actualizare poate fi văzută
+  ca o schemă hebbiană normalizată, în care ponderile conexiunilor
+  dintre neuroni devin mai puternice dacă (produsele) atât intrării
+  $\x$ cât și ieșirii $\eta$ sunt puternice. Se poate vedea vectorul de
+  ponderi $\vu$ ca fiind „învățat" pe baza unei forme de feedback de la
+  ieșirea $\eta$.
+  Apoi, în condiții rezonabile, Oja \cite{Oja1982SimplifiedNM} a
+  arătat că $\vu_i$ converge către vectorul propriu asociat cu
+  cea mai mare valoare proprie a $\boldsymbol{\Sigma}$.
+\end{example}
+
+Schema hebbiană normalizată \eqref{eqn:Hebbian} poate fi interpretată ca
+o aproximare de ordinul întâi a unei scheme de coborâre a gradientului proiectată
+\textit{stocastică} pe
+obiectivul problemei \eqref{eq:pca-reconstruction-ch5} (cu dimensiunea lotului
+$1$ și cu numărul de coloane ale $\vU$ egal cu $1$) atâta timp cât
+$\norm{\vu}_2 = 1$, care este menținută de operația de proiecție din
+\eqref{eqn:Hebbian}.
+Merită să o păstrăm în minte, atât ca
+o dovadă a corectitudinii pentru utilizarea metodelor gradientului stocastic pentru
+optimizarea costurilor de reconstrucție precum
+\eqref{eq:pca-reconstruction-ch5}, cât și pentru
+sugestia sa că \textit{algoritmi mai simpli decât propagarea înapoi
+  (de la capăt la capăt) pot
+reuși în învățarea autocodorilor consistenți}.
+
+\begin{figure}
+  \centering
+  \begin{tikzpicture}
+    \draw (-0.1, -0.2) .. controls (1, 0.25) .. (2.1, -0.1);
+    \draw (2.1, -0.1) .. controls (1.75, 1) .. (2.1, 2);
+    \draw (2.1, 2) .. controls (1, 1.75) .. (-0.1, 2);
+    \draw (-0.1, 2) .. controls (0.25, 1) .. (-0.1, -0.2);
+
+    \draw (0.35, 0.5) .. controls (0.7, 0.75) .. (0.85, 1.2);
+    \draw (0.85, 1.2) .. controls (1.0, 1.4) .. (1.15, 1.2);
+    \draw (1.15, 1.2) .. controls (1.3, 0.75) .. (1.65, 0.5);
+
+    \node[fill, red, circle, inner sep=0.75pt] at (1, 0.9) {};
+    \node[fill, red, circle, inner sep=0.75pt] at (1.35, 0.45) {};
+
+    \node at (1, -0.5) {\(\x\)};
+
+    \draw[->] (2.25, 1) -- (3.75, 1);
+    \node at (3, 1.25) {\(\fl\)};
+
+    \draw (4.1, 0.1) -- (5.9, 0.1);
+    \draw (5.9, 0.1) -- (5.9, 1.9);
+    \draw (5.9, 1.9) -- (4.1, 1.9);
+    \draw (4.1, 1.9) -- (4.1, 0.1);
+
+    \node[fill, red, circle, inner sep=0.75pt] at (5, 1) {};
+    \node[fill, red, circle, inner sep=0.75pt] at (5.5, 0.5) {};
+
+    \draw[red] (5, 1) -- (5.5, 0.5);
+
+    \node at (5, -0.5) {\(\z\)};
+
+    \draw[->] (6.25, 1) -- (7.75, 1);
+    \node at (7, 1.25) {\(\re\)};
+
+    \draw (7.9, -0.2) .. controls (9, 0.25) .. (10.1, -0.1);
+    \draw (10.1, -0.1) .. controls (9.75, 1) .. (10.1, 2);
+    \draw (10.1, 2) .. controls (9, 1.75) .. (7.9, 2);
+    \draw (7.9, 2) .. controls (8.25, 1) .. (7.9, -0.2);
+
+    \draw (8.35, 0.5) .. controls (8.7, 0.75) .. (8.85, 1.2);
+    \draw (8.85, 1.2) .. controls (9.0, 1.4) .. (9.15, 1.2);
+    \draw (9.15, 1.2) .. controls (9.3, 0.75) .. (9.65, 0.5);
+
+    \node[fill, red, circle, inner sep=0.75pt] at (9, 0.9) {};
+    \node[fill, red, circle, inner sep=0.75pt] at (9.35, 0.45) {};
+
+    \draw[red] (9, 0.9) .. controls (9.1, 0.55) .. (9.35, 0.45);
+
+    \node at (9, -0.5) {\(\hat{\x}\)};
+  \end{tikzpicture}
+  \caption{O reprezentare a interpolării prin aplatizarea varietății
+    pe o varietate în \(\R^{3}\) de dimensiune \(d = 2\). Pentru a interpola
+    două puncte pe varietatea datelor, mapați-le prin harta de aplatizare
+    \(\fl\) în spațiul aplatizat, luați interpolanții lor convecși,
+    și apoi mapați-i înapoi pe varietatea datelor prin harta de
+  reconstrucție \(\re\).}
+  \label{fig:idealized_interpolation}
+\end{figure}
+
+\subsection{PCA Neliniară și Autocodare}\label{sub:nonlinear-pca}\label{sec:NLPCA}
+Desigur, ar trebui să ne așteptăm ca lucrurile să nu mai fie atât de simple
+când avem de-a face cu distribuții mai complexe ale căror
+structuri de dimensiune redusă de bază sunt neliniare.
+
+\paragraph{Date pe o Subvarietate Neliniară.} Deci, pentru a depăși structura
+liniară abordată de PCA, putem presupune că distribuția datelor se află pe o subvarietate (netedă) $\mathcal{M}$. Dimensiunea intrinsecă a subvarietății, să zicem $d$, este de obicei mult mai mică decât
+dimensiunea spațiului ambiental $\mathbb{R}^D$. Din această perspectivă
+geometrică, de obicei vrem să găsim o mapare neliniară $f$ astfel încât
+varietatea rezultată
+$f(\mathcal{M})$ să fie aplatizată, așa cum este ilustrat de exemplul arătat în
+\Cref{fig:idealized_interpolation}. Spațiul caracteristic $\vz$ rezultat
+este de obicei
+mai compact (de dimensiune mai mică) decât spațiul $\vx$, iar
+varietatea este plată.
+Din perspectiva statistică, care este complementară perspectivei geometrice
+dar distinctă în general, putem, de asemenea, să vrem să ne asigurăm că distribuția
+datelor pe $\mathcal{M}$ este mapată la o distribuție suficient de regulată,
+să zicem o distribuție gaussiană sau uniformă (cu
+suport de dimensiune foarte redusă), în spațiul $\vz$. Aceste două proprietăți asigură că eșantionarea și interpolarea în spațiul $\vz$ sunt cât mai ușoare posibil, și sunt formalizări matematice ale
+noțiunilor dezirabile de caracteristici compacte și structurate în modelul varietății
+de dimensiune redusă pentru distribuția datelor.
+În general, problema învățării unei astfel de mapări de autocodare pentru această clasă
+de distribuții de date este cunoscută ca {\em analiza componentelor principale neliniare}
+(NLPCA).
+
+\paragraph{O Încercare Clasică prin Rețea cu Două Straturi.} După cum am
+văzut mai sus, în cazul PCA, o rețea neuronală liniară cu un singur
+strat este suficientă. Aceasta nu mai este cazul pentru NLPCA. În 1991, Kramer
+\cite{Kramer1991NonlinearPC} a propus să rezolve NLPCA folosind o rețea
+neuronală cu două straturi pentru a reprezenta maparea codificatorului $f$ (sau inversul său $g$) bazată
+pe proprietatea de reprezentare universală a rețelelor cu două straturi cu activare
+sigmoidă:
+\begin{equation}
+  \z = \vW_2 \sigma(\vW_1\x +\vb),
+\end{equation}
+unde $\sigma(\spcdot)$ este funcția sigmoidă:
+\begin{equation}
+  \sigma(x) = \frac{1}{1+ e^{-x}}.
+\end{equation}
+Cybenko \cite{Cybenko1989ApproximationBS} a arătat că funcțiile de
+forma de mai sus (cu suficiente noduri ascunse) pot aproxima orice funcție
+neliniară netedă, să zicem codificatorul $f(\spcdot)$, cu o precizie
+arbitrară. În special, ele pot reprezenta hărțile de aplatizare și reconstrucție
+pentru distribuții de date suportate pe uniuni de varietăți de dimensiune redusă,
+ca în \Cref{fig:idealized_interpolation}. Arhitectura generală a
+rețelelor originale propuse de Kramer este ilustrată în \Cref{fig:NLPCA}.
+\begin{figure}[tb]
+  \centering
+  \includegraphics[width=0.6\linewidth]{\toplevelprefix/chapters/chapter5/figs/kramer1991nonlinearPCA.png}
+  \caption{PCA neliniară prin rețele neuronale autoasociative de adâncime
+    doi atât pentru mapările de codare cât și decodare, sugerată de
+  Kramer \cite{Kramer1991NonlinearPC}.}
+  \label{fig:NLPCA}
+\end{figure}
+
+Din păcate, spre deosebire de cazul PCA de mai sus, nu există în general nicio
+schemă de învățare în formă închisă pentru parametrii $\boldsymbol{\theta} =
+(\vW, \vb)$ ai acestor rețele. Prin urmare, s-a propus să se antreneze
+rețeaua prin propagare înapoi cu supravegherea erorii de reconstrucție:
+\begin{equation}\label{eq:nonlinear-pca-ch5}
+  \min_{\boldsymbol{\theta}} \mathbb{E}[ \|\x - \hat{\x}(\boldsymbol{\theta})\|_2^2].
+\end{equation}
+Comparativ cu cazul simplu al PCA, utilizăm același obiectiv de reconstrucție
+pentru învățare, dar o clasă mult mai complexă de modele neliniare pentru
+parametrizarea și învățarea codificatorului și decodificatorului. Deși proprietățile
+de aproximare universală precum cele ale lui Cybenko sugerează că \textit{în principiu}
+învățarea autocodorilor consistenți prin acest cadru este posibilă---deoarece pentru
+orice eșantion aleator de date, având suficienți parametri, astfel de perechi de autocodare
+există---adesea se constată că este foarte netrivial să le găsim folosind coborârea gradientului.
+Mai mult, pentru a obține un obiectiv de reconstrucție suficient de informativ
+și un model pentru
+distribuția datelor de dimensiune înaltă din lumea reală, cum ar fi imaginile, numărul necesar
+de eșantioane și noduri ascunse poate fi uriaș.
+În plus, ca măsură a compactității reprezentării învățate,
+dimensiunea (inferioară) a $\z$ pentru stratul îngust este adesea aleasă
+euristic.\footnote{În lucrarea ulterioară \cite{Hinton-1993}, Hinton et al. au sugerat să folosească principiul lungimii minime de descriere (MDL) pentru a promova
+  compactitatea schemei de codare învățate, într-un spirit foarte similar cu
+măsura ratei de distorsiune introdusă în această carte.}
+
+\paragraph{Aplatizarea Varietății printr-o Rețea Mai Profundă.}
+Bazându-ne pe practica modernă a rețelelor profunde, astfel de arhitecturi clasice de rețea
+puțin adânci și late sunt cunoscute ca fiind destul de dificil de
+antrenat eficient și eficace prin propagare înapoi (BP), parțial
+din cauza gradientului care dispare al funcției sigmoide. Prin urmare,
+practica modernă sugerează în mod normal să se descompună în continuare
+transformarea neliniară $f$ (sau $g$) într-o compoziție de
+mai multe straturi de transformări mai simple, rezultând o arhitectură de rețea mai profundă
+\cite{Hinton504}, așa cum este ilustrat în \Cref{fig:ccnet_layers}.
+În contextul modern, elaborări suplimentare peste costul de reconstrucție de bază
+\eqref{eq:nonlinear-pca-ch5} se dovedesc, de asemenea, necesare pentru a obține performanțe bune pe
+distribuții de date complexe din lumea reală, cum ar fi imaginile.
+
+\begin{figure}[htb]
+  \centering
+  \begin{tikzpicture}
+    \draw (-0.1, -0.2) .. controls (1, 0.25) .. (2.1, -0.1);
+    \draw (2.1, -0.1) .. controls (1.75, 1) .. (2.1, 2);
+    \draw (2.1, 2) .. controls (1, 1.75) .. (-0.1, 2);
+    \draw (-0.1, 2) .. controls (0.25, 1) .. (-0.1, -0.2);
+
+    \draw (0.35, 0.5) .. controls (0.7, 0.75) .. (0.85, 1.2);
+    \draw (0.85, 1.2) .. controls (1.0, 1.4) .. (1.15, 1.2);
+    \draw (1.15, 1.2) .. controls (1.3, 0.75) .. (1.65, 0.5);
+
+    \node at (1, -0.5) {\(\x\)};
+
+    \draw[->] (2.25, 1.25) -- (3.25, 1.25);
+    \node at (2.75, 1.5) {\(\fl_{1}\)};
+
+    \draw[->] (3.5, 1.25) -- (4.5, 1.25);
+    \node at (4, 1.5) {\(\fl_{2}\)};
+
+    \draw[->] (4.75, 1.25) -- (5.75, 1.25);
+    \node at (5.25, 1.5) {\(\cdots\)};
+
+    \draw[->] (6, 1.25) -- (7, 1.25);
+    \node at (6.5, 1.5) {\(\fl_{L}\)};
+
+    \draw[->] (7, 0.75) -- (6, 0.75);
+    \node at (6.5, 0.5) {\(\re_{L}\)};
+
+    \draw[->] (5.75, 0.75) -- (4.75, 0.75);
+    \node at (5.25, 0.5) {\(\cdots\)};
+
+    \draw[->] (4.5, 0.75) -- (3.5, 0.75);
+    \node at (4, 0.5) {\(\re_{2}\)};
+
+    \draw[->] (3.25, 0.75) -- (2.25, 0.75);
+    \node at (2.75, 0.5) {\(\re_{1}\)};
+
+    \draw (7.3, 0.1) -- (9.1, 0.1);
+    \draw (9.1, 0.1) -- (9.1, 1.9);
+    \draw (9.1, 1.9) -- (7.3, 1.9);
+    \draw (7.3, 1.9) -- (7.3, 0.1);
+
+    \node at (8.2, -0.5) {\(\z\)};
+
+  \end{tikzpicture}
+  \caption{O reprezentare a procesului de construcție a perechii de aplatizare
+    și reconstrucție \((\fl, \re)\), unde codificatorul \(\fl =
+    \fl_{L} \circ \fl_{L - 1} \circ \cdots \circ \fl_{1}\) este
+    construit din compunerea straturilor de aplatizare, iar decodificatorul \(\re
+    = \re_{1} \circ \re_{2} \circ \cdots \circ \re_{L}\) este compus din
+  inversiunile fiecărui \(\fl_{\ell}\).}
+  \label{fig:ccnet_layers}
+\end{figure}
+
+În lumina teoremelor de aproximare universală precum cea a lui Cybenko, cineva
+ar putea să se întrebe inițial de ce, conceptual, autocodoarele mai profunde ar trebui să fie preferate
+față de cele puțin adânci.
+Din perspectiva pur a expresivității, putem înțelege acest fenomen
+printr-un unghi geometric legat de sarcina de aplatizare a varietății
+neliniare pe care este suportată distribuția noastră ipotezată a datelor. O abordare pur
+constructivă pentru aplatizarea varietății procedează incremental, în
+paralel cu ceea ce am văzut în \Cref{ch:compression,ch:representation} cu
+interacțiunea dintre difuzie, eliminarea zgomotului și compresie. În cadrul geometric,
+\textit{procesul de aplatizare} incremental corespunzător lui $f_{\ell}$
+ia forma transformării unei vecinătăți a unui punct al varietății pentru a fi
+mai aproape de o varietate plată (adică un subspațiu) și impunerea consistenței locale
+cu restul eșantioanelor de date; operația incrementală corespunzătoare în
+decodificator, $g_{\ell}$, anulează această transformare. Această procedură încorporează precis
+informații despre curbură despre varietatea de bază, care este
+estimată din eșantioanele de date. Având suficiente eșantioane din varietate și
+o instanțiere atentă a acestui proces conceptual, este posibil să se implementeze
+această procedură ca o procedură computațională care aplatizează verificabil varietățile
+neliniare într-un mod de tip cutie albă \cite{Psenka-JMLR24}. Cu toate acestea, abordarea este
+limitată în aplicabilitatea sa la distribuții de date de dimensiune înaltă, cum ar fi
+imaginile, din cauza scalabilității nefavorabile, motivând dezvoltarea unor metode
+mai flexibile pentru autocodarea incrementală.
+
+\subsection{Autocodare Rară}
+În schemele de autocodare de mai sus, dimensiunea spațiului caracteristic
+$d$ este de obicei aleasă să fie mult mai mică decât cea a spațiului original de date
+$D$ pentru a impune sau promova în mod explicit reprezentarea învățată
+să fie de dimensiune redusă. Cu toate acestea, în practică,
+în mod normal nu cunoaștem dimensiunea intrinsecă a distribuției
+datelor. Prin urmare, alegerea dimensiunii spațiului caracteristic pentru
+autocodare se face adesea empiric. În situații mai generale,
+distribuția datelor poate fi un amestec de câteva subspații
+sau subvarietăți de dimensiune redusă. În aceste cazuri, nu mai este fezabil
+să se impună un singur spațiu de dimensiune redusă pentru toate caracteristicile împreună.
+
+Autocodorul rar este menit să rezolve unele dintre aceste limitări. În
+particular, dimensiunea spațiului caracteristic poate fi egală cu sau
+chiar mai mare decât cea a spațiului datelor, așa cum este ilustrat în
+\Cref{fig:SAE}. Cu toate acestea, caracteristicile trebuie să fie foarte
+rare în spațiul caracteristic. Deci, dacă impunem raritatea ca măsură
+de parsimonie în plus față de reducerea ratei în obiectivul
+\eqref{eqn:autoencode-objective-ch5}, obținem un nou obiectiv pentru
+autocodarea rară:
+\begin{equation}
+  \min_{f, g}
+  [\|\Z\|_0 - \Delta R_{\epsilon}(\Z) + d(\X, \hat \X)],
+  \label{eqn:autoencode-sparse}
+\end{equation}
+unde „norma" $\ell^0$ $\|\spcdot\|_0$ este cunoscută pentru a promova raritatea.
+Aceasta este foarte similară cu obiectivul de reducere a ratei rare
+\eqref{eq:sparse-rr} pe care l-am folosit în \Cref{ch:representation} anterior pentru a deriva arhitectura CRATE de tip cutie albă.
+
+\begin{figure}
+  \centering
+  \includegraphics[width=0.5\linewidth]{\toplevelprefix/chapters/chapter5/figs/SAE_diagram.png}
+  \caption{Ilustrarea unui autocodor rar (SAE), comparat cu
+  cel al unui autocodor tipic (AE) din \Cref{fig:AE}. }
+  \label{fig:SAE}
+\end{figure}
+
+
+Ca metodă pentru învățarea perechilor de autocodare într-un mod de la capăt la capăt, autocodarea
+rară a fost practicată în trecut
+\cite{Ranzato2006-oq,10.5555/3042573.3042641}, dar aproape toate cadrele moderne
+de autocodare se bazează în schimb pe un cadru diferit, probabilistic
+de autocodare, pe care îl vom studia acum.
+
+\subsection{Autocodare Variațională}\label{sec:vae}
+
+În concepția clasică a autocodării, urmând Hinton și Rumelhart
+\cite{Rumelhart1986}, distribuția datelor joacă un rol foarte minor în
+formulare, în ciuda centralității sale pentru reprezentarea pe care o
+învățăm în cele din urmă. Într-adevăr, în cadrul naiv, se speră că prin antrenarea unei rețele profunde
+pentru a reconstrui eșantioane din distribuția datelor cu un gât de sticlă configurabil
+corespunzător pentru reprezentarea $\vz$, codificatorii învățați $f$ și $g$ vor
+ajunge în mod natural să corespundă unei reprezentări de caracteristici
+compacte și structurate pentru date. Acest lucru este rareori cazul în practică.
+O metodologie îmbunătățită, mai modernă pentru autocodare care încă găsește
+aplicații semnificative până în prezent este \textit{autocodarea variațională}
+\cite{Kingma2013-sb,Kingma2019-zh}.
+Vom vedea cum acest cadru, care antrenează un autocodor variațional (VAE)
+derivat prin considerații de modelare probabilistică, atât generalizează
+antrenamentul clasic al autocodorului (prin minimizarea pierderii de reconstrucție),
+cât și îl stabilizează cu regularizare adecvată. Mai târziu, vom vedea cum să
+mergem mai departe și să depășim natura de tip cutie neagră a rețelelor profunde folosite
+pentru a reprezenta mapările de codare și decodare $f$ și $g$.
+
+\subsubsection{Perspectiva Probabilistică asupra Autocodării}
+În modelul varietății pentru distribuția datelor, obiectele matematice cheie
+sunt \textit{suportul} distribuției datelor, și anume varietatea $\cM$,
+și densitatea datelor pe suport, să zicem $p$. Când formulăm
+autocodarea din perspectiva probabilistică, adesea ne gândim la
+intrarea de dimensiune înaltă $\vx$ ca având o densitate $p$ cu suport pe $\R^D$; se
+poate gândi la adăugarea unei cantități foarte mici de zgomot la distribuția (degenerată)
+suportată pe varietatea $\cM$ pentru a obține această densitate $p$, în linie
+cu construcțiile noastre de eliminare a zgomotului-difuzie din \Cref{ch:compression}.
+Apoi obiectivul modelării probabilistice generative este să învețe densitatea $p$
+din eșantioane $\vx$, să zicem dintr-o clasă de modele $p(\vx;\, \vtheta)$ parametrizate
+de $\vtheta$. După cum am reamintit în \Cref{ch:compression}, o abordare clasică
+pentru a realiza acest lucru este prin estimarea maximei verosimilități:
+\begin{equation*}\label{eq:VAE-MLE}
+\max_{\vtheta}\, \bE_{\vx}[ \log p(\vx;\, \vtheta) ].
+\end{equation*}
+Pentru anumite clase reprezentative de distribuții de date $p$
+și clase suficient de expresive de modele $p(\vx;\, \vtheta)$, chiar și probleme
+de învățare mai simple decât estimarea maximei verosimilități sunt cunoscute ca fiind
+statistic dificile \cite{Yang1999-wb}. Prin urmare, este de dorit să exploatăm
+cunoașterea că $\vx$ are structură de dimensiune redusă căutând să factorizăm
+distribuția $p(\vx ;\, \vtheta)$ conform unui model de variabilă „latentă"
+de dimensiune redusă $\vz$. Într-adevăr, prin condiționare putem scrie $p(\vx,
+\vz ;\, \vtheta)
+= p(\vz;\, \vtheta) p(\vx \mid \vz;\, \vtheta)$, și
+\begin{align*}
+p(\vx; \vtheta) &= \int p(\vz;\, \vtheta) p(\vx \mid \vz;\, \vtheta) \odif \vz
+\\
+&=
+\bE_{\vz \sim p(\,\cdot\,;\, \vtheta)}[ p(\vx \mid \vz;\, \vtheta) ].
+\end{align*}
+Clasic, modelul nostru pentru distribuția datelor $p(\vx;\, \vtheta)$ corespunde
+unei alegeri a distribuției latente $p(\vz;\, \vtheta)$ și a distribuției
+condiționale $p(\vx \mid \vz;\, \vtheta)$.
+Chiar și așa, calcularea modelului pentru distribuția datelor din aceste distribuții
+latente este intractabilă, cu excepția cazurilor speciale, analoge celor pe care le-am
+studiat în \Cref{ch:classic}.
+În același mod, calcularea posteriorului $p(\vz \mid \vx;\, \vtheta)$ din
+date, permițându-ne să \textit{codăm} eșantioane la latenții lor corespunzători, este
+în general intractabilă.
+Există astfel un compromis între expresivitatea modelului nostru generativ,
+tractabilitatea sa computațională și acuratețea oricăror aproximări pe care le facem
+la cadrul probabilistic de bază de dragul
+tractabilității computaționale.
+În navigarea acestui compromis, este nevoie și de o abordare computațională flexibilă
+pentru învățarea parametrilor modelului $\vtheta$ din date, analogă obiectivului
+maximei verosimilități.
+
+În cadrul autocodării variaționale, navigăm acest compromis prin
+trei perspective cheie:
+\begin{enumerate}
+\item Postulăm distribuții \textit{simple} pentru $\vz$ și $\vx$ condiționale
+  pe $\vz$, dar facem ca parametrii lor să depindă într-un mod foarte flexibil de
+  datele de intrare $\vx$ (unde este relevant) folosind rețele profunde.
+\item Înlocuim posteriorul $p(\vz \mid \vx;\, \vtheta)$, folosit pentru codare
+  și a cărui formă este implicată (prin regula lui Bayes) de alegerile noastre de modelare pentru $\vz$,
+  cu o aproximare tractabilă $q(\vz \mid \vx;\, \veta)$, care are proprii săi
+  parametri $\veta$.
+\item Învățăm împreună $\vtheta$ și $\veta$ prin maximizarea unei limite inferioare tractabile
+  pentru verosimilitatea $p(\vx ;\, \vtheta)$, cunoscută ca limita inferioară a dovezilor (ELBO).
+\end{enumerate}
+Ne vom concentra pe instanțierea cea mai utilă a cadrului VAE
+în practică, și anume
+unde priorul $p(\vz ;\, \vtheta)$ și condiționala $p(\vx \mid \vz;\,
+\vtheta)$ sunt ambele gaussiene. Și anume, folosim următoarele distribuții
+gaussiene:
+\begin{align*}
+\vz &\sim \cN(\Zero, \vI), \\
+\vx \mid \vz &\sim \cN(g_1(\vz), \diag(e^{g_2(\vz)}) \vI),
+\end{align*}
+unde $g = (g_1, g_2)$ sunt rețele profunde cu parametrii $\vtheta$, care
+corespund \textit{decodificatorului} în autocodor.
+Similar, pentru posteriorul aproximativ $q(\vz \mid \vx;\, \veta)$, folosim
+o distribuție gaussiană specială cu parametri dați de un codificator
+MLP $f = (f_1, f_2)$ cu parametrii $\veta$:
+\begin{equation*}
+\vz \mid \vx \sim \cN(f_1(\vx), \diag(e^{f_2(\vx)}) \vI).
+\end{equation*}
+Aceasta face codarea și decodarea probabilistică simple: pur și simplu mapăm datele noastre
+$\vx$ la parametrii de medie și varianță ai unei distribuții gaussiene pentru
+codare, și viceversa pentru decodare.
+Pentru învățarea codificatorului și decodificatorului, pornim de la obiectivul
+maximei verosimilități \Cref{eq:VAE-MLE} și derivăm o limită inferioară convenabilă cunoscută ca
+limita inferioară a dovezilor, sau ELBO. Pornind de la manipulări algebrice simple
+\begin{align*}
+\log p(\vx;\, \vtheta) &=
+\log \frac{p(\vx, \vz;\, \vtheta)}{p(\vz \mid \vx;\, \vtheta)}
+\\
+&=
+\log \frac{p(\vx, \vz;\, \vtheta)}{q(\vz \mid \vx;\, \veta)}
++
+\log \frac{q(\vz \mid \vx;\, \veta)}{p(\vz \mid \vx;\, \vtheta)},
+\end{align*}
+luăm așteptări în raport cu $\vz \sim q(\,\cdot\, \mid
+\vx;\, \veta)$ și
+folosim inegalitatea Gibbs (\Cref{thm:information-inequality}) pentru a obține
+\begin{equation*}
+\log p(\vx;\, \vtheta)
+\geq
+\bE_{\vz \sim q(\,\cdot\, \mid \vx ;\, \veta)} \left[
+  \log \frac{p(\vx, \vz;\, \vtheta)}{q(\vz \mid \vx;\, \veta)}
+\right].
+\end{equation*}
+Partea dreaptă a acestei limite este ELBO; ca limită inferioară pentru log-verosimilitatea
+punctuală a $p(\vx;\, \vtheta)$, maximizarea sa oferă un compromis
+principial
+între obiectivul maximei verosimilități și tractabilitatea computațională.
+Interesant, derivarea de mai sus arată că strânsoarea sa depinde de divergența
+KL între posteriorul aproximativ $q(\vz \mid \vx;\, \veta)$ și
+posteriorul adevărat $p(\vz \mid \vx;\, \vtheta)$, implicând că cu cât posteriorul nostru
+aproximativ este mai precis, cu atât maximizarea ELBO conduce la
+maximizarea obiectivului de bază de interes, verosimilitatea
+datelor. Astfel, obiectivul VAE este:
+\begin{equation}\label{eq:elbo-objective}
+\max_{\vtheta, \veta}\,
+\bE_{\vx}
+\bE_{\vz \sim q(\,\cdot\, \mid \vx ;\, \veta)} \left[
+  \log \frac{p(\vx, \vz;\, \vtheta)}{q(\vz \mid \vx;\, \veta)}
+\right].
+\end{equation}
+Prin derivarea noastră, maximizarea acestui obiectiv corespunde unui compromis
+între maximizarea funcției de verosimilitate a datelor și minimizarea divergenței
+KL între posteriorul aproximativ și cel adevărat, care este un obiectiv foarte
+sensibil având în vedere ipotezele de modelare VAE.
+
+\subsubsection{Antrenarea VAE ca Autocodare Probabilistică}
+
+Există o metodologie generală pentru maximizarea obiectivului ELBO din
+\Cref{eq:elbo-objective} folosind coborârea gradientului stocastic și diverși estimatori
+Monte Carlo tractabili pentru gradienții asociați. Cu toate acestea, sarcina este
+mai simplă sub ipotezele gaussiene pe care le-am făcut mai sus. În acest caz, ELBO
+citește
+\begin{align*}
+&\max_{\vtheta, \veta}\,
+\bE_{\vx}
+\bE_{\vz \sim q(\,\cdot\, \mid \vx ;\, \veta)} \left[
+  \log \frac{p(\vx, \vz;\, \vtheta)}{q(\vz \mid \vx;\, \veta)}
+\right]\\
+=&
+\max_{\vtheta, \veta}\,
+\left\{
+  \bE_{\vx}
+  \bE_{\vz \sim q(\,\cdot\, \mid \vx ;\, \veta)} \left[
+    \log p(\vx, \vz;\, \vtheta)
+  \right]
+  + \frac{d \log(2\pi e)}{2}
+  + \frac{1}{2} \ip{ \bE_{\vx}[f_2(\vx)]}{\mathbf{1}}
+\right\}
+\\
+\equiv &
+\max_{\vtheta, \veta}\,
+\left\{
+  \bE_{\vx}
+  \bE_{\vz \sim q(\,\cdot\, \mid \vx ;\, \veta)} \left[
+    \log p(\vx \mid \vz;\, \vtheta)
+    + \log p(\vz)
+  \right]
+  + \frac{1}{2} \ip{ \bE_{\vx}[f_2(\vx)]}{\mathbf{1}}
+\right\}
+\\
+\equiv &
+\max_{\vtheta, \veta}\,
+\left\{
+  2\bE_{\vx}\left[
+    \bE_{\vz \sim q(\,\cdot\, \mid \vx ;\, \veta)} \left[
+      \log p(\vx \mid \vz;\, \vtheta)
+    \right]
+    + \ip{ f_2(\vx) - e^{f_2(\vx)}}{\mathbf{1}}
+    - \norm{f_1(\vx)}_2^2
+  \right]
+\right\}, \labelthis \label{eq:elbo-for-gaussians}
+\end{align*}
+urmând \Cref{thm:max_entropy} și calculul entropiei gaussiene realizat în \Cref{app:diffusion-denoising}, unde $\equiv$
+denotă echivalența obiectivelor de optimizare (în fiecare caz, eliminăm unele
+constante aditive care nu schimbă soluțiile problemei de optimizare).
+Termenul rămas corespunde părții de „autocodare" a obiectivului
+ELBO: intuitiv, caută să maximizeze verosimilitatea datelor generate de
+decodificator când latenții $\vz$ sunt distribuiți conform posteriorului
+aproximativ (generat de codificatorul aplicat unui eșantion de date $\vx$), care este
+o formă probabilistică de autocodare.
+Pentru a vedea acest lucru mai direct, considerați cazul special în care posteriorul
+aproximativ se concentrează pe media sa $f_1(\vx)$, pentru fiecare $\vx$: acesta
+este limita
+unde log-varianța sa $f_{2,i}(\vx) \to -\infty$ pentru fiecare coordonată
+$i = 1, \dots, d$.
+Pentru simplitate, presupunem mai mult că $g_2(\vx) = \mathbf{1}$, dând decodificatorului
+varianță unitară constantă pe fiecare coordonată.
+Apoi termenul de pierdere în cauză converge la
+\begin{align*}
+\bE_{\vx}
+\bE_{\vz \sim q(\,\cdot\, \mid \vx ;\, \veta)} \left[
+  \log p(\vx \mid \vz;\, \vtheta)
+\right]
+&\to
+\bE_{\vx} \left[
+  \log p(\vx \mid f_1(\vx);\, \vtheta)
+\right]
+\\
+&\equiv
+-\frac{1}{2} \bE_{\vx} \left[
+  \|\vx - g_1\circ f_1(\vx)\|_2^2
+\right].
+\end{align*}
+Deci cu un codificator foarte încrezător, care mapează determinist fiecare eșantion
+$\vx$ la un singur punct $f_1(\vx)$ în spațiul $\vz$, și un decodificator izotrop,
+partea de „autocodare" a problemei de maximizare ELBO devine într-adevăr
+un obiectiv clasic de autocodare!\footnote{În cazul general în care $g_2$ nu este
+fixat ca $\mathbf{1}$, cititorul poate verifica că termenul de autocodare din
+obiectivul ELBO converge la un obiectiv clasic de autocodare \textit{regularizat}.}
+În același timp, observați că acest caz special este de fapt exclus de
+termenii suplimentari din \Cref{eq:elbo-for-gaussians}---aceștia corespund efectiv
+termenilor de regularizare care descurajează codificatorul să colapseze.
+Pierderea generală ELBO (\Cref{eq:elbo-objective,eq:elbo-for-gaussians}) este
+prin urmare o generalizare strictă a obiectivului clasic de reconstrucție prin autocodare
+(\Cref{eq:nonlinear-pca-ch5}), atât în termenii termenului său de fidelitate a datelor
+cât și în termenii includerii termenilor de regularizare.
+
+\subsubsection{Antrenarea unui VAE}
+VAE-urile sunt de obicei antrenate prin alternarea ascensiunii gradientului stocastic pe obiectivul
+ELBO (\Cref{eq:elbo-for-gaussians}), date fiind eșantioane individuale
+$\vx$ din
+distribuția adevărată a datelor și din $\vz \sim q(\,\cdot\,\mid \vx;\, \veta)$. În
+particular, este standard să se colecteze și să se antreneze pe multe eșantioane generate independent
+$\vz^{i}$ pentru fiecare eșantion $\vx$. Pentru a lua gradienți ai
+\Cref{eq:elbo-for-gaussians} în raport cu parametrii codificatorului $\veta$,
+se folosește așa-numitul truc de reparametrizare scriind $\vz \sim
+q(\,\cdot\,\mid \vx;\, \veta)$ ca
+\begin{equation*}
+\vz =_{\mathrm{d}} f_1(\vx) + \diag(e^{\tfrac{1}{2}f_2(\vx)}) \vg,
+\quad \vg \sim
+\cN(0, \vI),
+\end{equation*}
+unde $=_{\mathrm{d}}$ denotă egalitatea în distribuție. Apoi se pot lua pur și simplu
+multe eșantioane gaussiene standard independente $\vg^{i}$ pentru fiecare eșantion de date
+$\vx$, se generează eșantioanele corespunzătoare din posteriorul aproximativ
+$\vz^i$ și se calculează gradienții în raport cu $\veta$ folosind diferențierea
+automată fără probleme.
+
+
+
+\section{Învățarea Reprezentărilor Auto-Consistente}
+\label{sec:self-consistency}
+
+În capitolele anterioare, am studiat metode care ne-ar permite să învățăm o distribuție de dimensiune redusă prin compresie (cu pierderi). După cum am menționat în \Cref{ch:intro} și am demonstrat în capitolele anterioare, progresele făcute în inteligența mașinilor se bazează în mare parte pe găsirea de soluții computațional fezabile și eficiente pentru a realiza compresia dorită, nu doar calculabile sau tractabile în teorie, ci și scalabile în practică:
+\begin{equation}
+\mbox{\textbf{calculabil}} \;
+   \Longrightarrow \; \mbox{\textbf{tractabil}} \; \Longrightarrow \;
+   \mbox{\textbf{scalabil}}.
+\end{equation}
+Este chiar corect să spunem că progresul extraordinar în inteligența mașinilor făcut în ultimul deceniu sau cam așa ceva este în mare parte atribuit dezvoltării modelelor și metodelor scalabile, să zicem prin antrenarea rețelelor profunde prin propagare înapoi. Modele mari cu miliarde de parametri antrenate cu trilioane de puncte de date pe zeci de mii de GPU-uri puternice au demonstrat capacități supra-umane în memorarea cunoștințelor existente. Acest lucru i-a determinat pe mulți să creadă că „inteligența" acestor modele va continua să se îmbunătățească pe măsură ce scala lor continuă să crească.
+
+În timp ce sărbătorim minunile inginerești ale unor astfel de sisteme mari de învățare automată create de om, trebuie să admitem și că, în comparație cu inteligența din natură, această abordare pentru îmbunătățirea inteligenței mașinilor necesită resurse în mod inutil de multe. Ființele inteligente naturale, inclusiv animalele și oamenii, pur și simplu nu își pot permite o astfel de soluție de forță brută pentru învățare deoarece trebuie să opereze cu un buget foarte limitat în energie, spațiu și timp, supuse multor constrângeri fizice stricte.
+
+În primul rând, există dovezi științifice puternice că creierul nostru nu efectuează propagare înapoi globală de la capăt la capăt pentru a-și îmbunătăți sau corecta predicțiile. În schimb, este cunoscut de mult timp în neuroștiință că creierul nostru corectează erorile cu feedback local în buclă închisă, cum ar fi codarea predictivă. Aceasta a fost baza științifică care l-a inspirat pe Norbert Wiener să dezvolte teoria controlului prin feedback și programul Ciberneticii în anii 1940.
+
+În al doilea rând, am văzut în secțiunile anterioare că pentru a învăța o reprezentare consistentă, trebuie să învățăm o autocodare bidirecțională:
+\begin{equation}
+ \X
+\xrightarrow{\hspace{1mm} \mathcal{E} = f \hspace{1mm}} \Z  \xrightarrow{\hspace{1mm} \mathcal{D} = g \hspace{1mm}} \hat{\X}.
+\end{equation}
+Aceasta necesită impunerea ca datele de intrare observate $\X$ și cele decodate $\hat \X$ să fie apropiate printr-o anumită măsură de similaritate $d(\X, \hat \X)$. În natură, animalele sau oamenii rareori au acces direct la adevărul de bază $\X$. De exemplu, nu avem niciodată acces direct la forma 3D adevărată, distanța sau dinamica obiectelor dintr-o scenă. Cu toate acestea, toți am învățat să le estimăm și să le prezicem foarte precis și eficient. Prin urmare, o întrebare importantă este: cum putem învăța distribuția adevărată a $\X$, chiar dacă nu putem compara direct estimarea noastră $\hat \x$ cu adevărul de bază $\x$? După cum vom vedea în acest capitol, răspunsul constă, de asemenea, în feedback-ul în buclă închisă, precum și în dimensionalitatea redusă a distribuției datelor.
+
+
+
+
+
+
+După cum știm din capitolul anterior, pentru a ne asigura că o reprezentare este consistentă, trebuie să comparăm $\hat \X \sim p(\hat\x)$ generat și $\X \sim p(\x)$ original, cel puțin în distribuție. Chiar și când avem acces la $\X$ și $\hat \X$, tehnic, calcularea și minimizarea distanței dintre două distribuții poate fi problematică, mai ales când suportul distribuțiilor este de dimensiune redusă. Divergența KL introdusă în \Cref{ch:compression} nu este nici măcar bine definită între două distribuții care nu au suporturi suprapuse.
+
+Ca o încercare timpurie de a atenua dificultatea de mai sus în calcularea și minimizarea distanței dintre două distribuții (de dimensiune redusă), oamenii au sugerat învățarea generatorului/decodificatorului $g$ prin abordări discriminative \cite{Tu-2007}. Această linie de gândire a condus la ideea de {\em Rețele Generative Adversariale (GAN)} \cite{goodfellow2014generative}. Aceasta introduce un discriminator $d$, de obicei modelat de o rețea profundă, pentru a discerne diferențele dintre eșantioanele generate $\hat \X$ și cele reale $\X$:
+\begin{equation}
+ \Z \xrightarrow{\hspace{2mm} g(\z,\eta) \hspace{2mm}} \hat \X, \, \X \xrightarrow{\hspace{2mm} d(\x, \theta)\hspace{2mm}} \{\mathbf 0, \mathbf 1\}.
+ \label{eqn:GAN}
+\end{equation}
+Se sugerează că putem încerca să aliniem distribuțiile dintre $\hat \x$ și $\x$ printr-un {\em joc Stackelberg} între generator $g$ și discriminator $d$:
+\begin{equation}
+\max_{\theta}\min_{\eta} \mathbb{E}_{p({\x})}\big[\log d(\x,\theta)\big] + \mathbb{E}_{p({\z})}\big[1 - \log d(\underbrace{g(\z,\eta)}_{\hat \x \,\sim\, p_g},\theta)\big].
+\end{equation}
+Adică, discriminatorul $d$ încearcă să minimizeze entropia încrucișată dintre eșantioanele adevărate $\X$ și cele generate $\hat \X$ în timp ce generatorul $g$ încearcă să facă opusul.
+
+Se poate arăta că găsirea unui echilibru pentru jocul Stackelberg de mai sus este echivalentă cu minimizarea {\em divergenței Jensen-Shannon}:
+\begin{equation}
+    \mathcal{D}_{JS}(p(\x), p_g(\hat \x)) = \mathcal{D}_{KL}\big(p \| (p + p_g)/{2}\big) + \mathcal{D}_{KL}\big(p_g \| (p + p_g)/{2}\big).
+\end{equation}
+Observați că, în comparație cu divergența KL, divergența JS este bine definită chiar dacă suporturile celor două distribuții nu se suprapun. Cu toate acestea, divergența JS nu are o expresie în formă închisă nici măcar între două gaussiene, în timp ce divergența KL are. În plus, deoarece distribuțiile datelor sunt de dimensiune redusă, divergența JS poate fi foarte slab condiționată pentru optimizare.\footnote{așa cum este arătat în \cite{arjovsky2017wasserstein}.} Acest lucru poate explica de ce multe euristici suplimentare sunt de obicei folosite în multe variante ulterioare ale GAN.
+
+Deci, în schimb, s-a sugerat și înlocuirea divergenței JS cu distanța de mișcare a pământului (EM) sau distanța Wasserstein.\footnote{În linii mari, pentru distribuții cu suporturi de dimensiune redusă potențial nesuprapuse, divergența JS se comportă ca norma $\ell^0$, iar distanța EM se comportă ca norma $\ell^1$.} Cu toate acestea, atât divergența JS cât și distanța Wasserstein pot fi calculate doar aproximativ între două distribuții generale.\footnote{De exemplu, distanța Wasserstein necesită calcularea diferenței maxime între așteptările celor două distribuții peste toate funcțiile 1-Lipschitz.} Mai mult, nici divergența JS nici distanța Wasserstein nu au formule în formă închisă, chiar pentru distribuții gaussiene.\footnote{Distanța Wasserstein (normă $\ell^1$) poate fi mărginită de distanța Wasserstein (normă $\ell^2$) care are o formă închisă \cite{salmona2021gromovwasserstein}. Cu toate acestea, după cum este bine cunoscut în geometria de dimensiune înaltă, norma $\ell^1$ și norma $\ell^2$ deviază semnificativ în termenii proprietăților lor geometrice și statistice pe măsură ce dimensiunea devine mare \cite{Wright-Ma-2021}. Marginea poate deveni foarte slabă.}
+
+Dacă este dificil să comparăm distribuțiile datelor $\X$ și $\hat \X$, ar fi posibil să comparăm caracteristica învățată $\Z$ cu imaginea sa $\hat \Z$ sub codificatorul $f$:
+\begin{equation}
+ \X
+\xrightarrow{\hspace{1mm} \mathcal{E} = f \hspace{1mm}} \Z  \xrightarrow{\hspace{1mm} \mathcal{D} = g \hspace{1mm}} \hat{\X} \xrightarrow{\hspace{1mm} \mathcal{E} = f \hspace{1mm}} \hat \Z?
+\label{eqn:closed-autoencoding}
+\end{equation}
+Aceasta conduce la noțiunea de {\em reprezentare auto-consistentă}.
+\begin{definition}[Reprezentare Auto-Consistentă]\label{def:closed_loop}
+    Date fiind datele \(\vX\), numim \textit{reprezentare auto-consistentă} o pereche de funcții \((f \colon \cX \to \cZ, g \colon \cZ \to \cX)\), astfel încât \textit{caracteristicile} \(\vZ = f(\vX)\) sunt compacte și structurate, iar \textit{caracteristicile de autocodare} \(\hat{\vZ} \doteq f \circ g(\vZ)\) sunt \textit{apropiate} de \(\vZ\).
+    \begin{enumerate}
+        \item Spunem că este \textit{auto-consistentă pe eșantioane} dacă \(\vZ \approx \hat{\vZ}\) într-o anumită normă cu probabilitate mare.
+        \item Spunem că reprezentarea este \textit{auto-consistentă distributional} dacă \(\Law(\vZ) \approx \Law(\hat{\vZ})\).
+    \end{enumerate}
+\end{definition}
+
+
+
+\subsection{Transcriere în Buclă Închisă prin Jocuri Stackelberg}\label{sec:closed-loop-transcription}
+
+
+
+Cum încercăm să ne asigurăm că o reprezentare învățată este auto-consistentă? Ca de obicei, să presupunem $\X = \cup_{k=1}^K \X_k$ cu fiecare subset de eșantioane $\X_k$ aparținând unei subvarietăți de dimensiune redusă: $\X_k \subset \mathcal{M}_k, k = 1,\ldots, K$. Urmând notația din \Cref{ch:general-distribution}, folosim o matrice $\bm \Pi_k(i,i) = 1$ pentru a denota apartenența eșantionului $i$ la clasa $k$ și $\bm \Pi_k(i,j) = 0$ altfel. Se caută o mapare continuă $f(\cdot,\bm \theta): \x \mapsto \z$ de la $\X$ la o reprezentare optimă $\Z = [\z_1, \ldots, \z_N] \subset \mathbb{R}^{d \times N}$:
+\begin{equation}
+\bm X  \xrightarrow{\hspace{2mm} f(\x, \bm \theta) \hspace{2mm}} \bm Z,
+\label{eqn:LDR}
+\end{equation}
+care maximizează următorul obiectiv de reducere a ratei de codare (MCR$^2$):
+\begin{equation}\label{eq:mcr2-formulation}
+\begin{split}
+\max_{\Z} \; \Delta R_\epsilon(\Z  \mid \bm{\Pi}) %
+&\doteq \underbrace{\frac{1}{2}\log\det \Big(\I + {\alpha} \Z \Z^\top \Big)}_{R_{\epsilon}(\Z)} \;-\; \underbrace{\sum_{k=1}^{K}\frac{\gamma_k}{2} \log\det\Big(\I + {\alpha_k} \Z \bm{\Pi}^{j} \Z^\top \Big)}_{R^c_{\epsilon}(\Z \mid \bm \Pi)},
+\end{split}
+\end{equation}
+unde $\alpha = {d}/({N\epsilon^2})$, $\alpha_k = d/({\mathrm{tr}(\bm{\Pi}_k)\epsilon^2})$, $\gamma_k =  {\mathrm{tr}(\bm{\Pi}_{k})}/{N}$ pentru fiecare $k = 1,\dots, K$.
+
+O problemă cu învățarea unei astfel de mapări unilaterale \eqref{eqn:LDR} prin maximizarea obiectivului de mai sus \eqref{eq:mcr2-formulation} este că tinde să extindă dimensiunea subspațiului învățat pentru caracteristicile din fiecare clasă\footnote{Dacă dimensiunea spațiului caracteristic $d$ este prea mare, maximizarea reducerii ratei poate supraestima dimensiunea fiecărei clase. Prin urmare, pentru a învăța o reprezentare bună, trebuie să se preselecteze o dimensiune adecvată pentru spațiul caracteristic, așa cum s-a realizat în experimentele din \cite{yu2020learning}. De fapt, aceeași problemă de „selecție a modelului" persistă chiar și în cel mai simplu caz cu un singur subspațiu, care este PCA clasic \cite{Jolliffe1986}. După cunoștințele noastre, selectarea numărului corect de componente principale într-o situație eterogenă zgomotoasă rămâne un subiect activ de cercetare \cite{hong2020selecting}.}, așa cum am văzut în \Cref{sec:chap4-representation-learning-problem} din \Cref{ch:compression}. Pentru a verifica dacă caracteristicile învățate sunt consistente, adică nici nu supraestimează nici nu subestimează structura intrinsecă a datelor, putem lua în considerare învățarea unui decodificator $g(\cdot,\eta): \z \mapsto  \x$ de la reprezentarea $\Z = f(\X,\bm\theta)$ înapoi la spațiul datelor $\x$: $\hat \X = g(\Z, \bm\eta)$:
+\begin{equation}
+    \X \xrightarrow{\hspace{2mm} f(\x, \bm\theta)\hspace{2mm}} \Z \xrightarrow{\hspace{2mm} g(\z, \bm \eta) \hspace{2mm}} \hat \X,
+    \label{eqn:autoencoding-ch6}
+\end{equation}
+și verificăm cât de apropiate sunt $\X$ și $\hat \X$. Aceasta formează o autocodare care este ceea ce am studiat extensiv în \Cref{ch:autoencoding} anterior.
+
+\paragraph{Măsurarea distanței în spațiul caracteristic.}
+Cu toate acestea, după cum am discutat mai sus, dacă nu avem opțiunea de a calcula distanța dintre $\X$ și $\hat \X$, suntem lăsați cu opțiunea de a compara caracteristicile lor corespunzătoare $\Z$ și $\hat \Z = f(\hat \X, \bm \theta)$. Observați că sub obiectivul MCR$^2$, distribuțiile $\Z$ sau $\hat \Z$ rezultate tind să fie liniare pe bucăți, astfel încât distanța lor poate fi calculată mai ușor. Mai precis, deoarece caracteristicile fiecărei clase, $\Z_k$ și $\hat{\Z}_k$, sunt aproape de a fi un subspațiu/gaussian de dimensiune redusă, „distanța" lor poate fi măsurată prin reducerea ratei, cu \eqref{eq:mcr2-formulation} restricționată la două seturi de dimensiune egală:
+\begin{equation}
+\Delta R_\epsilon\big(\Z_k, \hat{\Z}_k\big) \doteq R_\epsilon\big(\Z_k \cup \hat{\Z}_k\big) - \frac{1}{2} \big( R_\epsilon\big(\Z_k) + R_\epsilon\big(\hat \Z_k)\big).
+\end{equation}
+Distanța totală dintre $\Z$ și $\hat \Z$ este dată de:
+\begin{equation}
+d(\Z, \hat \Z) \doteq   \sum_{k=1}^K \Delta R_\epsilon\big(\Z_k, \hat{\Z}_k\big) =  \sum_{k=1}^K \Delta R_\epsilon\big(\Z_k, f(g(\Z_k, \bm\eta),\bm \theta)\big).
+\label{eqn:Z-distance}
+\end{equation}
+
+
+Dacă suntem interesați să discernem {\em orice} diferențe în distribuțiile datelor originale $\X$ și cele decodate $\hat \X$, putem vedea codificatorul de caracteristici $f(\cdot, \bm \theta)$ ca un „discriminator" pentru a {\em mări} orice diferență între toate perechile de $\X_k$ și $\hat \X_k$, prin simpla maximizare a distanței $d(\X, \hat \X)$:
+\begin{equation}
+\max_f d(\Z, \hat \Z) = \max_{\bm \theta} \sum_{k=1}^K \Delta R_\epsilon\big(\Z_k, \hat{\Z}_k\big) = \max_{\bm \theta} \sum_{k=1}^K \Delta R_\epsilon\big(f(\X_k,\bm \theta), f(\hat{\X}_k,\bm \theta)\big).
+    \label{eqn:max-distance}
+\end{equation}
+Adică, o „distanță" între $\X$ și $\hat \X$ poate fi măsurată ca reducerea maximă realizabilă a ratei între toate perechile de clase din aceste două seturi. Într-un fel, aceasta măsoară cât de bine sau prost se aliniază $\hat \X$ decodat cu datele originale $\X$---prin urmare măsurând calitatea „injectivității" codificatorului $f$. Observați că o astfel de măsură discriminativă este consistentă cu ideea GAN \eqref{eqn:GAN} care încearcă să separe $\X$ și $\hat \X$ în două clase, măsurate prin entropia încrucișată.
+
+Cu toate acestea, aici codificatorul discriminativ $f$ se generalizează în mod natural la cazurile în care distribuțiile datelor sunt multi-clasă și multi-modale, iar discriminativitatea este măsurată cu o măsură mai rafinată---reducerea ratei---în loc de pierderea tipică cu două clase (de exemplu, entropia încrucișată) folosită în GAN-uri. Adică, putem vedea codificatorul $f$ ca un discriminator generalizat care înlocuiește clasificatorul binar $d$ din \eqref{eqn:GAN}:
+\begin{equation}
+ \Z \xrightarrow{\hspace{2mm} g(\z,\bm \eta) \hspace{2mm}} \hat \X, \, \X \xrightarrow{\hspace{2mm} f(\x, \bm \theta)\hspace{2mm}} \{\hat \Z, \Z\}.
+ \label{eqn:closed-loop-GAN}
+\end{equation}
+Conducta generală poate fi ilustrată prin următoarea diagramă „în buclă închisă":
+\begin{equation}
+    \X \xrightarrow{\hspace{2mm} f(\x, \bm \theta)\hspace{2mm}} \Z \xrightarrow{\hspace{2mm} g(\z,\bm \eta) \hspace{2mm}} \hat \X \xrightarrow{\hspace{2mm} f(\x, \bm \theta)\hspace{2mm}} \ \hat \Z,
+\end{equation}
+unde modelul general are parametrii: $\bm \Theta = \{\bm \theta, \bm \eta\}$. \Cref{fig:auto-encoding-closed} arată procesul general.
+
+\begin{figure}[t]
+{\includegraphics[width=1.0\linewidth]{\toplevelprefix/chapters/chapter5/figs/diagrams_redu_gan_2.pdf}}
+\caption{{\bf %
+ O Transcriere în Buclă Închisă.} Codificatorul $f$ are roluri duale: învață o reprezentare $\z$ pentru datele $\x$ prin maximizarea reducerii ratei lui $\z$ și este, de asemenea, un „senzor de feedback" pentru orice discrepanță între datele $\x$ și cele decodate $\hat \x$. Decodificatorul $g$ are, de asemenea, roluri duale: este un „controler" care corectează discrepanța dintre $\x$ și $\hat \x$ și, de asemenea, urmărește să minimizeze rata generală de codare pentru reprezentarea învățată.} \label{fig:auto-encoding-closed}
+\end{figure}
+
+
+\paragraph{Codificator și decodificator ca joc cu doi jucători.}
+Evident, pentru a asigura că autocodarea învățată este auto-consistentă, obiectivul principal al decodificatorului $g(\cdot, \bm \eta)$ este să {\em minimizeze} distanța dintre $\Z$ și $\hat \Z$. Adică, pentru a învăța $g$, vrem să minimizăm distanța $d(\Z, \hat \Z)$:
+\begin{equation}
+\min_g d(\Z, \hat \Z) \doteq \min_\eta  \sum_{k=1}^K \Delta R\big(\Z_k, \hat{\Z}_k\big) =  \min_{\bm \eta}  \sum_{k=1}^K \Delta R\big(\Z_k, f(g(\Z_k, \bm \eta),\bm \theta)\big),
+\label{eqn:min-distance}
+\end{equation}
+unde $\Z_k = f(\X_k,\bm \theta)$ și $\hat \Z_k = f(\hat{\X}_k,\bm\theta)$.
+
+\begin{example}
+Cineva s-ar putea întreba de ce avem nevoie de maparea $f(\cdot, \bm \theta)$ să funcționeze ca discriminator între $\X$ și $\hat \X$ prin maximizarea $\max_{\bm \theta} \Delta R_\epsilon\big(f(\X,\bm \theta), f(\hat \X, \bm \theta)\big)$. \Cref{fig:decoder} oferă o ilustrare simplă: ar putea exista mulți decodificatori $g$ astfel încât $f\circ g$ să fie o mapare identitate (Id). $f\circ g(\z) = \z $ pentru toți $\z$ în subspațiul $S_{\z}$ din spațiul caracteristic. Cu toate acestea, $g\circ f$ nu este neapărat o hartă de autocodare pentru $\x$ în distribuția originală $S_{\x}$ (aici desenată ca subspațiu pentru simplitate). Adică, $g\circ f(S_{\x}) \not\subset S_{\x}$, cu atât mai puțin $g\circ f(S_{\x}) = S_{\x}$ sau $g\circ f(\x) = \x$. Ar trebui să ne așteptăm că, fără un control atent al imaginii lui $g$, acesta ar fi cazul cu probabilitate mare, mai ales când suportul distribuției lui $\x$ este extrem de mic-dimensional în spațiul original de date de dimensiune înaltă.
+\end{example}
+\begin{figure}
+\centering{\includegraphics[width=3.0in]{\toplevelprefix/chapters/chapter5/figs/diagrams_fig1.pdf}}
+\caption{\textbf{{Încorporări} %
+ ale subvarietăților de dimensiune redusă într-un spațiu de dimensiune înaltă.} $S_{\x}$ (albastru) este subvarietatea pentru datele originale $\x$; $S_{\z}$ (roșu) este imaginea lui $S_{\x}$ sub maparea $f$, reprezentând caracteristica învățată $\z$; iar curba verde este imaginea caracteristicii $\z$ sub maparea de decodare $g$.} \label{fig:decoder}
+\end{figure}
+
+Comparând natura contractantă și contrastivă a \eqref{eqn:min-distance} și \eqref{eqn:max-distance} asupra aceleiași măsuri de distanță, vedem rolurile codificatorului $f(\cdot, \bm \theta)$ și decodificatorului $g(\cdot, \bm \eta)$ în mod natural ca „{\bf un joc cu doi jucători}": {\em în timp ce codificatorul $f$ încearcă să mărească diferența dintre datele originale și datele lor transcrise, decodificatorul $g$ urmărește să minimizeze diferența.} Acum, pentru comoditate, să definim funcția de „codare în buclă închisă":
+\begin{equation}
+    h(\x, \bm \theta,\bm \eta) \doteq f\big(g\big(f(\x, \bm \theta), \bm \eta\big), \bm \theta\big): \; \x \mapsto \hat \z.
+\end{equation}
+
+În mod ideal, vrem ca această funcție să fie foarte apropiată de $f(\x, \bm \theta)$ sau cel puțin distribuțiile imaginilor lor ar trebui să fie apropiate. Cu această notație, combinând \eqref{eqn:min-distance} și \eqref{eqn:max-distance}, o noțiune în buclă închisă de „distanță" între $\X$ și $\hat \X$ poate fi calculată ca {\em un punct de echilibru} la următorul joc Stackelberg (cf \Cref{sec:minimax}) pentru aceeași utilitate în termenii reducerii ratei:
+\begin{equation}
+\mathcal{D}(\X, \hat \X) \doteq  \max_{\bm \theta} \min_{\bm \eta} \sum_{k=1}^K \Delta R_\epsilon\big(f(\X_k,\bm \theta), h(\X_k,\bm \theta,\bm \eta)\big).
+    \label{eq:MCR2-GAN-pair}
+\end{equation}
+
+Observați că aceasta măsoară doar diferența dintre (caracteristicile) datelor originale și versiunea lor transcrisă. Nu măsoară cât de bună este reprezentarea $\Z$ (sau $\hat \Z$) pentru clasele multiple din $\X$ (sau $\hat \X$). În acest scop, putem combina distanța de mai sus cu obiectivele originale de tip MCR$^2$ \eqref{eq:mcr2-formulation}: și anume, reducerea ratei $\Delta R_\epsilon(\Z)$ și $\Delta R_\epsilon(\hat \Z)$ pentru LDR învățat $\Z$ pentru $\X$ și $\hat \Z$ pentru $\hat \X$ decodat. Observați că, deși codificatorul $f$ încearcă să {\em maximizeze} reducerea ratei multi-clasă a caracteristicilor $\Z$ ale datelor $\X$, decodificatorul $g$ ar trebui să {\em minimizeze} reducerea ratei caracteristicilor multi-clasă $\hat \Z$ ale $\hat \X$ decodat. Adică, decodificatorul $g$ încearcă să folosească o rată minimă de codare necesară pentru a obține o calitate bună de decodare.
+
+Prin urmare, jocul Stackelberg general „multi-clasă" pentru învățarea transcrierii în buclă închisă, numit CTRL-Multi, este
+\begin{eqnarray}
+&&\max_{\bm \theta} \min_{\bm \eta} \mathcal{T}_{\X}(\bm \theta, \bm \eta) \\
+&\doteq& \underbrace{\Delta R_\epsilon\big(f(\X,\bm \theta)\big)}_{\text{Codare expansivă}} + \underbrace{\Delta R_\epsilon\big(h(\X,\bm \theta, \bm \eta)\big)}_{\text{Decodare compresivă}} + \sum_{k=1}^K \underbrace{\Delta R_\epsilon\big(f(\X_k,\bm \theta), h(\X_k,\bm \theta,\bm \eta)\big)}_{\text{Codare contrastivă \& Decodare contractivă}}   \\
+&=& \Delta R_\epsilon\big(\Z(\bm \theta) \big) + \Delta R_\epsilon\big(\hat \Z(\bm \theta, \bm \eta)\big) + \sum_{k=1}^K \Delta R_\epsilon\big(\Z_k(
+\bm \theta), \hat \Z_k(\bm \theta, \bm \eta) \big),
+    \label{eq:MCR2-GAN-objective}
+\end{eqnarray}
+supus anumitor constrângeri (limite superioare sau inferioare) asupra primului termen și celui de-al doilea termen.
+
+
+
+Observați că, fără termenii asociați cu partea generativă $h$ sau cu toți acești termeni fixați ca constantă, obiectivul de mai sus este exact obiectivul MCR$^2$ original introdus în \Cref{ch:compression}. Într-un cadru nesupravegheat, dacă vedem fiecare eșantion (și augmentările sale) ca propria sa clasă, formularea de mai sus rămâne exact aceeași. Numărul de clase $k$ este pur și simplu numărul de eșantioane independente. În plus, observați că funcția obiectiv a jocului de mai sus depinde doar de (caracteristicile) datelor $\X$, prin urmare se pot învăța codificatorul și decodificatorul (parametrii) fără necesitatea eșantionării sau potrivirii vreunei distribuții suplimentare (așa cum este de obicei necesar în GAN-uri sau VAE-uri).
+
+Ca un caz special, dacă $\X$ are doar o clasă, jocul Stackelberg se reduce la o formă specială „cu două clase" sau „binară",\footnote{Deoarece primii doi termeni de reducere a ratei devin automat zero} numită CTRL-Binary,
+\begin{equation}
+ \max_{\bm \theta} \min_{\bm \eta} \mathcal{T}^b_{\X}(\bm \theta, \bm \eta) \doteq \Delta R_\epsilon\big(f(\X,\bm \theta), h(\X,\bm \theta,\bm \eta)\big) = \Delta R_\epsilon\big(\Z(\bm \theta), \hat \Z(\bm \theta, \bm \eta)\big),
+    \label{eq:MCR2-GAN-objective-binary}
+\end{equation}
+între $\X$ și $\hat\X$ decodat prin vizualizarea $\X$ și $\hat \X$ ca două clase $\{\bm 0, \bm 1\}$. Observați că acest caz binar seamănă cu formularea GAN original \eqref{eqn:GAN}. În loc să folosească entropia încrucișată, formularea noastră adoptă o măsură de reducere a ratei mai rafinată, care s-a dovedit a promova diversitatea în reprezentarea învățată în \Cref{ch:compression}.
+
+Uneori, chiar și când $\X$ conține mai multe clase/moduri, se poate vedea totuși toate clasele împreună ca o singură clasă. Apoi, obiectivul binar de mai sus este de a alinia distribuția unită a tuturor claselor cu $\hat \X$ decodat. Aceasta este de obicei o sarcină mai simplă de realizat decât cea multi-clasă \eqref{eq:MCR2-GAN-objective}, deoarece nu necesită învățarea unui CTRL multi-clasă mai rafinat pentru date, așa cum vom vedea mai târziu în experimente. Observați că o caracteristică bună a formulării de mai sus este că {\em toate cantitățile din obiective sunt măsurate în termenii reducerii ratei pentru caracteristicile învățate} (presupunând că caracteristicile devin în cele din urmă gaussiene de subspațiu).
+
+Se poate observa că cadrul de învățare de mai sus se inspiră din corecția erorilor în buclă închisă practicată pe scară largă în sistemele de control cu feedback. Mecanismul în buclă închisă este folosit pentru a forma un sistem general de feedback între cele două rețele de codare și decodare pentru corectarea oricărei „erori" în distribuțiile dintre datele $\x$ și cele decodate $\hat \x$. Folosind terminologia din teoria controlului, se poate vedea rețeaua de codare $f$ ca un „senzor" pentru feedback-ul erorilor, în timp ce rețeaua de decodare $g$ ca un „controler" pentru corecția erorilor. Cu toate acestea, observați că aici „ținta" pentru control nu este un scalar sau un vector de dimensiune finită, ci o distribuție continuă---pentru ca distribuția lui $\hat \x$ să se potrivească cu cea a datelor $\x$. Aceasta este în general o problemă de control într-un spațiu de dimensiune infinită. Spațiul difeomorfismelor posibile ale subvarietăților pe care $f$ încearcă să le modeleze este de dimensiune infinită \cite{Lee2002IntroductionTS}. În mod ideal, sperăm că atunci când senzorul $f$ și controlerul $g$ sunt optimi, distribuția lui $\x$ devine un „punct fix" pentru bucla închisă în timp ce distribuția lui $\z$ atinge o reprezentare liniară discriminativă compactă. Prin urmare, programele minimax \eqref{eq:MCR2-GAN-objective} și \eqref{eq:MCR2-GAN-objective-binary} pot fi interpretate și ca jocuri între un senzor de feedback al erorilor și un controler de reducere a erorilor.
+
+Întrebarea rămasă este dacă cadrul de mai sus poate învăța într-adevăr o reprezentare bună (de autocodare) a unui set de date dat? Înainte de a oferi o justificare teoretică formală (în subsecțiunea următoare), prezentăm câteva rezultate empirice.
+
+\paragraph{Vizualizarea corelației caracteristicilor $\Z$ și caracteristicilor decodate $\hat \Z$.} Vizualizăm similaritatea cosinus între $\Z$ și $\hat{\Z}$ învățate din obiectivul multi-clasă \eqref{eq:MCR2-GAN-objective} pe MNIST, CIFAR-10 și ImageNet (10 clase), care indică cât de aproape este $\hat{\z} = f\circ g(\z)$ de $\z$. Rezultatele din \Cref{fig:justifyz=z} arată că $\Z$ și $\hat{\Z}$ sunt aliniate foarte bine în cadrul fiecărei clase. Modelele bloc-diagonale pentru MNIST sunt mai clare decât cele pentru CIFAR-10 și ImageNet, deoarece imaginile din CIFAR-10 și ImageNet au aspecte vizuale mai diverse.
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/MNIST_MNIST_ZZhat_heatmap_epo200.png}
+        \caption{MNIST}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/cifar_heatmat_cifar.png}
+        \caption{CIFAR-10}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/Imagenet_heatmat_epoch200000.png}
+        \caption{ImageNet}
+    \end{subfigure}
+    \caption{{Vizualizarea} %
+    alinierii dintre $\Z$ și $\hat{\Z}$: $|\Z^\top \hat{\Z}|$ în spațiul caracteristic pentru (\textbf{a}) MNIST, (\textbf{b}) CIFAR-10, și~(\textbf{c}) ImageNet-10-Clase.}
+    \label{fig:justifyz=z}
+\end{figure}
+
+
+
+
+\paragraph{Vizualizarea autocodării datelor $\X$ și celor decodate $\hat \X$.} Comparăm câteva $\X$ reprezentative și $\hat{\X}$ corespunzătoare pe MNIST, CIFAR-10 și ImageNet (10 clase) pentru a verifica cât de aproape este $\hat \x = g\circ f(\x)$ de $\x$. Rezultatele sunt prezentate în \Cref{fig:justify_xhat_equals_x}, iar vizualizările sunt create din eșantioane de antrenament. Vizual, $\hat \x$ autocodat captează fidel caracteristicile vizuale majore din eșantionul de antrenament respectiv $\x$, în special poziția, forma și aspectul. Pentru un set de date mai simplu precum MNIST, imaginile autocodate sunt aproape identice cu originalul.
+
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/MNIST_MNIST_train_images_epoch200.png}
+        \caption{{\small MNIST $\X$}}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/cifar_input.png}
+        \caption{{\small CIFAR-10 $\X$}}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/Imagenet_input.png}
+        \caption{{\small ImageNet $\X$}}
+    \end{subfigure}
+
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/MNIST_MNIST_train_recon_images_epoch200_multi.png}
+        \caption{{\small MNIST $\hat{\X}$}}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/cifar_reconstruct.png}
+        \caption{{\small CIFAR-10 $\hat{\X}$}}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.3\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/Imagenet_reconstruct.png}
+        \caption{{\small ImageNet $\hat{\X}$}}
+    \end{subfigure}
+    \caption{Vizualizarea proprietății de auto-codare a transcrierii învățate în buclă închisă \mbox{($\x \approx \hat{\x} = g\circ f(\x)$)} pe MNIST, CIFAR-10 și ImageNet (măriți pentru o vizualizare mai bună).}
+    \label{fig:justify_xhat_equals_x}
+\end{figure}
+
+
+\subsection{Un Amestec de Gaussiene de Dimensiune Redusă}
+
+În cele de mai sus, am argumentat că este posibil să formulăm problema învățării unei distribuții de date ca o problemă de autocodare în buclă închisă. Am văzut, de asemenea, empiric că o astfel de schemă pare să funcționeze. Întrebarea rămasă este când și de ce ar trebui să funcționeze o astfel de schemă. Este dificil să răspundem la această întrebare pentru cazurile cele mai generale cu distribuții arbitrare de date. Cu toate acestea, ca de obicei, să vedem dacă putem ajunge la o justificare riguroasă pentru cazul ideal când distribuția datelor este un amestec de subspații de dimensiune redusă sau gaussiene de rang redus. O caracterizare și înțelegere clară a acestui caz special important ar arunca lumină asupra cazurilor mai generale.\footnote{Deoarece majoritatea distribuțiilor cu structuri de dimensiune redusă pot fi bine aproximate de această familie de distribuții.}
+
+În acest scop, să presupunem mai întâi că \(\vX\) este distribuit conform unui amestec de gaussiene de dimensiune redusă, iar eticheta (adică atribuirea subspațiului) pentru \(\vX\) este dată de \(\vy\). Apoi, să stabilim o problemă de optimizare minimax pentru a învăța distribuția datelor, să zicem prin învățarea unei codări a \(\vX\) în reprezentări \(\vZ\) care sunt suportate pe un amestec de subspații \textit{ortogonale}, și o decodare a \(\vZ\) înapoi în \(\vX\). Apoi, reprezentarea pe care vrem să o obținem este maximizată de versiunea discutată anterior a câștigului de informație, adică \( \Delta R_{\epsilon}(\vZ) = R_{\epsilon}(\vZ) - \sum_{k=1}^K R_{\epsilon}(\bm Z_k) \), care impune ca reprezentarea \(\vZ_{k}\) a fiecărei clase \(k\) să acopere un subspațiu care este ortogonal pe subspațiile suport ale altor clase. Modul de a măsura consistența decodării este, ca înainte, dat de \(\sum_{k = 1}^{K}\Delta R_\epsilon(\vZ_{k}, \hat{\vZ}_{k})\), care impune ca reprezentarea \(\vZ_{k}\) și autocodarea sa \(\hat{\vZ}_{k}\) pentru fiecare clasă \(k\) să acopere același subspațiu. Astfel, putem stabili un joc Stackelberg simplificat:
+\begin{equation}\label{eq:ctrl_msp_game}
+    \max_{\bm \theta}\min_{\bm \eta}\bc{\Delta R_\epsilon(\vZ(\bm \theta)) + \sum_{k = 1}^{K}\Delta R_\epsilon(\vZ_{k}(\bm \theta), \hat{\vZ}_{k}(\bm \theta, \bm \eta))}
+\end{equation}
+Observați că aceasta este o configurare mai simplă decât ceea ce este folosit în practică---nu există un termen \(\Delta R_\epsilon(\hat{\vZ})\), de exemplu, și lucrăm în cadrul supravegheat cu etichete de clasă (deși tehnicile folosite pentru a demonstra următorul rezultat sunt ușor de extins la formulări nesupravegheate). De asemenea, consistența reprezentărilor este măsurată doar într-un sens distributional prin \(\Delta R_\epsilon\) (deși aceasta poate fi înlocuită cu o metrică de distanță pe eșantioane, cum ar fi norma \(\ell_{2}\) dacă se dorește, și se pot trage concluzii echivalente, \textit{mutatis mutandis}).
+
+În condiții blânde, pentru a realiza codificatorul și decodificatorul doriți care realizează \(\vZ\) dintr-o sursă de date \(\vX\) care este deja distribuită conform unui amestec de gaussiene corelate de dimensiune redusă, avem nevoie doar de un codificator și decodificator liniar pentru a desface și albi gaussienele. Studiem apoi acest cadru în cazul în care \(\bm \theta\) și \(\bm \eta\) parametrizează matrici a căror normă de operator este constrânsă.
+
+Vrem să înțelegem ce tipuri de optimi sunt învățate în acest cadru. Un concept de soluție potrivit pentru acest tip de joc, unde soluția optimă a decodificatorului este definită doar în raport cu codificatorul (și nu, în special, în raport cu o altă proprietate intrinsecă a decodificatorului), este un \textit{echilibru Stackelberg} unde decodificatorul urmează codificatorul.
+Și anume, la un astfel de echilibru, decodificatorul ar trebui să-și optimizeze obiectivul; între timp, codificatorul ar trebui să-și optimizeze obiectivul, având în vedere că, indiferent de ce alege, decodificatorul va alege un răspuns optim (care poate afecta obiectivul codificatorului). În termeni de teorie a jocurilor, este ca și cum decodificatorul merge \textit{al doilea}: își alege ponderile după codificator, iar atât codificatorul cât și decodificatorul încearcă să-și optimizeze obiectivul în lumina acestui fapt. Este tractabil computațional să învățăm echilibrele secvențiale prin metode de gradient prin \textit{optimizare alternativă}, unde fiecare parte folosește rate de învățare diferite. Expunerea detaliată a echilibrelor secvențiale depășește scopul acestei cărți și oferim mai multe detalii tehnice în \Cref{sec:minimax}. În acest cadru, avem următorul rezultat:
+\begin{theorem}[\cite{pai2022pursuit}, Prescurtat]\label{thm:ctrl_theory}
+    Să presupunem că \(\vX\) este distribuit pe un amestec de subspații. În anumite condiții realiste, dar tehnice, este valabil că toate echilibrele secvențiale ale \eqref{eq:ctrl_msp_game} respectă:
+    \begin{itemize}
+        \item \(\vZ_{k}\) se află pe subspații ortogonale și sunt izotrope pe acele subspații, adică maximizează câștigul de informație.
+        \item Autocodarea este auto-consistentă, adică subspațiile acoperite de \(\vZ_{k}\) și \(\hat{\vZ}_{k}\) sunt aceleași pentru toți \(k\).
+    \end{itemize}
+\end{theorem}
+Această noțiune de auto-consistență este maximul pe care îl putem aștepta dacă există doar ipoteze geometrice asupra datelor, adică nu există ipoteze statistice. Dacă presupunem că coloanele lui \(\vX\) sunt extrase dintr-un model de amestec gaussian de rang redus, atunci versiuni analoge ale acestei teoreme certifică că \(\vZ_{k}\) sunt, de asemenea, gaussiene de rang redus a căror covarianță este izotropă, de exemplu.
+În esență, acest rezultat validează, prin cazul simplu al amestecurilor gaussiene pe subspații, că jocurile minimax pentru optimizarea câștigului de informație și auto-consistenței pot obține soluții optime.
+
+
+
+
+
+
+\section{Învățarea Continuă a Reprezentărilor Auto-Consistente}
+\label{sec:continuous}
+
+\subsection{Învățare Incrementală pe Clase}
+\label{sec:class-wise-incremental}
+
+După cum am văzut, rețelele neuronale profunde au demonstrat o mare capacitate de a învăța reprezentări pentru sute sau chiar mii de clase de obiecte, atât în contexte discriminative cât și generative. Cu toate acestea, rețelele trebuie de obicei antrenate offline, cu date eșantionate uniform din toate clasele simultan. Este cunoscut faptul că atunci când o rețea (în buclă deschisă) este actualizată pentru a învăța clase noi fără date din cele vechi, cunoștințele învățate anterior vor cădea victimă problemei {\em uitării catastrofale} \cite{McCloskey1989catastrophic}. Aceasta este cunoscută în neuroștiință ca dilema stabilitate-plasticitate: provocarea de a asigura că un sistem neuronal poate învăța dintr-un mediu nou, păstrând în același timp cunoștințele esențiale din cele anterioare \cite{Grossberg1987CompetitiveLF}.
+
+În contrast, sistemele neuronale naturale (de exemplu, creierul animalelor) nu par să sufere deloc de o astfel de uitare catastrofală. Ele sunt capabile să dezvolte memorie nouă a obiectelor noi, păstrând în același timp memoria obiectelor învățate anterior. Această abilitate, pentru sistemele neuronale naturale sau artificiale, este adesea denumită {\em învățare incrementală, învățare continuă, învățare secvențială} sau {\em învățare pe viață} \cite{controlled-forgetting}.
+
+
+
+Deși multe lucrări recente au evidențiat modul în care sistemele neuronale artificiale pot fi antrenate în moduri mai flexibile, cele mai puternice eforturi existente pentru a răspunde dilemei stabilitate-plasticitate pentru rețelele neuronale artificiale necesită de obicei fie stocarea exemplarelor brute \cite{icarl,chaudhry2019tiny}, fie furnizarea de mecanisme externe \cite{EWC}. Exemplarele brute, în special în cazul intrărilor de dimensiune înaltă precum imaginile, sunt costisitoare și dificil de scalat, în timp ce mecanismele externe---care includ de obicei rețele secundare și spații de reprezentare pentru redare generativă, alocarea incrementală a resurselor de rețea, duplicarea rețelei sau izolarea explicită a părților folosite și nefolosite ale rețelei---necesită euristici și implică costuri ascunse.
+
+
+Aici suntem interesați de un cadru de învățare incrementală care este similar cu natura. Aceasta contracarează aceste practici existente cu două calități cheie.
+\begin{enumerate}
+    \item Prima este că ar trebui să fie \emph{bazată pe memorie.} Când învățăm clase noi, nu sunt disponibile exemplare brute ale claselor vechi pentru a antrena rețeaua împreună cu date noi. Aceasta implică că trebuie să ne bazăm pe o „memorie" compactă și astfel structurată învățată pentru clasele vechi, cum ar fi reprezentările generative învățate incremental ale claselor vechi, precum și mapările asociate de codare și decodare \cite{fearnet}.
+    \item A doua este că ar trebui să fie \emph{autonomă}. Învățarea incrementală are loc într-un singur sistem neuronal cu o capacitate fixă și într-un spațiu comun de reprezentare. Capacitatea de a minimiza uitarea este implicată de optimizarea unui obiectiv general de învățare, fără rețele externe, modificări arhitecturale sau mecanisme de alocare a resurselor.
+\end{enumerate}
+
+Structurile liniare incoerente pentru caracteristicile diferitelor clase seamănă foarte mult cu modul în care obiectele sunt codificate în diferite zone ale cortexului inferotemporal al creierului animalelor \cite{Chang-Cell-2017,Bao2020AMO}. Transcrierea în buclă închisă $\X \rightarrow \Z \rightarrow \hat{\X} \rightarrow \hat{\Z}$ seamănă, de asemenea, cu mecanismele ipotezate popular pentru formarea memoriei \cite{2020Vandeven,Josselyn2020MemoryER}. Aceasta conduce la o întrebare: deoarece memoria în creier este formată într-un mod incremental, poate cadrul de transcriere în buclă închisă de mai sus să sprijine și învățarea incrementală?
+
+\paragraph{Eșantionare și redare a memoriei LDR.} {\em Structurile} liniare simple ale LDR o fac unic potrivită pentru învățarea incrementală: distribuția caracteristicilor $\Z_j$ ale fiecărei clase învățate anterior poate fi reprezentată explicit și concis printr-un subspațiu principal $\mathcal{S}_j$ în spațiul caracteristic. Pentru a păstra memoria unei clase vechi $j$, trebuie doar să păstrăm subspațiul în timp ce învățăm clase noi. În acest scop, eșantionăm pur și simplu $m$ caracteristici prototip reprezentative pe subspațiu de-a lungul celor mai mari $r$ componente principale și denotăm aceste caracteristici ca $\Z_{j,old}$. Datorită structurilor liniare simple ale LDR, putem eșantiona din $\Z_{j,old}$ calculând media și covarianța lui $\Z_{j,old}$ după învățarea clasei $j$. Stocarea necesară este extrem de mică, deoarece trebuie să stocăm doar medii și covarianțe, care sunt eșantionate după necesitate. Să presupunem că un total de $t$ clase vechi au fost învățate până acum. Dacă caracteristicile prototip, notate $\Z_{old} \doteq [\Z^1_{old},\ldots, \Z^t_{old}]$, pentru toate aceste clase pot fi păstrate când învățăm clase noi, subspațiile $\{\mathcal{S}_j\}_{j=1}^t$ reprezentând memoria trecută vor fi păstrate de asemenea. Detalii despre eșantionare și calcularea mediei și covarianței pot fi găsite în lucrarea \cite{tong2023incremental}.
+
+\begin{figure*}[t]
+\centering
+\includegraphics[width=0.9\textwidth]{\toplevelprefix/chapters/chapter5/figs/framework-v7.png}
+\caption{\textbf{Cadrul general} al învățării incrementale bazate pe transcriere în buclă închisă pentru o memorie LDR structurată. Este necesară doar o singură rețea de codare-decodare complet autonomă: pentru o nouă clasă de date $\X_{new}$, o nouă memorie LDR $\Z_{new}$ este învățată incremental ca un joc minimax între codificator și decodificator supus constrângerii că memoria veche a claselor trecute $\Z_{old}$ este intactă prin transcrierea în buclă închisă (sau redare): $\Z_{old} \approx \hat{\Z}_{ old} = f(g(\Z_{ old}))$.
+\vspace{-0.2in}}
+\label{fig:framework}
+\end{figure*}
+
+\paragraph{Învățarea incrementală LDR cu o constrângere de memorie veche.}
+Observați că, cu autocodarea învățată \eqref{eqn:autoencoding-ch6}, se pot reda și utiliza imaginile, să zicem $\hat\X_{old} = g(\Z_{old}, \bm \eta)$, asociate cu caracteristicile memoriei pentru a evita uitarea în timp ce învățăm clase noi. Aceasta este de obicei modul în care modelele generative au fost folosite pentru metodele anterioare de învățare incrementală. Cu toate acestea, cu cadrul în buclă închisă, redarea explicită a imaginilor din caracteristici nu este necesară. Memoria trecută poate fi păstrată eficient prin optimizare exclusiv pe caracteristicile în sine.
+
+Considerați sarcina de a învăța incremental o nouă clasă de obiecte.\footnote{Desigur, se poate lua în considerare și cadrul mai general în care sarcina conține un lot mic de clase noi, fără modificări serioase.} Denotăm un set de eșantioane nou corespunzător ca $\X_{new}$. Caracteristicile lui $\X_{new}$ sunt notate ca $\Z_{new}(\bm \theta) = f(\X_{new}, \bm \theta)$. Le concatenăm împreună cu caracteristicile prototip ale claselor vechi $\Z_{old}$ și formăm $\Z = [\Z_{new}(\bm \theta), \Z_{old}]$. Denotăm imaginile redate din toate caracteristicile ca $\hat{\X} = [{\hat{\X}_{new}(\bm \theta,\bm \eta)}, {\hat{\X}_{old}(\bm \eta)}]$, deși nu trebuie de fapt să le calculăm sau să le folosim explicit. Avem nevoie doar de caracteristicile imaginilor redate, notate $\hat{\Z} = f(\hat{\X}, \bm \theta) =  [{\hat{\Z}_{new}(\bm \theta,\bm \eta)}, {\hat{\Z}_{old}(\bm \theta,\bm \eta)}]$.
+
+
+Oglindind motivația pentru obiectivul CTRL multi-clasă \eqref{eq:MCR2-GAN-objective}, am dori ca caracteristicile noii clase $\Z_{new}$ să fie incoerente cu toate cele vechi $\Z_{old}$. Deoarece $\Z_{new}$ este singura clasă nouă ale cărei caracteristici trebuie învățate, obiectivul \eqref{eq:MCR2-GAN-objective} se reduce la cazul în care $k=1$:
+\begin{equation}
+\min_{\bm \eta} \max_{\bm \theta} \Delta{R_\epsilon(\Z)} + \Delta{R_\epsilon(\hat{\Z})}+\Delta{R_\epsilon(\Z_{new},\hat{\Z}_{new})}.
+\label{eqn:unconstrained-minimax}
+\end{equation}
+Cu toate acestea, când actualizăm parametrii rețelei $(\bm \theta,\bm \eta)$ pentru a optimiza caracteristicile pentru noua clasă, mapările actualizate $f$ și $g$ vor schimba și caracteristicile claselor vechi. Prin urmare, pentru a minimiza distorsiunea reprezentărilor clasei vechi, putem încerca să impunem $\mbox{Cov}(\Z_{j,old}) = \mbox{Cov}(\hat{\Z}_{j,old})$. Cu alte cuvinte, în timp ce învățăm clase noi, impunem ca memoria claselor vechi să rămână „auto-consistentă" prin bucla de transcriere:
+\begin{equation}
+\Z_{old} \xrightarrow{\hspace{2mm} g(\z,\bm \eta) \hspace{2mm}} \hat \X_{old} \xrightarrow{\hspace{2mm} f(\x, \bm \theta)\hspace{2mm}} \ \hat \Z_{old}.
+\end{equation}
+Matematic, aceasta este echivalentă cu setarea
+$$\Delta R_\epsilon(\Z_{old},\hat{\Z}_{old}) \doteq  \sum_{j=1}^t \Delta R_\epsilon(\Z_{j,old},\hat{\Z}_{j,old}) = 0.$$
+Prin urmare, programul minimax de mai sus \eqref{eqn:unconstrained-minimax} este revizuit ca un joc minimax {\em constrâns}, pe care îl numim {\em transcriere incrementală în buclă închisă} (i-CTRL).
+Obiectivul acestui joc este identic cu obiectivul CTRL multi-clasă standard \eqref{eq:MCR2-GAN-objective}, dar include doar o constrângere suplimentară:
+\begin{eqnarray}
+\min_{\bm \eta} \max_{\bm \theta}  &&\Delta{R_\epsilon(\Z)}+\Delta{R_\epsilon(\hat{\Z})}+\Delta{R_\epsilon(\Z_{new},\hat{\Z}_{new})} \nonumber\\
+&& \mbox{supus la} \quad  \Delta R(\Z_{old},\hat{\Z}_{old}) = 0.
+\label{eqn:constrained-minimax}
+\end{eqnarray}
+
+În practică, programul minimax constrâns poate fi rezolvat prin minimizare și maximizare {\em alternativă} între codificatorul $f(\cdot, \bm \theta)$ și decodificatorul $g(\cdot, \bm \eta)$ după cum urmează:
+\begin{eqnarray}
+&\max_{\bm \theta}  &\Delta{R_\epsilon(\Z)}\!+\!\Delta{R_\epsilon(\hat{\Z})}\!+\!\lambda\cdot  \Delta{R_\epsilon(\Z_{new},\hat{\Z}_{new})} - \gamma\cdot \Delta{R_\epsilon(\Z_{old},\hat{\Z}_{old})}, \label{eqn:relaxed-max}\\
+&\min_{\bm \eta} &\Delta{R_\epsilon(\Z)}\!+\!\Delta{R_\epsilon(\hat{\Z})}\!+\!\lambda\cdot \Delta{R_\epsilon(\Z_{new},\hat{\Z}_{new})} + \gamma\cdot \Delta{R_\epsilon(\Z_{old},\hat{\Z}_{old})}; \label{eqn:relaxed-min}
+\end{eqnarray}
+unde constrângerea $\Delta R_\epsilon(\Z_{old},\hat{\Z}_{old}) = 0$ din \eqref{eqn:constrained-minimax} a fost convertită (și relaxată) într-un termen Lagrangian cu un coeficient corespunzător $\gamma$ și semn. Introducem suplimentar un alt coeficient $\lambda$ pentru ponderarea termenului de reducere a ratei asociat cu datele noi.
+
+
+
+\paragraph{Memorie optimă comună prin revizuire incrementală.}
+După cum vom vedea, programul minimax constrâns de mai sus poate deja obține performanțe de ultimă generație pentru învățarea incrementală. Cu toate acestea, dezvoltarea unei memorii optime pentru {\em toate clasele} nu se poate baza doar pe uitarea grațioasă. Chiar și pentru oameni, dacă o clasă de obiecte este învățată o singură dată, ar trebui să ne așteptăm ca memoria învățată să se estompeze pe măsură ce continuăm să învățăm altele noi, cu excepția cazului în care memoria poate fi consolidată prin revizuirea claselor vechi de obiecte.
+
+Pentru a emula această fază de formare a memoriei, după învățarea incrementală a unui întreg set de date, putem reveni să revizuim din nou toate clasele, câte o clasă pe rând. Ne referim la parcurgerea tuturor claselor o dată ca un „ciclu" de revizuire.\footnote{pentru a distinge de termenul „epocă" folosit în cadrul convențional de învățare comună.} Dacă este necesar, pot fi efectuate mai multe cicluri de revizuire. Este destul de așteptat ca revizuirea să poată îmbunătăți memoria (LDR) învățată. Dar oarecum surprinzător, cadrul în buclă închisă ne permite să revizuim chiar și într-un mod „{nesupravegheat pe clase}": când revizuim datele unei clase vechi, să zicem $\X_j$, sistemul nu are nevoie de eticheta clasei și poate trata pur și simplu $\X_j$ ca o clasă nouă $\X_{new}$. Adică, sistemul optimizează același program mini-max constrâns \eqref{eqn:constrained-minimax} fără nicio modificare; după ce sistemul este optimizat, se poate identifica subspațiul nou învățat acoperit de $\Z_{new}$ și îl folosește pentru a înlocui sau fuziona cu vechiul subspațiu $\mathcal{S}_j$. După cum arată experimentele noastre, un astfel de proces de revizuire incrementală nesupravegheată pe clase poate îmbunătăți treptat atât performanța discriminativă cât și cea generativă a memoriei LDR, convergând în cele din urmă la cea a unei memorii învățate în comun.
+
+\paragraph{Verificare experimentală.}
+Arătăm câteva rezultate experimentale pe următoarele seturi de date: MNIST \cite{lecun1998gradient} și CIFAR-10 \cite{krizhevsky2014cifar}. Toate experimentele sunt efectuate pentru cadrul mai dificil de învățare pe clase. Pentru ambele MNIST și CIFAR-10, cele 10 clase sunt împărțite în 5 sarcini cu 2 clase fiecare sau 10 sarcini cu 1 clasă fiecare. Pentru codificatorul $f$ și decodificatorul $g$, adoptăm o arhitectură de rețea foarte simplă modificată din DCGAN \cite{radford2016unsupervised}, care este doar o rețea convoluțională cu {\em patru straturi}. Aici arătăm doar câteva rezultate vizuale calitative; mai multe experimente și analize analitice pot fi găsite în lucrarea \cite{tong2023incremental}.
+
+\paragraph{Vizualizarea proprietăților de auto-codare.}
+Începem prin vizualizarea calitativă a unor imagini reprezentative $\X$ și celor redate corespunzătoare $\hat{\X}$ pe MNIST și CIFAR-10. Modelul este învățat incremental cu seturile de date împărțite în 5 sarcini. Rezultatele sunt prezentate în \Cref{fig:justify_xhat_equals_x_incremental}, unde observăm că $\hat{\X}$ reconstruit păstrează principalele caracteristici vizuale ale $\X$ inclusiv forme și texturi. Pentru un set de date mai simplu precum MNIST, $\hat{\X}$ redat este aproape identic cu intrarea $\X$! Acest lucru este destul de remarcabil având în vedere: (1) metoda noastră nu impune explicit $\hat{\x} \approx \x$ pentru eșantioane individuale așa cum fac majoritatea metodelor de autocodare, și (2) după ce a învățat incremental toate clasele, generatorul nu a uitat cum să genereze cifre învățate mai devreme, cum ar fi 0, 1, 2. Pentru un set de date mai complex precum CIFAR-10, demonstrăm, de asemenea, o calitate vizuală bună, captând fidel esența fiecărei imagini.
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/mnist_x.png}
+        \caption{MNIST $\X$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/mnist_recon_x.png}
+        \caption{MNIST $\hat{\X}$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/cifar10_x.png}
+        \caption{CIFAR-10 $\X$}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/cifar10_x_recon.png}
+        \caption{CIFAR-10 $\hat{\X}$}
+    \end{subfigure}
+    \caption{\small Vizualizarea proprietății de auto-codare a celei învățate ($\hat{\X} = g\circ f(\X)$). }
+        \label{fig:justify_xhat_equals_x_incremental}
+\end{figure}
+
+
+\paragraph{Subspațiile principale ale caracteristicilor învățate.}
+Majoritatea metodelor generative bazate pe memorie utilizează autocodoare, VAE-uri sau GAN-uri în scopuri de redare. Structura sau distribuția caracteristicilor învățate $\Z_j$ pentru fiecare clasă este neclară în spațiul caracteristic. Caracteristicile $\Z_j$ ale memoriei LDR, pe de altă parte, au o structură liniară clară. \Cref{fig:cifar_10_pca_sampling_main} vizualizează corelațiile dintre toate caracteristicile învățate $|\Z^\top\Z|$, în care observăm modele bloc-diagonale clare pentru ambele seturi de date.\footnote{Observați că aceste modele seamănă foarte mult cu matricea de similaritate a profilurilor de răspuns ale categoriilor de obiecte din diferite zone ale cortexului inferotemporal, așa cum este arătat în Extended DataFig.3 din \cite{Bao2020AMO}.} Aceasta indică faptul că caracteristicile pentru diferite clase $\Z_j$ se află într-adevăr pe subspații care sunt incoerente unul de celălalt. Prin urmare, caracteristicile fiecărei clase pot fi bine modelate ca un subspațiu principal în spațiul caracteristic.
+
+\begin{figure}[tb]
+\centering
+\includegraphics[height=4.1cm]{\toplevelprefix/chapters/chapter5/figs/Heatmap_MNIST.jpg}
+\includegraphics[height=4cm]{\toplevelprefix/chapters/chapter5/figs/Heatmap_CIFAR10.png}
+\caption{\small Structura bloc diagonală a $|\Z^\top \Z|$ în spațiul caracteristic pentru MNIST (stânga) și CIFAR-10 (dreapta).}
+\label{fig:cifar_10_pca_sampling_main}
+\end{figure}
+
+
+
+\paragraph{Imaginile redate ale eșantioanelor din componentele principale.}
+Deoarece caracteristicile fiecărei clase pot fi modelate ca un subspațiu principal, vizualizăm în continuare componentele principale individuale din cadrul fiecăruia dintre aceste subspații. \Cref{fig:pca_sampling_main} arată imaginile redate din caracteristicile eșantionate de-a lungul primelor 4 componente principale pentru diferite clase, pe MNIST și CIFAR-10, respectiv. Fiecare rând reprezintă eșantioane de-a lungul unei componente principale și arată clar caracteristici vizuale similare, dar sunt distinct diferite de cele din alte rânduri. Vedem că modelul își amintește diferite poziții ale lui „4" după ce a învățat toate clasele rămase. Pentru CIFAR-10, memoria învățată incremental își amintește poziții și forme reprezentative ale cailor și navelor.
+
+\begin{figure}[t]
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/mnist_4.png}
+        \caption{$\hat{\x}_{old}$ eșantionat pentru „4"}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/mnist_7.png}
+        \caption{$\hat{\x}_{old}$ eșantionat pentru „7"}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/horse_z.jpg}
+        \caption{$\hat{\x}_{old}$ eșantionat pentru „cal"}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.20\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/ship_z.jpg}
+        \caption{$\hat{\x}_{old}$ eșantionat pentru „navă"}
+    \end{subfigure}
+    \caption{\small Vizualizarea a 5 $\hat \x=g(\z)$ reconstruite din $\z$-uri cu cea mai mică distanță față de componentele principale (primele 4) ale caracteristicilor învățate pentru {MNIST} (clasa „4" și clasa „7") și {CIFAR-10} (clasa „cal" și clasa „navă").}
+    \label{fig:pca_sampling_main}
+\end{figure}
+
+
+
+\paragraph{Eficacitatea revizuirii incrementale.}
+Verificăm cum memoria LDR învățată incremental poate fi consolidată în continuare cu o fază de revizuire incrementală nesupravegheată descrisă anterior. Experimentele sunt efectuate pe CIFAR-10, cu 10 pași. \Cref{fig:memory_review} stânga arată imagini redate ale primei clase „avion" la sfârșitul învățării incrementale a tuturor celor zece clase, eșantionate de-a lungul primelor 3 componente principale -- fiecare două rânduri (16 imagini) sunt de-a lungul unei direcții principale. Calitatea lor vizuală rămâne foarte decentă—observăm aproape nicio uitare. Figura din dreapta arată imagini redate după revizuirea primei clase o dată. Observăm o îmbunătățire semnificativă a calității vizuale după revizuire, iar componentele principale ale caracteristicilor din subspațiu încep să corespundă atributelor vizuale distinct diferite din aceeași clasă.
+
+\begin{figure}
+\centering
+\includegraphics[width=0.41\textwidth]{\toplevelprefix/chapters/chapter5/figs/memory_before_review_clip.png}
+\includegraphics[width=0.4\textwidth]{\toplevelprefix/chapters/chapter5/figs/memory_after_review_clip.png}
+ \caption{\small Vizualizarea imaginilor redate $\hat{\x}_{old}$ ale clasei 1-„avion" în CIFAR-10, înainte (stânga) și după (dreapta) un ciclu de revizuire.}
+\label{fig:memory_review}
+\end{figure}
+
+
+\subsection{Învățare Nesupravegheată Continuă pe Eșantioane}
+\label{sec:sample-wise-incremental}
+
+După cum știm, formularea CTRL în buclă închisă poate învăța deja o autocodare decentă, chiar și fără informații despre clase, cu programul CTRL-Binary:
+\begin{align}
+      \max_{\bm \theta} \min_{\bm \eta} \quad \Delta R_\epsilon(\Z, \hat{\Z})
+ \label{eqn:CTRL-Binary}
+\end{align}
+Cu toate acestea, observați că \eqref{eqn:CTRL-Binary} este practic limitată deoarece aliniază doar setul de date $\X$ și $\hat \X$ regenerat la nivel de distribuție.
+Nu există nicio garanție că fiecare eșantion $\x$ ar fi aproape de $\hat \x = g(f(\x))$ decodat.
+
+\paragraph{Constrângeri pe eșantioane pentru transcrierea nesupravegheată.}
+\label{sec:constraints}
+Pentru a îmbunătăți proprietățile discriminative și generative ale reprezentărilor învățate în cadrul nesupravegheat, propunem două mecanisme suplimentare pentru jocul maximin CTRL-Binary de mai sus \eqref{eqn:CTRL-Binary}. Pentru simplitate și uniformitate, aici acestea vor fi formulate ca constrângeri de egalitate asupra măsurilor de reducere a ratei, dar în practică ele pot fi impuse ușor în timpul optimizării.
+
+\paragraph{Auto-consistență pe eșantioane prin transcriere în buclă închisă.}
+În primul rând, pentru a aborda problema că CTRL-Binary nu învață o autocodare consistentă pe eșantioane, trebuie să promovăm ca $\hat \x$ să fie aproape de $\x$ pentru fiecare eșantion. În cadrul CTRL, acest lucru poate fi realizat prin impunerea ca caracteristicile lor corespunzătoare $\z=f(\x)$ și $\hat \z = f(\hat \x)$ să fie apropiate.
+Pentru a promova auto-consistența pe eșantioane, unde $\hat{\x} = g(f(\x))$ este aproape de $\x$, vrem ca distanța dintre $\z$ și $\hat{\z}$ să fie zero sau mică, pentru toate cele $N$ eșantioane.
+Această distanță poate fi măsurată prin reducerea ratei:
+\begin{align}
+\sum_{i\in N} \Delta R_\epsilon(\z^i,\hat{\z}^i) = 0.
+\label{eqn:sample-self-consistency}\vspace{-2mm}
+\end{align}
+Observați că aceasta evită din nou măsurarea diferențelor în spațiul imaginii.
+
+\paragraph{Auto-supervizare prin comprimarea eșantioanelor augmentate.}
+Deoarece nu cunoaștem nicio informație despre eticheta clasei între eșantioane în cadrul nesupravegheat, cel mai bun lucru pe care îl putem face este să vedem fiecare eșantion și augmentările sale (să zicem prin translație, rotație, ocluzie etc.) ca o „clasă"—o idee de bază din spatele aproape tuturor metodelor de învățare auto-supervizată. În cadrul reducerii ratei, este natural să comprimăm caracteristicile fiecărui eșantion și augmentările sale. În această lucrare, adoptăm transformările standard din SimCLR \cite{chen2020simple} și denotăm o astfel de transformare ca $\tau$. Denotăm fiecare eșantion augmentat $\x_a = \tau(\x)$ și caracteristica sa corespunzătoare ca $\z_a = f(\x_a, \bm \theta) $. În scopuri discriminative, sperăm că clasificatorul este {\em invariant} la astfel de transformări. Prin urmare, este natural să impunem ca caracteristicile $\z_a$ ale tuturor augmentărilor să fie aceleași cu cele $\z$ ale eșantionului original $\x$. Aceasta este echivalentă cu a cere ca distanța dintre $\z$ și $\z_a$, măsurată din nou în termenii reducerii ratei, să fie zero (sau mică) pentru toate cele $N$ eșantioane:
+\begin{align}
+\sum_{i\in N} \Delta R_\epsilon(\z^i,\z_{a}^i) = 0.
+\label{eqn:sample-compression}\vspace{-3mm}
+\end{align}
+
+
+\paragraph{Învățarea reprezentărilor nesupravegheate prin transcriere în buclă închisă.}
+Până acum, știm că obiectivul CTRL-Binary $\Delta R_\epsilon(\Z, \hat{\Z})$ din \eqref{eqn:CTRL-Binary} ajută la alinierea distribuțiilor în timp ce auto-consistența pe eșantioane \eqref{eqn:sample-self-consistency} și augmentarea pe eșantioane \eqref{eqn:sample-compression} ajută la alinierea și comprimarea caracteristicilor asociate cu fiecare eșantion. Pe lângă consistență, vrem, de asemenea, ca reprezentările învățate să fie maxim discriminative pentru diferite eșantioane (aici văzute ca diferite „clase"). Observați că termenul de distorsiune a ratei $R_\epsilon(\Z)$ măsoară rata de codare (deci volumul) tuturor caracteristicilor.
+
+\paragraph{CTRL nesupravegheat.} Punând aceste elemente împreună, propunem să învățăm o reprezentare prin următorul program maximin constrâns, pe care îl numim {\em CTRL nesupravegheat} (u-CTRL):
+\begin{align}
+      \max_\theta \min_\eta  \quad & R_\epsilon(\Z) + \Delta R_\epsilon(\Z, \hat{\Z}) \label{eqn:constrained_maxmin}\\
+ \mbox{supus la} \quad & \sum_{i\in N} \Delta R_\epsilon(\z^i, \hat{\z}^i) = 0, \;\; \mbox{și} \;\; \sum_{i\in N} \Delta R_\epsilon(\z^i, \z_{a}^i) = 0. \nonumber
+\end{align}
+\Cref{fig:framework-uCTRL} ilustrează arhitectura generală a sistemului în buclă închisă asociat cu acest program.
+\begin{figure}[t]
+\centering
+\includegraphics[width=0.98\textwidth]{\toplevelprefix/chapters/chapter5/figs/uCTRLv3.png}
+\caption{\textbf{Cadrul general} al transcrierii în buclă închisă pentru învățarea nesupravegheată. Două constrângeri suplimentare sunt impuse asupra metodei Binary-CTRL: 1) auto-consistență pentru caracteristicile pe eșantioane $\z^i$ și $\hat{\z}^i$, să zicem $\z^i \approx \hat{\z}^i$; și 2) invarianță/similaritate între caracteristicile eșantioanelor augmentate $\z^i$ și $\z_{a}^i$, să zicem $\z^i \approx \z_{a}^i=f(\tau(\x^i), \bm \theta)$, unde $\x^i_a=\tau(\x^i)$ este o augmentare a eșantionului $\x^i$ prin o anumită transformare $\tau(\cdot)$.}
+\label{fig:framework-uCTRL}
+\end{figure}
+
+În practică, programul de mai sus poate fi optimizat prin maximizare și minimizare alternativă între codificatorul $f(\cdot,\bm \theta)$ și decodificatorul $g(\cdot,\bm \eta)$. Adoptăm următoarea strategie de optimizare care funcționează bine în practică, care este folosită pentru toate experimentele ulterioare pe seturi de date de imagini reale:
+\vspace{-1mm}
+\begin{align}
+  &  \max_{\theta}\; R_\epsilon(\Z) + \Delta{R_\epsilon(\Z, \hat{\Z})-\lambda_{1}\sum_{i\in N} \Delta R_\epsilon(\z^i, \z_{a}^i)} -\lambda_{2}\sum_{i\in N} \Delta R_\epsilon(\z^i, \hat{\z}^i) \label{eqn:constrained_max}; \\
+   & \min_{\eta}\; R_\epsilon(\Z) + \Delta{R_\epsilon(\Z, \hat{\Z})+\lambda_{1}\sum_{i\in N} \Delta R_\epsilon(\z^i, \z_{a}^i)+ \lambda_{2}\sum_{i\in N} \Delta R_\epsilon(\z^i, \hat{\z}^i)} \label{eqn:constrained_min},
+\end{align}
+unde constrângerile $\sum_{i\in N} \Delta R_\epsilon(\z^i, \hat{\z}^i) = 0$ și $\sum_{i\in N} \Delta R_\epsilon(\z^i, \z_{a}^i) = 0$ din \eqref{eqn:constrained_maxmin} au fost convertite (și relaxate) în termeni Lagrangieni cu coeficienții corespunzători $\lambda_{1}$ și $\lambda_{2}$.\footnote{Observați că calcularea termenilor de reducere a ratei $\Delta R$ pentru toate eșantioanele sau un lot de eșantioane necesită calcularea costisitoare a $\log\det$ a matricelor mari. În practică, din semnificația geometrică a $\Delta R$ pentru doi vectori, $\Delta R$ poate fi aproximat cu o normă $\ell^2$ sau distanța cosinus între doi vectori.}
+
+Reprezentarea de mai sus este învățată fără informații despre clase. Pentru a facilita sarcinile discriminative sau generative, aceasta trebuie să fie foarte structurată. S-a verificat experimental că acesta este într-adevăr cazul și u-CTRL demonstrează avantaje semnificative față de alte metode de învățare incrementală sau nesupravegheată \cite{pmlr-v234-tong24a}. Aici ilustrăm doar câteva rezultate calitative cu experimentul pe setul de date CIFAR-10 \cite{krizhevsky2014cifar}, cu augmentări standard pentru învățarea auto-supervizată \cite{chen2020simple}. Se poate consulta \cite{pmlr-v234-tong24a} pentru experimente pe seturi de date mai multe și mai mari și evaluările lor cantitative.
+
+După cum se poate vedea din experimente, o structură specifică și unică apare într-adevăr în mod natural în reprezentările învățate folosind u-CTRL: global, caracteristicile imaginilor din aceeași clasă tind să fie grupate bine împreună și separate de alte clase, așa cum este arătat în \Cref{fig:heatmap_z}; local, caracteristicile din jurul eșantioanelor individuale prezintă structuri aproximativ liniare pe bucăți de dimensiune redusă, așa cum este arătat în \Cref{fig:tsne}.
+
+\begin{figure}[t]
+     \footnotesize
+     \centering
+    \includegraphics[width=0.5\textwidth]{\toplevelprefix/chapters/chapter5/figs/CIFAR10_cifar10_heatmap_zz.png}
+    \caption{\small Apariția structurilor bloc-diagonale ale $|\Z^\top \Z|$ în spațiul caracteristic pentru CIFAR-10.}
+    \label{fig:heatmap_z}
+\end{figure}
+
+\begin{figure}[ht!]
+    \begin{subfigure}[t]{0.46\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/uCTRL-tsne2.png}
+        \caption{u-CTRL}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}[t]{0.46\textwidth}
+        \centering
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter5/figs/MoCoV2-tsne3.png}
+        \caption{MoCoV2}
+    \end{subfigure}
+    \caption{\small Vizualizări t-SNE ale caracteristicilor învățate ale CIFAR-10 cu diferite modele.}
+    \label{fig:tsne}
+\end{figure}
+
+\paragraph{Generarea nesupravegheată condiționată de imagini prin reducerea ratei.}
+Distribuția de caracteristici foarte structurată sugerează, de asemenea, că reprezentarea învățată poate fi foarte utilă în scopuri generative. De exemplu, putem organiza caracteristicile eșantioanelor în clustere semnificative și le putem modela cu distribuții (gaussiene) sau subspații de dimensiune redusă. Prin eșantionarea din aceste modele compacte, putem regenera condiționat eșantioane semnificative din clusterele calculate. Aceasta este cunoscută ca {\em generare nesupravegheată condiționată de imagini} \cite{hwang2021stein}.
+
+Pentru a grupa caracteristicile, exploatăm faptul că cadrul de reducere a ratei \eqref{eqn:maximal-rate-reduction} este inspirat de gruparea nesupravegheată prin compresie \cite{ma2007segmentation}, care oferă o modalitate principială de a găsi apartenența $\bm \Pi$.
+Concret, maximizăm același obiectiv de reducere a ratei \eqref{eqn:maximal-rate-reduction} peste $\bm \Pi$, dar fixăm reprezentarea învățată $\Z$ în schimb. Vedem pur și simplu apartenența $\bm \Pi$ ca o funcție neliniară a caracteristicilor $\Z$, să zicem $h_{\bm \pi}(\cdot,\xi):\Z \mapsto \bm \Pi$ cu parametrii $\xi$. În practică, modelăm această funcție cu o rețea neuronală simplă, cum ar fi un cap MLP imediat după caracteristica de ieșire $\z$.
+Pentru a estima o apartenență „pseudo" $\hat{\bm \Pi}$ a eșantioanelor, rezolvăm următoarea problemă de optimizare peste $\bm \Pi$:
+\begin{align}
+    \hat{\bm \Pi} = \arg\max_{\xi} \Delta R_\epsilon(\Z| \bm \Pi(\xi)).
+\label{eqn:cluster_mcr}
+\end{align}
+În \Cref{fig:vis_clustering}, vizualizăm imagini generate din cele zece clustere nesupravegheate din \eqref{eqn:cluster_mcr}. Fiecare bloc reprezintă un cluster și fiecare rând reprezintă o componentă principală pentru fiecare cluster. În ciuda învățării și antrenării fără etichete, modelul nu numai că organizează eșantioanele în clustere corecte, dar este, de asemenea, capabil să păstreze diversitățile statistice din cadrul fiecărui cluster/clasă. Putem recupera cu ușurință diversitatea din cadrul fiecărui cluster calculând diferite componente principale și apoi eșantionând și generând în consecință. Deși experimentele prezentate aici sunt oarecum limitate în scară, vom explora metode mai directe și mai puternice care utilizează distribuțiile de date și reprezentările învățate pentru generarea și estimarea condiționată în capitolul următor.
+\begin{figure}[t]
+    \footnotesize
+    \centering
+    \includegraphics[width=0.95\textwidth]{\toplevelprefix/chapters/chapter5/figs/CIFAR10_generatedfromcluster.png}
+    \caption{\small Generarea nesupravegheată condiționată de imagini din fiecare cluster al CIFAR-10, folosind u-CTRL. Imaginile din rânduri diferite înseamnă generare din componente principale diferite ale fiecărui cluster.}
+    \label{fig:vis_clustering}
+\end{figure}
+
+
+
+
+
+\section{Rezumat și Note}
+Istoric, autocodarea a fost unul dintre factorii importanți de inovare în cercetarea
+rețelelor neuronale pentru învățare, deși cele mai impresionante demonstrații practice
+ale învățării profunde au fost probabil în alte domenii
+(cum ar fi clasificarea discriminativă, cu AlexNet
+\cite{krizhevsky2012imagenet}, sau modelarea generativă cu arhitecturi GPT
+\cite{brown2020language}).
+Lucrările pe care le-am prezentat pe parcursul capitolului, în special lucrarea lui
+\cite{Hinton504}, au servit drept catalizatori ai interesului de cercetare în rețelele neuronale
+în perioadele în care nu erau altfel proeminente în peisajul cercetării în învățarea automată.
+În practica modernă, autocodoarele rămân componente de bază ale multor sisteme la scară largă
+pentru generarea de date foarte structurate, cum ar fi date vizuale, date de vorbire
+și date moleculare, în special abordarea VQ-VAE
+\cite{van-den-Oord2017-jr}, care se bazează pe metodologia autocodorului variațional
+pe care am discutat-o în \Cref{sec:vae}.
+Problema de bază a autocodării rămâne de o importanță intelectuală primordială
+datorită conexiunii sale strânse cu învățarea reprezentărilor și anticipăm că
+va reapărea pe radarul cercetătorilor practici în viitor pe măsură ce
+eficiența în antrenarea și implementarea modelelor mari continuă să devină mai
+importantă.
+
+Materialele prezentate în a doua jumătate a acestui capitol se bazează pe o serie de
+lucrări recente pe tema transcrierii în buclă închisă: \cite{Dai-entropy-2022},
+\cite{pai2022pursuit}, \cite{tong2023incremental} și \cite{pmlr-v234-tong24a}. În special, \Cref{sec:closed-loop-transcription} se bazează pe lucrarea pionieră a \cite{Dai-entropy-2022}. După aceea, lucrarea \cite{pai2022pursuit} a oferit justificări teoretice puternice pentru cadrul în buclă închisă, cel puțin pentru un caz ideal. \Cref{sec:class-wise-incremental} și \Cref{sec:sample-wise-incremental} se bazează pe lucrările \cite{tong2023incremental} și, respectiv, \cite{pmlr-v234-tong24a}. Ele demonstrează că cadrul în buclă închisă sprijină în mod natural învățarea incrementală și continuă, fie într-un cadru pe clase sau pe eșantioane. Cititorul poate consulta aceste lucrări pentru mai multe detalii tehnice și experimentale.
+
+
+\paragraph{Rețele neuronale puțin adânci vs.\ profunde, pentru autocodare și mai mult.}
+În \Cref{sub:nonlinear-pca}, am discutat teorema de aproximare universală a lui Cybenko
+și cum aceasta afirmă că, în principiu, o rețea neuronală cu un singur
+strat ascuns (și neliniarități elementare adecvate) este suficientă pentru
+a aproxima orice funcție țintă regulară adecvat. Desigur, în practică,
+motivul arhitectural major pentru dominația rețelelor neuronale în practică a fost
+rafinarea tehnicilor pentru antrenarea rețelelor neuronale \textit{mai profunde}.
+De ce este necesară profunzimea?
+Din punct de vedere fundamental, problema separărilor de profunzime, care
+construiește setări în care o rețea neuronală mai profundă poate aproxima o clasă dată
+de funcții țintă cu eficiență exponențial superioară față de o rețea
+puțin adâncă,
+a fost studiată pe larg în literatura teoretică:
+exemplele includ \cite{Telgarsky2016-sn,Bresler2020-xy,Venturi2021-qc}.
+Ușurința antrenării rețelelor mai profunde
+în practică nu a primit un răspuns la fel de satisfăcător din
+perspectiva teoriei.
+ResNet-urile \cite{he2016deep} reprezintă lucrarea empirică pionieră de
+a face rețelele mai profunde mai ușor de antrenat, folosite în aproape toate arhitecturile
+moderne într-o anumită formă. Studiile teoretice s-au concentrat foarte mult pe
+antrenabilitatea rețelelor foarte profunde, cuantificată prin nucleul tangent neuronal
+inițial \cite{Buchanan2021-sj,Martens2021-cx}, dar aceste studii nu au oferit
+perspective semnificative asupra beneficiilor de antrenabilitate ale rețelelor mai profunde în etapele
+medii și târzii ale antrenării (dar vezi \cite{Yang2021-gw} pentru rădăcina unei linii
+de cercetare care încearcă să abordeze acest lucru).
+
+\section{Exerciții și Extensii}
+
+\begin{exercise}[Înțelegerea Conceptuală a Aplatizării Varietății]
+  Considerați date care se află pe o varietate curbată $\cM$ încorporată în $\R^D$ (precum
+  o suprafață curbată în spațiul tridimensional), așa cum este discutat în subsecțiunea
+  aplatizării varietății din \Cref{sub:nonlinear-pca}.
+  În acest exercițiu, vom descrie ingredientele de bază ale algoritmului de
+  aplatizare a varietății din \cite{Psenka-JMLR24}.
+  O varietate este numită plată dacă este un set deschis în spațiul euclidian (sau
+  mai general, un set deschis într-un subspațiu).
+
+  \begin{enumerate}
+    \item Să presupunem că varietatea $\cM$ este un \textit{graf}: aceasta înseamnă că $\cM
+      \subset \R^{D_1} \times \R^{D_2}$ (să zicem), și că există o funcție $F
+      : \R^{D_1} \to \R^{D_2}$ astfel încât
+      \begin{equation}
+        \cM = \set{(\x, F(\x) \mid \x \in \R^{D_1})}.
+      \end{equation}
+      Dați un întreg $D_3$ și o hartă $f : \R^{D_1} \times \R^{D_2} \to \R^{D_3}$
+      care aplatizează $\cM$ și descrieți procedura de reconstrucție corespunzătoare
+      (fără pierderi) din reprezentarea aplatizată.
+    \item Acum să presupunem că $\cM$ este o varietate netedă generală. Varietățile netede
+      au proprietatea că sunt bine aproximate local de subspații
+      în apropierea fiecărui punct. Descrieți în termeni intuitivi cum să aplatizați varietatea
+      $\cM$ local la fiecare punct, prin raportarea la un graf. (Algoritmul din
+      \cite{Psenka-JMLR24} efectuează o versiune rafinată a acestui proces de aplatizare
+      locală într-un mod care le permite să fie lipite împreună pentru a forma o aplatizare
+      globală.)
+  \end{enumerate}
+\end{exercise}
+
+
+\begin{exercise}[Reproduceți Transcrierea în Buclă Închisă]
+
+  Implementați o conductă de transcriere în buclă închisă pentru învățarea reprezentărilor pe
+  setul de date CIFAR-10 urmând
+  metodologia din \Cref{sec:closed-loop-transcription}.
+  Consultați \cite{Dai-entropy-2022} pentru hiperparametri utili și setări de
+  arhitectură. Reproduceți rezultatul din \Cref{fig:justifyz=z}.
+
+
+\end{exercise}
+
+\end{document}

--- a/chapters/chapter6/conditional_ro.tex
+++ b/chapters/chapter6/conditional_ro.tex
@@ -1,0 +1,2300 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Inferență cu Distribuții de Dimensiune Redusă}
+\label{ch:conditional-inference}
+
+\begin{quote}
+
+\hfill    ``{\em Matematica este arta de a da același nume la lucruri diferite}.''
+
+$~$ \hfill --- Henri Poincar\'e 
+\end{quote}
+\vspace{5mm}
+
+
+În capitolele anterioare ale acestei cărți, am studiat cum să învățăm eficace și eficient o reprezentare pentru o variabilă $\x$ din lume cu o distribuție $p(\x)$ care are un suport de dimensiune redusă într-un spațiu de dimensiune înaltă. Până acum, am dezvoltat în principal metodologia pentru învățarea reprezentării și autocodarea într-un mod general, agnostic față de distribuție sau sarcină. Cu o astfel de reprezentare învățată, se pot deja utiliza pentru a efectua unele sarcini generice și de bază, cum ar fi clasificarea (dacă codarea este supravegheată cu clasa) și generarea de eșantioane aleatorii care au aceeași distribuție ca datele date (să zicem imagini naturale sau limbaje naturale).
+
+În general, totuși, universalitatea și scalabilitatea cadrului teoretic și computațional prezentat în această carte ne-a permis să învățăm distribuția unei varietăți de date importante de dimensiune înaltă din lumea reală, cum ar fi limbajele naturale, pozele umane, imaginile naturale, videoclipurile și chiar scenele 3D. Odată ce structurile intrinseci bogate și de dimensiune redusă ale acestor date reale pot fi învățate și reprezentate corect, ele încep să permită o familie largă de sarcini puternice, adesea aparent miraculoase. Prin urmare, de aici înainte, vom începe să arătăm cum să conectăm și să adaptăm metodele generale prezentate în capitolele anterioare pentru a învăța reprezentări utile pentru distribuții specifice de date structurate și pentru multe sarcini populare în practica modernă a inteligenței mașinilor.
+
+\section{Inferență Bayesiană și Optimizare Constrânsă}
+\paragraph{Valorificarea Dimensionalității Reduse pentru Inferență Stabilă și Robustă.}
+În general, o reprezentare sau autocodare bună ar trebui să ne permită să utilizăm distribuția de dimensiune redusă învățată a datelor $\x$ și reprezentarea sa $\z$ pentru diverse sarcini ulterioare de clasificare, estimare și generare în condiții diferite. După cum am menționat mai devreme în Capitolul \ref{ch:intro} Secțiunea \ref{sec:intro-low-dimensionality}, importanța {\em dimensionalității reduse} a distribuției este cheia pentru a efectua inferențe stabile și robuste legate de datele $\x$, așa cum este ilustrat de cele câteva exemple simple din Figura \ref{fig:low-dim-properties}, din observații incomplete, zgomotoase și chiar corupte. După cum se dovedește, exact același concept se aplică datelor de dimensiune înaltă din lumea reală ale căror distribuții au un suport de dimensiune redusă, cum ar fi imaginile și limbajele naturale.
+
+În ciuda unei varietăți amețitoare de aplicații în practica învățării automate cu date precum limbajele, imaginile, videoclipurile și multe alte modalități, aproape toate aplicațiile practice pot fi văzute ca un caz special al următoarei probleme de inferență: dată o observație $\y$ care depinde de $\x$, să zicem
+\begin{equation}
+    \y = h(\x) + \boldsymbol{w},
+\end{equation}
+unde $h(\cdot)$ reprezintă măsurători ale unei părți din $\x$ sau anumite atribute observate și $\vw$ reprezintă un anumit zgomot de măsurare și chiar corupții (rare), rezolvăm „problema inversă" de a obține o estimare cea mai probabilă $\hat \x(\y)$ a lui $\x$ sau generarea unui eșantion $\hat{\x}$ care este cel puțin consistent cu observația $\y \approx h(\hat{\x})$. Figura \ref{fig:inference_roadmap} ilustrează relația generală dintre $\x$ și $\y$.
+
+\begin{figure}
+  \centering 
+  \includegraphics[width=0.9\textwidth]{\toplevelprefix/chapters/chapter6/figs/inference_roadmap.pdf}
+  \caption{\small \textbf{Inferență cu distribuții de dimensiune redusă.} Aceasta este imaginea generică pentru acest capitol: avem o distribuție de dimensiune redusă pentru \(\vx \in \R^{D}\) (aici descrisă ca o uniune de două varietăți \(2\)-dimensionale în \(\R^{3}\)) și un model de măsurare \(\y = h(\vx) + \vw \in \R^{d}\). Vrem să inferăm diverse lucruri despre acest model, inclusiv distribuția condiționată a \(\vx\) dată \(\vy\), sau așteptarea condiționată \(\mathbb{E}[\vx \mid \y]\), date fiind diverse informații despre model și (potențial finite) eșantioane fie ale \(\vx\) fie ale \(\vy\).}
+  \label{fig:inference_roadmap}
+\end{figure}
+
+\begin{example}[Completarea Imaginilor și Predicția Textului]
+Completarea populară a imaginilor naturale și predicția limbajului natural sunt două sarcini tipice care ne cer să recuperăm date complete $\x$ din observațiile sale parțiale $\y$, cu părți din $\x$ mascate și de completat pe baza restului. Figura \ref{fig:image-text-completion} arată câteva exemple de astfel de sarcini. De fapt, sunt exact aceste sarcini care au inspirat cum să antrenăm modele mari moderne pentru generarea de text (cum ar fi GPT) și completarea imaginilor (cum ar fi autocodorul mascat) pe care le vom studia mai detaliat mai târziu.
+    \begin{figure}
+        \centering
+        \includegraphics[height=0.4\linewidth]{\toplevelprefix/chapters/chapter6/figs/image-completion.jpg} \hspace{10mm} \includegraphics[height=0.45\linewidth]{\toplevelprefix/chapters/chapter6/figs/text-prediction.jpg}
+        \caption{Stânga: completarea imaginii. Dreapta: predicția textului. În special, predicția textului este inspirația pentru popularul Transformer Generativ Pre-antrenat (GPT).}
+        \label{fig:image-text-completion}
+    \end{figure}
+\end{example}
+
+
+\paragraph{Interpretare statistică prin regula lui Bayes.} În general, pentru a îndeplini astfel de sarcini bine, trebuie să obținem distribuția condiționată $p(\x\mid \y)$. Dacă am avea aceasta, atunci am putea găsi estimarea de verosimilitate maximă (predicția): 
+\begin{equation}
+  \hat{\x} = \argmax_{\x} p(\x\mid \y);
+\end{equation}
+calcula estimarea așteptării condiționate: 
+\begin{equation}
+  \hat{\x} = \mathbb{E}[\x \mid \y] = \int \x p(\x\mid \y)\odif{\vx};
+\end{equation}
+și eșantiona din distribuția condiționată:  
+\begin{equation}
+  \hat{\x} \sim p(\x \mid \y).
+\end{equation}
+
+Observați că din regula lui Bayes, avem
+\begin{equation}
+  p(\x\mid \y) = \frac{p(\y\mid \x) p(\x) }{p(\y)}.
+\end{equation} 
+De exemplu, estimarea de verosimilitate maximă poate fi calculată rezolvând următorul program (log verosimilitate maximă):
+\begin{equation}
+    \hat{\x} = \argmax_{\x} [\log p(\y\mid \x) + \log p(\x)], 
+\end{equation}
+să zicem prin ascensiune gradient:
+\begin{equation}
+    \x_{k+1} = \x_k + \alpha \cdot \big(\nabla_{\x} \log p(\y \mid \x) + \nabla_{\x} \log p(\x)\big).
+    \label{eqn:loglikelihoo-gradient-ascent}
+\end{equation}
+Calcularea eficientă a distribuției condiționate $p(\x \mid \y)$ depinde în mod natural de modul în care învățăm și exploatăm distribuția de dimensiune redusă $p(\x)$ a datelor $\x$ și modelul de observație $\y = h(\x) + \vw$ care determină distribuția condiționată $p(\y \mid \x)$.
+
+\begin{remark}[Abordare End-to-End versus Bayesiană]
+În practica modernă a învățării automate bazate pe date, pentru anumite sarcini populare oamenii adesea învață direct distribuția condiționată $p(\x\mid \y)$ sau o mapare (probabilistică) sau un regresor. O astfel de mapare este adesea modelată de unele rețele profunde și antrenată end-to-end cu suficiente eșantioane pereche $(\x, \y)$. O astfel de abordare este foarte diferită de abordarea bayesiană de mai sus în care sunt necesare atât distribuția lui $\x \sim p(\x)$, cât și maparea (de observație). Beneficiul abordării bayesiene este că distribuția învățată $p(\x)$ poate facilita multe sarcini diferite cu modele și condiții de observație variate.
+\end{remark}
+
+\paragraph{Interpretare geometrică ca optimizare constrânsă.}
+
+Deoarece suportul \(\cS_{\vx}\) al distribuției lui \(\vx\) este de dimensiune redusă, putem presupune că există o funcție \(F\) astfel încât
+\begin{equation}
+  F(\vx) = \boldsymbol{0} \qquad \iff \qquad \vx \in \cS_{\vx}
+\end{equation}
+astfel încât \(\cS_{\vx} = F^{-1}(\{\vzero\})\) este suportul de dimensiune redusă al distribuției $p(\x)$. Geometric, o alegere naturală a lui $F(\x)$ este „funcția distanță" până la suportul $\mathcal{S}_{\x}$:\footnote{Observați că, în realitate, avem doar eșantioane discrete pe suportul distribuției. În același spirit de continuare, prin difuzie sau codare cu pierderi studiată în Capitolul \ref{ch:compression}, putem aproxima funcția distanță ca $F(\x) \approx \min_{\x_p \in \cC_{\vx}^{\epsilon}} \|\x - \x_p\|_2$ unde $\mathcal{S}_{\x}$ este înlocuit de o acoperire \(\cC_{\vx}^{\epsilon}\) a eșantioanelor cu bile de rază $\epsilon$.}
+\begin{equation}
+    F(\x) = \min_{\x_p \in \mathcal{S}_{\x}} \|\x - \x_p\|_2. 
+\end{equation}
+Acum, dat $\y = h(\x) +\vw$, pentru a rezolva pentru $\x$, putem rezolva următoarea problemă de optimizare constrânsă:
+\begin{equation}
+    \max_{\x} - \frac{1}{2}\|h(\x) - \y\|_2^2 \quad \mbox{s.t.} \quad F(\x) = \boldsymbol{0}. 
+\end{equation}
+Folosind metoda multiplicatorilor Lagrange augmentați, putem rezolva următorul program neconstrâns:
+\begin{equation}
+   \max_{\x} \left[-\frac{1}{2}\|h(\x) - \y\|_2^2  + \vlambda^{\top} F(\x) - \frac{\mu}{2} \|F(\x)\|_2^2\right]
+\end{equation}
+pentru anumiți multiplicatori Lagrange constanți $\vlambda$.
+Aceasta este echivalentă cu următorul program:
+\begin{equation}\label{eq:lagrange_multiplier_continuation}
+\max_{\x} \left[\log \exp\Big(- \frac{1}{2}\|h(\x) - \y\|_2^2\Big) + \log \exp\Big( - \frac{\mu}{2} \big\|F(\x) - \vlambda/\mu\big\|_2^2\Big)\right],
+\end{equation} 
+unde $\vc \doteq {\vlambda}/{\mu}$ poate fi văzut ca o „medie" pentru funcția de constrângere. Pe măsură ce $\mu$ devine mare când se impune constrângerea prin continuare\footnote{În același spirit de continuare din \Cref{ch:compression} unde am obținut aproximări mai bune ale distribuției noastre trimițând \(\eps \to 0\), aici trimitem \(\mu \to \infty\). Valori mai mari ale lui \(\mu\) vor constrânge \(F\) să ia valori din ce în ce mai mici la optim, ceea ce înseamnă că optimul se află într-o vecinătate din ce în ce mai mică a suportului \(\cS_{\vx}\). Interesant, teoria multiplicatorilor Lagrange sugerează că, în anumite condiții benigne asupra \(F\) și altor termeni din obiectiv, trebuie doar să facem \(\mu\) suficient de mare pentru a asigura \(F(\vx) = \vzero\) la optim, ceea ce înseamnă că la o penalitate \textit{finită} obținem o aproximare \textit{perfectă} a suportului. În general, ar trebui să avem intuiția că \(\mu\) joacă același rol ca \(\epsilon^{-1}\).}, $\|\vc\|_2$ devine din ce în ce mai mic.
+
+Programul de mai sus poate fi interpretat în două moduri diferite. În primul rând, se poate vedea primul termen ca probabilitatea condiționată a lui $\y$ dat $\x$, iar al doilea termen ca o densitate de probabilitate pentru $\x$:
+\begin{equation}
+  p(\y\mid \x) \propto \exp\Big(- \frac{1}{2}\|h(\x) - \y\|_2^2\Big), \quad 
+    p(\x) \propto \exp\Big( - \frac{\mu}{2}\|F(\x) - \vc\|_2^2\Big).
+\end{equation} 
+Prin urmare, rezolvarea optimizării constrânse pentru problema inversă este echivalentă cu efectuarea inferenței Bayes cu densitățile de probabilitate de mai sus. Astfel, rezolvarea programului de mai sus \eqref{eq:lagrange_multiplier_continuation} prin ascensiune gradient este echivalentă cu estimarea de verosimilitate maximă de mai sus \eqref{eqn:loglikelihoo-gradient-ascent}, 
+în care gradientul ia forma:
+\begin{equation}
+   \nabla_{\x} \log p(\y \mid \x) + \nabla_{\x} \log p(\x)   =  \pdv{h}{\vx}(\vx)\big(\y - h(\x)\big) + \mu \pdv{F}{\vx}(\vx)\big(\vc - F(\x)\big),
+\end{equation}
+unde $\pdv{h}{\vx}(\vx)$ și $\pdv{F}{\vx}(\vx)$ sunt Jacobianele lui $h(\x)$ și $F(\x)$, respectiv.
+
+În al doilea rând, observați că programul de mai sus \eqref{eq:lagrange_multiplier_continuation} este echivalent cu:
+\begin{equation}
+\min_{\x} \frac{1}{2}\|h(\x) - \y\|_2^2 + \frac{\mu}{2} \big\|F(\x) - \vlambda/\mu\big\|_2^2,
+\label{eqn:energy-minimization}
+\end{equation} 
+Datorită formei pătratice evidente a celor doi termeni, aceștia pot fi interpretați și ca anumite funcții de „energie". O astfel de formulare este adesea denumită „Minimizarea Energiei" în literatura de învățare automată.
+
+
+
+\paragraph{Câteva setări practice reprezentative pentru inferență.} 
+În practică, totuși, informațiile inițiale despre distribuțiile lui $\x$ și relația dintre $\x$ și $\y$ pot fi date în multe moduri și forme diferite. În general, ele pot fi în mare parte categorizate în patru cazuri, care sunt, conceptual, din ce în ce mai provocatoare:
+\begin{itemize}
+\item {\em Cazul 1:} Sunt cunoscute atât un model pentru distribuția lui $\x$, cât și modelul de observație $\y = h(\x)$ $(+ \boldsymbol{w})$, chiar cu o formă analitică. Acesta este de obicei cazul pentru multe probleme clasice de procesare a semnalului, cum ar fi eliminarea zgomotului din semnal, problema de recuperare a vectorului rar pe care l-am văzut în Capitolul \ref{ch:classic} și problema de recuperare a matricei de rang redus care va fi introdusă mai jos.
+\item {\em Cazul 2:} Nu avem un model pentru distribuție, ci doar eșantioane $\X = \{\x_1, \ldots, \x_N\}$ ale lui $\x$, iar modelul de observație $\y = h(\x)$ $ (+ \boldsymbol{w})$ este cunoscut.\footnote{În literatură, această setare este uneori denumită {\em inferență bayesiană empirică}.} Un model pentru distribuția $p(\x)$ a lui $\x$ trebuie să fie învățat, iar ulterior distribuția condiționată $p(\x\mid \y)$. Completarea imaginilor naturale sau completarea limbajului natural (de exemplu, BERT și GPT) sunt exemple tipice ale acestei clase de probleme.
+\item {\em Cazul 3:} Avem doar eșantioanele pereche: $(\X, \Y) = \{ (\x_1, \y_1), \ldots, (\x_N, \y_N) \}$ ale celor două variabile $(\x, \y)$. Distribuțiile lui $\x$ și $\y$ și relația lor $h(\cdot)$ trebuie să fie învățate din aceste date de eșantioane pereche. De exemplu, date fiind multe imagini și legendele lor, învățarea de a efectua generarea de imagini condiționată de text este o astfel de problemă.
+\item {\em Cazul 4:} Avem doar eșantioanele $\Y = \{\y_1, \ldots, \y_N\}$ ale observațiilor $\y$, iar modelul de observație $h(\cdot)$ trebuie să fie cunoscut, cel puțin într-o familie parametrică $h(\cdot, \boldsymbol{\theta})$. Distribuția $p(\x)$ și $p(\x \mid \y)$ trebuie să fie învățate din $\hat \x$, estimate din $\Y$. De exemplu, învățarea de a reda o vizualizare nouă dintr-o secvență de vizualizări calibrate sau necalibrate este o astfel de problemă.
+\end{itemize}
+În acest capitol, vom discuta abordări generale pentru a învăța distribuțiile dorite și a rezolva estimarea condiționată asociată sau generarea pentru aceste cazuri, de obicei cu o problemă reprezentativă. Pe parcursul capitolului, ar trebui să păstrați în minte \Cref{fig:inference_roadmap}.
+
+
+
+
+
+\section{Inferență Condiționată cu o Distribuție de Date Cunoscută}
+Observați că în setarea pe care am discutat-o în capitolele anterioare, rețeaua de autocodare este antrenată să reconstruiască un set de eșantioane ale vectorului aleator $\x$. Acest lucru ne-ar permite să regenerăm eșantioane din distribuția (de dimensiune redusă) învățată. În practică, dimensionalitatea redusă a distribuției, odată dată sau învățată, poate fi exploatată pentru sarcini de recuperare, completare sau predicție stabile și robuste. Adică, în condiții destul de blânde, se poate recupera $\x$ din măsuri foarte compresive, parțiale, zgomotoase sau chiar corupte ale lui $\x$ de tipul:
+\begin{equation}
+    \y = h(\x) + \vw,
+\end{equation}
+unde $\y$ este de obicei o observație a lui $\x$ care este de dimensiune mult mai mică decât $\x$ și $\vw$ poate fi zgomot aleator sau chiar corupții brute rare. Aceasta este o clasă de probleme care au fost studiate pe larg în literatura clasică de procesare a semnalului, pentru structuri de dimensiune redusă cum ar fi vectori rari, matrici de rang redus și mai mult. Cititorii interesați pot vedea \cite{Wright-Ma-2022} pentru o expunere completă a acestui subiect.
+
+Aici, pentru a pune lucrarea clasică într-un cadru modern mai general, ilustrăm ideea de bază și faptele prin sarcina, probabil cea mai simplă, de completare a datelor (și în special a imaginilor). Adică, considerăm problema de a recupera un eșantion $\x$ când părți din el lipsesc (sau chiar sunt corupte). Vrem să recuperăm sau să prezicem restul lui $\x$
+din observarea doar a unei fracțiuni din el:
+\begin{equation}
+f: \mathcal{P}_{\Omega}(\x) \mapsto \hat{\x},
+\end{equation}
+unde $\mathcal{P}_{\Omega}(\spcdot)$ reprezintă o operație de mascare
+(vezi \Cref{fig:matrix-completion} pentru un exemplu).
+
+În această secțiune și următoarea, vom studia sarcina de completare în două scenarii diferite: Unul este când distribuția datelor $\x$ de interes este deja dată {\em apriori}, chiar într-o anumită formă analitică. Acesta este cazul care prevalează în procesarea clasică a semnalului unde structurile semnalelor sunt presupuse a fi cunoscute, de exemplu, cu bandă limitată, rare sau de rang redus. Celălalt este când sunt disponibile doar eșantioane brute ale lui $\x$ și trebuie să învățăm distribuția de dimensiune redusă din eșantioane pentru a rezolva bine sarcina de completare. Acesta este cazul pentru sarcinile de completare a imaginilor naturale sau predicție a cadrelor video. Ca un precursor al restului capitolului, începem cu cel mai simplu caz de completare a imaginii: când imaginea de completat poate fi bine modelată ca o matrice de rang redus. Vom trece la cazuri din ce în ce mai generale și setări mai provocatoare mai târziu.
+
+\paragraph{Completarea matricei de rang redus.}  
+Problema de {\em completare a matricei} de rang redus este o problemă clasică pentru completarea datelor când distribuția sa este de dimensiune redusă și cunoscută. Considerați un eșantion aleator al unei matrici $\X_o =
+[\x_1, \ldots, \x_n] \in \mathbb{R}^{m\times n}$ din spațiul tuturor matricelor de rang $r$. În general, presupunem că rangul
+matricei este
+\begin{equation}
+\mbox{rank}(\X_o) = r < \min\{m, n\}.
+\end{equation}
+Deci este clar că local dimensiunea intrinsecă a spațiului tuturor matricelor de rang $r$ este mult mai mică decât spațiul ambiental $mn$.
+
+Acum, fie $\Omega$ să indice un set de indici ai intrărilor observate ale matricei $\X_o$. Fie intrările observate:
+\begin{equation}
+\Y = \mathcal{P}_{\Omega}(\X_o).
+\end{equation}
+Intrările rămase suportate pe $\Omega^c$ sunt neobservate sau
+lipsă. Problema este dacă putem recupera din $\Y$ intrările lipsă
+ale lui $\X$ corect și eficient. Figura \ref{fig:matrix-completion} arată un
+exemplu de completare a unei astfel de matrici.
+
+\begin{figure}
+\centering
+\includegraphics[width=0.3\linewidth]{\toplevelprefix/chapters/chapter6/figs/masked-checkerboard.png}\;\;
+\includegraphics[width=0.3\linewidth]{\toplevelprefix/chapters/chapter6/figs/mask.png}\;\;
+\includegraphics[width=0.3\linewidth]{\toplevelprefix/chapters/chapter6/figs/checkerboard.png}
+\caption{Ilustrarea completării unei imagini ca matrice de rang redus
+  cu unele intrări mascate sau corupte. Stânga: imaginea mascată/coruptă
+$\Y$; mijloc: masca $\Omega$; dreapta: imaginea completată $\hat \X$.}
+\label{fig:matrix-completion}
+\end{figure}
+
+Observați că motivul fundamental pentru care o astfel de matrice poate fi completată este că coloanele și rândurile matricei sunt foarte corelate și
+toate se află pe un subspațiu de dimensiune redusă. Pentru exemplul arătat în
+Figura \ref{fig:matrix-completion}, dimensiunea sau rangul matricei completate este doar doi. Prin urmare, ideea fundamentală pentru a recupera o astfel de matrice este să căutăm o matrice care are cel mai mic rang dintre toate
+matricele care au intrări în acord cu cele observate:
+\begin{equation}
+\min_{\X} \mbox{rank}(\X) \quad \mbox{supus la}
+\quad
+\Y = \mathcal{P}_{\Omega}(\X).
+\label{eqn:rank-min}
+\end{equation}
+Aceasta este cunoscută ca problema de {\em completare a matricei de rang redus}. Vezi \cite{Wright-Ma-2022} pentru o caracterizare completă a spațiului tuturor matricelor de rang redus. Deoarece funcția rang este discontinuă și minimizarea rangului
+este în general o problemă NP-hard, am vrea să o relaxăm cu
+ceva mai ușor de optimizat.
+
+Bazându-ne pe cunoștințele noastre despre compresie din Capitolul
+\ref{ch:compression}, am putea promova caracterul de rang redus al
+matricei recuperate $\X$ impunând rata de codare cu pierderi (sau
+volumul acoperit de $\X$) a datelor din $\X$ să fie mică:
+\begin{equation}
+\min R_\epsilon(\X) = \frac{1}{2} \log \det \left(\boldsymbol{I} +
+\alpha  \X\X^\top \right) \quad \mbox{supus la}
+\quad
+\Y = \mathcal{P}_{\Omega}(\X).
+\label{eqn:rate-min}
+\end{equation}
+Problema poate fi văzută ca o relaxare continuă a problemei de mai sus
+de completare a matricei de rang redus \eqref{eqn:rank-min} și poate fi
+rezolvată prin coborâre gradient. Se poate arăta că operatorul de coborâre gradient
+pentru obiectivul $\log\det$ minimizează precis un
+surogat apropiat al rangului matricei $\X\X^\top$.
+
+Funcția de distorsiune a ratei este o funcție neconvexă, iar coborârea sa
+gradient nu garantează întotdeauna găsirea soluției optime globale. Cu toate acestea, deoarece structura de bază căutată pentru $\X$ este liniară pe bucăți, funcția rang admite o relaxare convexă destul de eficace: norma
+nucleară---suma tuturor valorilor singulare ale matricei $\X$. După
+cum s-a arătat în literatura de detectare compresivă, în condiții destul de
+largi,\footnote{De obicei, astfel de condiții specifică
+cantitatea necesară și suficientă de intrări necesare pentru ca completarea
+să fie fezabilă computațional. Aceste condiții au fost
+caracterizate sistematic în \cite{Wright-Ma-2022}.} problema de
+completare a matricei \eqref{eqn:rank-min}
+poate fi rezolvată eficient prin următorul program convex:
+\begin{equation}
+\min \|\X\|_* \quad \mbox{supus la}
+\quad
+\Y = \mathcal{P}_{\Omega}(\X),
+\label{eqn:nuclear-min}
+\end{equation}
+unde norma nucleară $\|\X\|_*$ este suma valorilor singulare ale
+$\X$. În practică, adesea convertim programul de optimizare convex constrâns de mai sus
+într-unul neconstrâns:
+\begin{equation}
+\min \|\X\|_*  + \lambda \|
+\Y - \mathcal{P}_{\Omega}(\X)\|_F^2,
+\label{eqn:nuclear-min-lagrangian}
+\end{equation}
+pentru un anumit $\lambda > 0$ ales corespunzător. Cititorii interesați pot consulta
+\cite{Wright-Ma-2022} pentru cum să dezvolte algoritmi care pot rezolva
+programele de mai sus eficient și eficace.
+Figura \ref{fig:matrix-completion} arată un exemplu real în care
+matricea $\hat \X$ este de fapt recuperată rezolvând programul de mai sus.
+
+\paragraph{Extensii suplimentare.}
+S-a arătat că imaginile (sau mai precis texturile) și scenele 3D
+cu structuri de rang redus pot fi completate foarte eficient prin
+rezolvarea programelor de optimizare de tipul de mai sus, chiar dacă există
+corupție și distorsiune suplimentară
+\cite{Zhang2010TILTTI,Liang-ECCV2012,Yi_2023_ICCV}:
+\begin{equation}
+    \Y \circ \tau = \X_o + \boldsymbol{E},
+\end{equation}
+unde $\tau$ este o distorsiune neliniară necunoscută a imaginii și $\boldsymbol{E}$ este o matrice necunoscută care modelează unele ocluziuni și corupții (rare). Din nou, cititorii interesați pot consulta \cite{Wright-Ma-2022} pentru o prezentare mai detaliată.
+
+\section{Inferență Condiționată cu o Reprezentare de Date Învățată}
+În subsecțiunea anterioară, motivul pentru care putem infera $\x$ din observația parțială $\y$ este pentru că (suportul) distribuției lui $\X$ este cunoscut sau specificat {\em apriori}, să zicem ca mulțimea tuturor matricelor de rang redus. Pentru multe seturi de date practice, nu avem distribuția lor într-o formă analitică precum matricele de rang redus, să zicem mulțimea tuturor imaginilor naturale. Cu toate acestea, dacă avem suficiente eșantioane ale datelor $\x$, ar trebui să putem învăța mai întâi distribuția sa de dimensiune redusă și să o valorificăm pentru sarcini viitoare de inferență bazate pe o observație $\y = h(\x) + \vw$. În această secțiune, presupunem că modelul de observație $h(\cdot)$ este dat și cunoscut. Vom studia cazul când $h(\cdot)$ nu este dat explicit în secțiunea următoare.
+
+
+\subsection{Completarea Imaginilor cu Auto-Codare Mascată}
+Pentru o imagine generală $\vX$ precum cea prezentată în stânga Figurii
+\ref{fig:crate_mae_pipeline}, nu o mai putem vedea ca o matrice de rang
+redus. Cu toate acestea, oamenii încă demonstrează o abilitate remarcabilă de a
+completa o scenă și de a recunoaște obiecte familiare în ciuda ocluziunii
+severe. Acest lucru sugerează că creierul nostru a învățat
+distribuția de dimensiune redusă a imaginilor naturale și o poate folosi pentru
+completare și, prin urmare, recunoaștere. Cu toate acestea, distribuția tuturor
+imaginilor naturale nu este la fel de simplă ca un subspațiu liniar de dimensiune redusă.
+Prin urmare, o întrebare naturală este dacă putem învăța distribuția mai
+sofisticată a imaginilor naturale și o putem folosi pentru a efectua
+completarea imaginilor?
+
+\begin{figure}[t!]
+\begin{center}
+  \includegraphics[width=0.99\textwidth]{\toplevelprefix/chapters/chapter6/figs/crate_mae_pipeline.png}
+\end{center}
+\caption{\small \textbf{Diagrama procesului general de autocodare (mascată).} Reprezentările token (imagine) sunt
+  transformate iterativ către o reprezentare parsimonioasă (de exemplu, comprimată
+  și rară) de fiecare strat codificator \(f^{\ell}\).
+  Mai mult, astfel de reprezentări sunt transformate înapoi la
+  imaginea originală de straturile decodificatorului \(g^{\ell}\). Fiecare strat codificator
+  \(f^{\ell}\) este menit să fie (parțial) inversat de un
+strat decodificator corespunzător \(g^{L - \ell}\).}
+\label{fig:crate_mae_pipeline}
+\end{figure}
+
+O abordare empirică a sarcinii de completare a imaginii este să găsim o schemă de codare și decodare prin
+rezolvarea următorului program de {\em autocodare mascată} (MAE) care
+minimizează pierderea de reconstrucție:
+\begin{equation}\label{eq:mae_loss}
+\min_{f, g} L_{\mathrm{MAE}}(f, g) \doteq \mathbb{E}\big[\norm{(g \circ
+f)(\mathcal{P}_\Omega(\vX)) - \vX}_{2}^{2}].
+\end{equation}
+Spre deosebire de problema de completare a matricei care are o structură
+de bază simplă, nu ar trebui să ne mai așteptăm ca mapările de codare și decodare
+să admită forme închise simple sau ca programul să poată fi rezolvat prin
+algoritmi expliciți.
+
+Pentru o imagine naturală generală, nu mai putem presupune că coloanele sau
+rândurile sale sunt eșantionate dintr-un subspațiu de dimensiune redusă sau o
+gaussiană de rang redus. Cu toate acestea, este rezonabil să presupunem că imaginea constă
+din mai multe regiuni. Petele de imagine din fiecare regiune sunt similare și pot
+fi modelate ca o gaussiană (de rang redus) sau un subspațiu. Prin urmare, pentru a exploata
+dimensionalitatea redusă a distribuției, obiectivul \textit{codificatorului}
+$f$ este să transforme $\X$ într-o reprezentare $\Z$:
+\begin{equation}
+    f: \X \mapsto \Z
+\end{equation}
+astfel încât distribuția lui $\Z$ să poată fi bine modelată ca un amestec de subspații, să zicem $\{\vU_{[K]}\}$,
+astfel încât reducerea ratei să fie maximizată în timp ce raritatea este minimizată:
+\begin{equation}\label{eq:sparse_rr}
+\mathbb{E}_{\vZ = f(\vX)}[\Delta R_{\epsilon}(\vZ \mid \vU_{[K]}) - \lambda
+\norm{\vZ}_{0}] = \mathbb{E}_{\vZ = f(\vX)}[R_\epsilon(\vZ) - R^{c}_\epsilon(\vZ \mid
+\vU_{[K]}) - \lambda \norm{\vZ}_{0}],
+\end{equation}
+unde funcțiile $R_\epsilon(\cdot)$ și $R^c_\epsilon(\cdot)$ sunt definite în \eqref{eq:coding_rate} și \eqref{eq:def-mcr-Rc}, respectiv.
+
+După cum am arătat în Capitolul anterior \ref{ch:representation},
+codificatorul $f$ care minimizează obiectivul de mai sus poate fi construit ca
+o secvență de operatori de tip transformer. După cum se arată în lucrarea lui
+\cite{Pai2024masked}, decodificatorul $g$ poate fi văzut și, prin urmare,
+construit explicit ca procesul invers al codificatorului $f$.
+Figura \ref{fig:crate_mae_layers} ilustrează arhitecturile generale
+atât ale codificatorului, cât și ale decodificatorului corespunzător la
+fiecare strat. Parametrii codificatorului $f$ și decodificatorului $g$ pot fi
+învățați optimizând pierderea de reconstrucție \eqref{eq:mae_loss} prin
+coborâre gradient.
+
+\begin{figure}[t!]
+\centering
+\includegraphics[width=0.99\textwidth]{\toplevelprefix/chapters/chapter6/figs/crate_mae_layers.png}
+\caption{\small \textbf{Diagrama fiecărui strat codificator
+  (\textit{sus}) și strat decodificator (\textit{jos}).} Observați că
+  cele două straturi sunt foarte anti-paralele --- fiecare este construit să
+  facă operațiile celuilalt în ordine inversă. Adică, în
+  stratul decodificator \(g^{\ell}\), blocul \(\ISTA\) al \(f^{L - \ell}\)
+  este parțial inversat mai întâi folosind un strat liniar, apoi
+  blocul \(\MSSA\) al \(f^{L - \ell}\) este inversat; această ordine
+desfășoară transformarea făcută în \(f^{L - \ell}\).}
+\label{fig:crate_mae_layers}
+\end{figure}
+
+Figura \ref{fig:mae_autoencoding-small} arată câteva rezultate reprezentative
+ale auto-codificatorului mascat astfel proiectat. Mai multe detalii de implementare și
+rezultate ale autocodificatorului mascat pentru completarea imaginilor naturale pot fi
+găsite în Capitolul \ref{ch:applications}.
+\begin{figure}[t]
+\centering
+\includegraphics[width=0.99\textwidth]{\toplevelprefix/chapters/chapter6/figs/crate_mae_autoencoding_small.pdf}
+\caption{\small \textbf{Vizualizări de autocodare ale CRATE-Base
+  și ViT-MAE-Base \cite{he2022masked} cu 75\% din petele mascate.}
+  Observăm că reconstrucțiile din CRATE-Base sunt la același nivel
+  cu reconstrucțiile din ViT-MAE-Base, în ciuda utilizării \(<
+  1/3\) din parametri.
+}
+\label{fig:mae_autoencoding-small}
+\end{figure}
+
+
+
+
+\subsection{Eșantionare Condiționată cu Potrivirea Măsurătorilor}
+\label{sec:conditioned-decoding}
+Problema de autocodare (mascată) de mai sus își propune să genereze o imagine eșantion care este consistentă cu anumite observații sau condiții. Dar să examinăm abordarea mai îndeaproape: dată
+partea vizuală a unei imagini $\X_v = \mathcal{P}_{\Omega}(\X)$, încercăm să
+estimăm partea mascată $\X_m = \mathcal{P}_{\Omega^c}(\X)$. Pentru realizările
+$(\vXi_v, \vXi_m)$ ale variabilei aleatorii $\vX=(\vX_v, \vX_m)$, fie
+\[p_{\X_m \mid \X_v}(\vXi_m\mid \vXi_v)\]
+distribuția condiționată a $\X_m$ dată
+$\X_v$. Este ușor de arătat că soluția optimă pentru formularea MAE
+\eqref{eq:mae_loss} este dată de așteptarea condiționată:
+\begin{equation}
+  \argmin_{h = g \circ f}\, L_{\mathrm{MAE}}(h)
+  = \vXi_v \mapsto \vXi_v + \mathbb{E}[\X_m \mid \X_v=\vXi_v].
+\end{equation}
+În general, totuși, această așteptare poate să nu se afle nici măcar pe
+distribuția de dimensiune redusă a imaginilor naturale! Aceasta explică parțial
+de ce unele dintre patch-urile recuperate în \Cref{fig:mae_autoencoding-small}
+sunt puțin neclare.
+
+Pentru multe scopuri practice, am dori să învățăm (o reprezentare
+a) distribuției condiționate $p_{\X_m \mid \X_v}$, sau echivalent
+$p_{\X \mid \X_v}$,
+și apoi să obținem un eșantion clar (cel mai probabil) din această distribuție direct. Observați că, atunci când distribuția lui $\X$ este de dimensiune redusă, este posibil ca dacă o
+parte suficientă din $\X$, $\X_v$, este observată, aceasta determină complet
+$\X$ și prin urmare partea lipsă $\X_m$. Cu alte cuvinte, distribuția
+$p_{\X \mid \X_v}$ este o funcție generalizată---dacă $\vX$ este complet determinat de $\vX_v$ aceasta este funcția delta, și mai general una dintre verii săi exotici.
+
+Prin urmare, în loc să rezolvăm sarcina de completare ca o problemă de estimare condiționată, ar trebui să o abordăm ca o problemă de eșantionare condiționată. În acest scop, ar trebui mai întâi să învățăm distribuția (de dimensiune redusă) a tuturor imaginilor naturale $\X$. Dacă avem suficiente eșantioane de imagini naturale, putem învăța distribuția printr-un proces de eliminare a zgomotului $\X_t$ descris în Capitolul \ref{ch:compression}. Apoi problema de recuperare a $\X$ din observația sa parțială $\Y = \mathcal{P}_\Omega(\x) +\vw$ devine o problemă de generare condiționată -- de a eșantiona distribuția condiționată de observație.
+
+\begin{figure}
+  \centering
+  \includegraphics[width=1.0\textwidth]{\toplevelprefix/chapters/chapter6/figs/ambient_diffusion.png}
+  \caption{\small \textbf{Vizualizări de eșantionare din modele antrenate prin difuzie ambientală \cite{Daras-NIPS2023} cu 80\% din pixeli mascați.} Folosind un raport similar de pixeli mascați ca în \Cref{fig:mae_autoencoding-small}, algoritmul de eșantionare prin difuzie ambientală recuperează o imagine mult mai clară decât imaginea neclară recuperată prin metoda bazată pe MAE. Prima metodă eșantionează din distribuția imaginilor naturale, în timp ce ultima aproximează așteptarea condiționată (adică media) acestei distribuții dată observația; această mediere cauzează neclaritatea.}
+  \label{fig:ambient_diffusion}
+\end{figure}
+
+\paragraph{Măsurători liniare generale.} 
+De fapt, putem considera chiar recuperarea lui $\X$ dintr-un model de observație liniară mai general:
+\begin{equation}
+    \Y = \vA\X_0,  \quad \X_t = \X_0 + \sigma_t \vG,  
+\end{equation}
+unde $\vA$ este un operator liniar pe spațiul matricelor\footnote{adică, dacă ne imaginăm desfășurarea lui \(\vX\) într-un vector lung, atunci \(\vA\) ia rolul unei matrici pe spațiul \(\vX\)} și $\vG \sim \mathcal{N}(\boldsymbol{0}, \vI)$. Operatorul de mascare $\mathcal{P}_{\Omega}(\cdot)$ din sarcina de completare a imaginii este un exemplu de astfel de model liniar. Atunci s-a arătat de \cite{daras2023ambient} că 
+\begin{equation}
+    \hat{\X}_* = \argmin_{\hat{\X}} \mathbb{E}[\|\vA(\hat{\X}(\vA\X_t, \vA) - \X_0)\|^2]
+\end{equation}
+satisface condiția că:
+\begin{equation}
+    \vA \hat{\X}_*(\vA(\X_t), \vA) = \vA \mathbb{E}[\X_0 \mid \vA \X_t, \vA].
+\end{equation} Observați că în cazul special când $\vA$ este de rang complet pe coloane, avem $ \mathbb{E}[\X_0 \mid \vA\X_t, \vA] = \mathbb{E}[\X_0 \mid \X_t]$. Prin urmare, în cazul mai general, s-a sugerat de \cite{daras2023ambient} că se poate încă folosi $\mathbb{E}[\X_0 \mid \vA(\X_t), \vA]$ astfel obținut pentru a înlocui $\mathbb{E}[\X_0 \mid \X_t]$ în procesul normal de eliminare a zgomotului pentru $\X_t$:
+\begin{equation}
+    \X_{t-s} = \gamma_t \X_t + (1-\gamma_t) \mathbb{E}[\X_0 \mid \vA\X_t, \vA].
+\end{equation}
+Aceasta funcționează de obicei foarte bine în practică, să zicem pentru multe sarcini de restaurare a imaginilor, așa cum se arată în \cite{daras2023ambient}. În comparație cu imaginile neclare recuperate din MAE, imaginile recuperate prin metoda de mai sus sunt mult mai clare deoarece valorifică o distribuție învățată a imaginilor naturale și eșantionează o imagine (clară) din distribuția care este consistentă cu măsurarea, așa cum se arată în \Cref{fig:ambient_diffusion} (cf \Cref{fig:mae_autoencoding-small}).
+
+
+\paragraph{Măsurători neliniare generale.}
+Pentru a generaliza problemele de completare a (imaginilor) de mai sus și a face lucrurile mai riguroase, putem considera că un vector aleator $\vx \sim p$ este parțial observat printr-o funcție de observație mai
+generală:
+\begin{equation}\label{eq:measurement-matching-observation}
+\vy = h(\vx) + \vw,
+\end{equation}
+unde $\vw$ reprezintă de obicei un anumit zgomot de măsurare aleator, să zicem de
+o distribuție gaussiană $\vw \sim \mathcal{N}(\mathbf{0}, \sigma^2
+\boldsymbol{I})$. Este ușor de văzut că, pentru $\x$ și $\y$ astfel legate, distribuția lor comună $p(\x, \y)$ este în mod natural aproape degenerată dacă zgomotul $\vw$ este mic. În mare măsură, putem vedea $p(\x, \y)$ ca o versiune zgomotoasă a unei hipersuprafețe definite de funcția $\y = h(\x)$ în spațiul comun $(\x, \y)$. Practic vorbind, vom considera o setare mai asemănătoare cu autocodarea mascată decât cu completarea pură a matricei, unde avem întotdeauna acces la un eșantion curat corespunzător $\vx$ pentru fiecare observație $\vy$ pe care o primim.\footnote{În unele aplicații mai specializate, în special în imagistica științifică, este de interes să putem învăța să generăm eșantioane din posteriorul $p_{\x \mid \y}$ fără acces la niciun eșantion curat/adevăr de bază al lui $\x$. Oferim o scurtă prezentare generală a metodelor pentru această setare în notele de final de capitol.}
+
+La fel ca completarea imaginii/matricei, suntem
+adesea confruntați cu o setare în care $\vy$ denotă o observație degradată sau altfel
+„cu pierderi"
+a intrării $\vx$. Aceasta se poate manifesta în forme destul de diferite.
+De exemplu, în diverse probleme de imagistică științifică sau
+medicală, datele măsurate $\vy$ pot fi o observație comprimată și
+coruptă a datelor de bază $\vx$; în timp ce în sarcini de viziune 3D,
+$\vy$ poate reprezenta o imagine capturată de o cameră a unui obiect fizic cu o
+poză (de dimensiune redusă) necunoscută $\vx$.
+În general, în virtutea modelării matematice (și, în unele cazuri, co-proiectării
+sistemului de măsurare), cunoaștem $h$ și o putem evalua pe orice intrare, și
+putem exploata aceste cunoștințe pentru a ajuta la reconstrucția și eșantionarea lui $\vx$.
+
+\begin{figure}[t]
+  \centering
+  \begin{subfigure}{0.45\textwidth}
+    \vspace{0.75cm}
+    \centering
+    \begin{tikzcd}[column sep=1.5cm]
+      \vx \arrow[r, "h(\vx) + \vw"] & \vy \arrow[r, "p_{\vx \mid \vy}"]
+      & \posteriorsample \arrow[r, "\posteriorsample + t\vg"] & \posteriorsample_t
+    \end{tikzcd}
+    \vspace{0.75cm}
+    \caption{}
+    \label{fig:left}
+  \end{subfigure}
+  \hfill
+  \begin{subfigure}{0.45\textwidth}
+    \centering
+    \begin{tikzcd}[column sep=1.5cm, row sep=0.5cm]
+    & \vy \\
+    \vx \arrow[ur, "h(\vx) + \vw"] \arrow[dr, "\vx + t\vg"] & \\
+    & \vx_t
+    \end{tikzcd}
+    \caption{}
+    \label{fig:right}
+  \end{subfigure}
+  \caption{Diagrame de dependență statistică pentru procesul de eșantionare condiționată.
+  \textbf{Stânga:} Într-o aplicație directă (conceptuală) a schemei de difuzie-eliminare a zgomotului
+  pe care am dezvoltat-o în \Cref{ch:compression} pentru eșantionarea condiționată, folosim
+  eșantioane din posteriorul $p_{\vx \mid \vy}$ pentru a antrena eliminatoare de zgomot direct pe
+  posterior la diferite niveluri de zgomot, apoi le folosim pentru a genera noi
+  eșantioane. În practică, totuși, nu avem în mod normal eșantioane directe din
+  posterior, ci mai degrabă eșantioane pereche $(\vx, \vy)$ din distribuția comună.
+  \textbf{Dreapta:} Se dovedește că este suficient să avem doar observații zgomotoase
+  ale lui $\vx$ pentru a realiza eliminatoarele de zgomot corespunzătoare lui $p_{\posteriorsample_t \mid
+  \posteriorsample}$: aceasta rezultă din independența condiționată a lui $\vx_t$ și
+  $\vy$ dat $\vx$. Aceasta implică că $p_{\posteriorsample_t} = p_{\vx_t \mid
+  \vy}$, ceea ce dă o funcție de scor pentru eliminarea zgomotului care constă din
+  funcția de scor necondiționată, plus un termen de corecție care impune
+  consistența măsurătorii.}
+  \label{fig:posterior-sampling-cds}
+\end{figure}
+
+
+La nivel tehnic, vrem ca reprezentarea învățată a datelor
+să ne faciliteze eșantionarea distribuției condiționate $p_{\vx\mid
+\vy}$, cunoscută și ca posterior, eficace și eficient. Mai precis,
+scriem $\vnu$ pentru a denota o realizare a variabilei aleatorii $\vy$.
+Vrem să generăm eșantioane $\hat{\x}$ astfel încât:
+\begin{equation}\label{eq:goal-sample-posterior}
+  \hat{\x} \sim   p_{\vx \mid \y}(\spcdot \mid \vy=\vnu).
+\end{equation}
+
+Reamintim că în \Cref{sub:compression_denoising}, am dezvoltat un mod natural și
+eficace de a produce eșantioane \textit{necondiționate} ale distribuției datelor
+$p$. Ingredientele sunt denoiser-ele $\bar{\x}^\ast(t, \vxi) = \bE[ \x \mid
+\vx_t=\vxi ]$, sau aproximările lor învățate $\bar{\x}_{\theta}(t, \vxi)$,
+pentru diferite niveluri de observații zgomotoase $\x_t = \x + t \vg$ (și $\vxi$ pentru
+realizările lor) sub
+zgomot Gaussian $\vg \sim \cN(\mathbf{0}, \vI)$, și $t \in
+[0, T]$ cu o alegere de timpi $0 = t_1 < \hdots < t_{L} = T$ la care să
+efectuăm denoising-ul iterativ, începând de la $\hat{\vx}_{t_L} \sim
+\cN(\mathbf{0}, T^2 \vI)$ (reamintiți \Cref{eq:denoising-iteration-basic}).\footnote{Reamintim din discuția noastră în \Cref{sub:sampling_denoising}
+că câteva îmbunătățiri mici la această schemă de denoising iterativ de bază sunt
+suficiente pentru a aduce performanță practică competitivă. Pentru claritate pe măsură ce dezvoltăm
+eșantionarea condiționată, ne vom concentra aici pe cea mai simplă instanțiere.}
+Am putea aplica direct această schemă pentru a genera eșantioane din posteriorul
+$p_{\vx \mid \vy}$ \textit{dacă} am avea acces la un set de date de eșantioane
+$\posteriorsample \sim p_{\vx \mid \y}(\spcdot \mid \vnu)$ pentru fiecare realizare
+$\vnu$ a $\vy$, prin generarea de observații zgomotoase
+$\posteriorsample_t$ și antrenarea de denoiser-e pentru a aproxima $\bE[
+  \posteriorsample \mid \posteriorsample_t=\spcdot, \vy=\vnu ]$, media posteriorului sub
+observația zgomotoasă (vezi \Cref{fig:posterior-sampling-cds}(a)).
+Totuși, efectuarea acestei re-eșantionări având doar eșantioane pereche $(\vx, \vy)$ din distribuția
+comună (să zicem prin gruparea eșantioanelor pe valori ale $\vy$) necesită
+prohibitiv de multe eșantioane pentru date de dimensiune înaltă, iar abordările alternative
+se bazează explicit sau implicit pe estimarea densității, care suferă în mod similar de
+blestemul dimensionalității.
+
+Din fericire, se dovedește că acest lucru nu este necesar.
+Considerați diagrama alternativă de dependență statistică din
+\Cref{fig:posterior-sampling-cds}(b), care corespunde variabilelor aleatoare
+din procesul obișnuit de denoising-difuzie, împreună cu măsurătoarea $\vy$. 
+Deoarece modelul nostru de observație presupus \eqref{eq:measurement-matching-observation}
+implică că $\vx_t$ și $\vy$ sunt independente condiționate de $\vx$, avem pentru
+orice realizare $\vnu$ a $\vy$
+\begin{equation}\label{eq:conditional-denoising-conditioning-order-irrelevant}
+  \begin{split}
+  p_{\posteriorsample_t\mid \vy}(\spcdot \mid \vnu)
+  &= \int
+  \underbrace{p_{\posteriorsample_t \mid \posteriorsample}(\spcdot\mid \vxi)}_{=
+  \cN(\vxi, t^2 \vI)}
+  \spcdot \underbrace{p_{\posteriorsample \mid \vy}}_{= p_{\vx\mid \vy}}(\vxi \mid
+  \vnu)
+  \odif \vxi
+  \\
+  &=
+  \int p_{\vx_t \mid \vx, \vy}(\spcdot\mid \vxi, \vnu) \spcdot p_{\vx \mid
+  \vy}(\vxi\mid \vnu) \odif \vxi
+  \\
+  &=
+  \int p_{\vx_t, \vx \mid \vy}(\spcdot, \vxi \mid \vnu) \odif \vxi
+  \\
+  &= p_{\vx_t \mid \vy}(\spcdot\mid \vnu).
+  \end{split}
+\end{equation}
+Mai sus, prima linie recunoaște o echivalență între distribuțiile
+care apar în \Cref{fig:posterior-sampling-cds} (a,b); a doua linie aplică aceasta
+împreună cu independența condiționată a $\vx_t$ și $\vy$ date $\vx$; a
+treia linie folosește definiția probabilității condiționate; iar linia finală
+marginalizează peste $\vx$.
+Astfel, denoiser-ele din procesul conceptual de eșantionare posterioară sunt egale cu
+$\bE[\vx \mid \vx_t=\spcdot, \vy=\vnu]$, pe care le putem învăța doar din eșantioane pereche $(\vx,
+\vy)$,
+și prin formula lui Tweedie (\Cref{thm:tweedie}), putem exprima aceste denoiser-e în
+termenii funcției scor a $p_{\vx_t \mid \vy}$, care, prin regula lui Bayes,
+satisface
+\begin{equation}
+  p_{\vx_t \mid \vy}(\vxi \mid \vnu) 
+  = \frac{p_{\vy \mid \vx_t}(\vnu \mid \vxi) p_{\vx_t}(\vxi)}{p_{\vy}(\vnu)}.
+\end{equation}
+Reamintim că densitatea lui $\vx_t$ este 
+dată de $p_t = \varphi_{t} \ast p$, unde $\varphi_{t}$ denotă
+densitatea Gaussiană standard cu medie zero și covarianță $t^2 \vI$ iar $\ast$ denotă
+convoluția. Aceasta nu este altceva decât \textit{funcția scor necondiționată}
+obținută din antrenarea standard de difuzie pe care am dezvoltat-o în
+\Cref{sub:compression_denoising}!
+Funcția scor condiționată satisface atunci, pentru orice realizare $(\vxi,
+\vnu)$ a $(\vx_t, \vy)$,
+\begin{equation}
+  \nabla_{\vxi} \log p_{\vx_t \mid \vy}(\vxi\mid \vnu)
+  =
+  \underbrace{\nabla_{\vxi} \log p_t(\vxi)}_{\text{potrivire scor}}
+  +
+  \underbrace{\nabla_{\vxi} \log p_{\vy \mid \vx_t}(\vnu \mid \vxi)}_{\text{potrivire măsurătoare}},
+  \label{eqn:conditional-denoising-score}
+\end{equation}
+dând (prin formula lui Tweedie) denoiser-ele noastre propuse ca
+\begin{align*}
+  \bE[ \vx \mid \vx_t=\vxi, \vy=\vnu]
+  &=
+  \vxi + t^2 \nabla_{\vxi}\log p_t(\vxi) + t^2 \nabla_{\vxi}\log p_{\vy \mid
+  \vx_t}(\vnu \mid \vxi)
+  \\
+  &=
+  \bE[\vx \mid \vx_t=\vxi] + t^2 \nabla_{\vxi}\log p_{\vy \mid \vx_t}(\vnu\mid
+  \vxi).
+  \labelthis \label{eq:posterior-sampling-denoiser-decomposition}
+\end{align*}
+Operatorii rezultați sunt interpretabili ca o versiune \textit{corectată} a
+denoiser-ului necondiționat pentru observația zgomotoasă, unde termenul de corecție (așa-numitul
+termen de ``potrivire a măsurătorii'') impune consistența cu
+observațiile $\vy$. Cititorul ar trebui să fie atent să observe la care argument se
+aplică operatorii gradient în funcțiile scor de mai sus pentru a înțelege pe deplin
+sensul acestui operator.
+
+Problema cheie rămasă în a face această procedură computațională este să prescriem
+cum să calculăm corecția de potrivire a măsurătorii, deoarece în general nu avem
+o expresie în formă închisă
+pentru verosimilitatea $p_{\vy \mid \vx_t}$ cu excepția cazului când $t
+= 0$. Înainte de a aborda această problemă, discutăm un exemplu concret ilustrativ
+al întregului proces, continuând de la cele pe care le-am dezvoltat în
+\Cref{sub:compression_denoising}.
+
+\begin{example}\label{example:denoising-conditional-gaussian}
+  Considerați cazul în care distribuția datelor este Gaussiană cu media $\vmu \in
+  \bR^D$ și
+  covarianța $\vSigma \in \bR^{D \times D}$, adică $\vx \sim \cN(\vmu, \vSigma)$.
+  Presupunem că $\vSigma \succeq \Zero$ este nenulă.
+  Mai mult, în modelul de măsurare \eqref{eq:measurement-matching-observation},
+  să presupunem că obținem măsurători liniare ale $\vx$ cu zgomot Gaussian
+  independent, unde $\vA \in \bR^{d \times D}$ și $\vy = \vA \vx + \sigma \vw$
+  cu $\vw \sim \cN(\Zero, \vI)$ independent de $\vx$.
+  Atunci $\vx =_{d} \vSigma^{1/2} \vg + \vmu$, unde $\vg \sim \cN(\Zero, \vI)$ este
+  independent de $\vw$ și $\vSigma^{1/2}$ este rădăcina pătrată pozitivă unică a
+  matricei de covarianță $\vSigma$, și
+  după câteva calcule algebrice, putem scrie apoi
+  \begin{equation*}
+    \begin{bmatrix}
+      \vx \\
+      \vy
+    \end{bmatrix}
+    =_{d}
+    \begin{bmatrix}
+      \vSigma^{1/2} & \Zero \\
+      \vA \vSigma^{1/2} & \sigma \vI
+    \end{bmatrix}
+    \begin{bmatrix}
+      \vg \\
+      \vw
+    \end{bmatrix}
+    +
+    \begin{bmatrix}
+      \vmu \\
+      \vA\vmu
+    \end{bmatrix}.
+  \end{equation*}
+  Prin independență, avem că $(\vg, \vw)$ este Gaussian comun, ceea ce înseamnă că
+  $(\vx, \vy)$ este de asemenea Gaussian comun, ca imagine afină a unui
+  vector Gaussian comun.
+  Matricea sa de covarianță este dată de
+  \begin{equation*}
+    \begin{bmatrix}
+      \vSigma^{1/2} & \Zero \\
+      \vA \vSigma^{1/2} & \sigma \vI
+    \end{bmatrix}
+    \begin{bmatrix}
+      \vSigma^{1/2} & \Zero \\
+      \vA \vSigma^{1/2} & \sigma \vI
+    \end{bmatrix}^\top
+    =
+    \begin{bmatrix}
+      \vSigma & \vSigma \vA^\top \\
+      \vA \vSigma & \vA \vSigma \vA^\top + \sigma^2 \vI
+    \end{bmatrix}.
+  \end{equation*}
+  Acum, aplicăm faptul că condiționarea unui vector aleator cu distribuție Gaussiană comună
+  pe un subset de coordonate este din nou o distribuție Gaussiană
+  (\Cref{exercise:conditional_gaussian}).
+  Prin aceasta, obținem că
+  \begin{equation}
+    p_{\x \mid \y}(\spcdot \mid \vnu) = \cN\left(
+    \underbrace{%
+      \vmu + \vSigma\vA^\top \left(\vA\vSigma\vA^\top + \sigma^2 \vI\right)^{-1} 
+      (\vnu - \vA\vmu)}_{\vmu_{\vx \mid \vy}(\vnu)},
+      \underbrace{%
+      \vSigma - \vSigma \vA^\top \left(\vA\vSigma\vA^\top + \sigma^2
+      \vI\right)^{-1} \vA \vSigma}_{\vSigma_{\vx\mid \vy}}
+    \right).
+  \end{equation}
+  Prin echivalența pe care am derivat-o mai sus, obținem printr-o altă aplicare a
+  \Cref{exercise:conditional_gaussian}
+  \begin{equation}\label{eq:conditional-posterior-denoiser-gaussian-case}
+    \bE[ \vx \mid \vx_t=\vxi, \vy=\vnu ]
+    =
+    \vmu_{\vx\mid \vy}(\vnu) + \vSigma_{\vx\mid\vy}\left(
+    \vSigma_{\vx\mid \vy} + t^2 \vI 
+    \right)^{-1}\left(
+    \vxi - \vmu_{\vx\mid \vy}(\vnu)
+    \right).
+  \end{equation}
+  Forma funcțională a acestui denoiser este destul de simplă, dar poartă o
+  dependență greoaie de datele problemei $\vmu$, $\vSigma$, $\vA$ și
+  $\sigma^2$.
+  Putem obține o înțelegere suplimentară a comportamentului său comparându-l cu
+  \Cref{eq:posterior-sampling-denoiser-decomposition}.
+  Avem ca de obicei
+  \begin{equation}\label{eq:posterior-denoiser-gaussian-case}
+    \bE[\vx \mid \vx_t=\vxi]
+    = \vmu + \vSigma\left(\vSigma + t^2 \vI\right)^{-1} (\vxi - \vmu),
+  \end{equation}
+  care este destul de simplu---sugerând că termenul de potrivire a măsurătorii este
+  destul de complicat. Pentru a confirma aceasta, putem calcula verosimilitatea $p_{\vy
+  \mid \vx_t}$ direct folosind următoarea expresie pentru distribuția comună
+  a $(\vx_t, \vy)$:
+  \begin{equation}
+    \begin{bmatrix}
+      \vx \\
+      \vx_t \\
+      \vy
+    \end{bmatrix}
+    =_{d}
+    \begin{bmatrix}
+      \vSigma^{1/2} & \Zero & \Zero \\
+      \vSigma^{1/2} & t\vI & \Zero \\
+      \vA \vSigma^{1/2} & \Zero & \sigma \vI
+    \end{bmatrix}
+    \begin{bmatrix}
+      \vg \\
+      \vg' \\
+      \vw
+    \end{bmatrix}
+    +
+    \begin{bmatrix}
+      \vmu \\
+      \vmu \\
+      \vA\vmu
+    \end{bmatrix},
+  \end{equation}
+  unde $\vg' \sim \cN(\Zero, \vI)$ independent de celelalte Gaussiene.
+  Aceasta este din nou o distribuție Gaussiană comună; restricționând doar la ultimele
+  două rânduri, avem covarianța
+  \begin{equation*}
+    \begin{bmatrix}
+      \vSigma^{1/2} & t\vI & \Zero \\
+      \vA \vSigma^{1/2} & \Zero & \sigma \vI
+    \end{bmatrix}
+    \begin{bmatrix}
+      \vSigma^{1/2} & t\vI & \Zero \\
+      \vA \vSigma^{1/2} & \Zero & \sigma \vI
+    \end{bmatrix}^\top
+    =
+    \begin{bmatrix}
+      \vSigma + t^2\vI & \vSigma\vA^\top \\
+      \vA\vSigma & \vA\vSigma\vA^\top + \sigma^2 \vI
+    \end{bmatrix}.
+  \end{equation*}
+  O altă aplicare a \Cref{exercise:conditional_gaussian} ne dă apoi
+  \begin{equation}
+    p_{\y \mid \vx_t}(\spcdot \mid \vxi) = \cN\left(
+    \underbrace{%
+      \vA\vmu + \vA\vSigma\left( \vSigma + t^2 \vI \right)^{-1}
+      \left(
+        \vxi - \vmu
+      \right)
+      }_{\vmu_{\vy \mid \vx_t}(\vxi)},
+      \underbrace{%
+        \vA\vSigma\vA^\top + \sigma^2 \vI - \vA\vSigma \left( \vSigma
+        + t^2 \vI\right)^{-1} \vSigma \vA^\top
+      }_{\vSigma_{\vy\mid \vx_t}}
+    \right).
+  \end{equation}
+  Acum observați că $\vmu_{\vy \mid \vx_t}(\vxi) = \vA \bE[\vx \mid \vx_t=\vxi]$.
+  Deci, prin regula lanțului,
+  \begin{align*}
+    t^2 \nabla_{\vxi} \log p_{\vy \mid \vx_t}(\vnu \mid \vxi)
+    &=
+    t^2 \nabla_{\vxi}\left[
+      -\frac{1}{2}
+      (\vnu - \vA \bE[\vx \mid \vx_t=\vxi])^\top
+      \vSigma_{\vy \mid \vx_t}^{-1}
+      (\vnu - \vA \bE[\vx \mid \vx_t=\vxi])
+      \right]
+    \\
+    &= t^2 (\vSigma+t^2 \vI)^{-1}\vSigma\vA^\top\vSigma_{\vy \mid \vx_t}^{-1}\left(
+    \vnu - \vA \bE[\vx \mid \vx_t=\vxi] \right).
+    \labelthis
+    \label{eq:conditional-posterior-measurementmatching-gaussian-case}
+  \end{align*}
+  Aceasta ne dă o descompunere mai interpretabilă a denoiser-ului posterior condiționat
+  \eqref{eq:conditional-posterior-denoiser-gaussian-case}: urmând
+  \Cref{eq:posterior-sampling-denoiser-decomposition}, este suma denoiser-ului
+  posterior necondiționat \eqref{eq:posterior-denoiser-gaussian-case}
+  și termenul de potrivire a măsurătorii
+  \eqref{eq:conditional-posterior-measurementmatching-gaussian-case}.
+  Putem analiza în continuare termenul de potrivire a măsurătorii. Observați că
+  \begin{equation}
+    \vSigma_{\vy \mid \vx_t}
+    =
+    \sigma^2 \vI + \vA\vSigma^{1/2} \left(
+      \vI - \vSigma^{1/2}\left(
+      \vSigma + t^2 \vI
+      \right)^{-1}
+      \vSigma^{1/2}
+    \right)\vSigma\vA^\top.
+  \end{equation}
+  Dacă notăm $\vSigma = \vV \vLambda \vV^\top$ o descompunere în valori proprii
+  a $\vSigma$, unde $(\vv_i)$ sunt coloanele lui $\vV$, putem scrie mai departe
+  \begin{align}
+    \vSigma^{1/2}\left(
+    \vI - \vSigma^{1/2}\left(
+    \vSigma + t^2 \vI
+    \right)^{-1}
+    \vSigma^{1/2}
+    \right) \vSigma^{1/2}
+    &=
+    t^2 \vV \vLambda^{1/2}\left(
+      \vLambda + t^2 \vI
+    \right)^{-1}
+    \vLambda^{1/2}
+    \vV^\top
+    \\
+    &=
+    t^2 \sum_{i=1}^D
+    \frac{\lambda_i}{\lambda_i + t^2}
+    \vv_i \vv_i\adj.
+  \end{align}
+  Atunci pentru orice valoare proprie a $\vSigma$ egală cu zero, termenul corespunzător din sumă
+  este zero; și
+  scriind $\lambda_{\min}(\vSigma)$ pentru cea mai mică valoare proprie pozitivă a
+  $\vSigma$ (are cel puțin o valoare proprie pozitivă, prin ipoteză), avem
+  (într-un sens care poate fi făcut precis cantitativ) că ori de câte ori $t \ll
+  \sqrt{\lambda_{\min}(\vSigma)}$, avem
+  \begin{equation}
+    \frac{\lambda_i t^2}{\lambda_i + t^2} \approx 0.
+  \end{equation}
+  Deci, când $t \ll \sqrt{\lambda_{\min}(\vSigma)}$, avem aproximarea
+  \begin{equation}
+    \vSigma_{\vy \mid \vx_t} \approx \sigma^2 \vI.
+  \end{equation}
+  Partea dreaptă a acestei aproximări este egală cu $\vSigma_{\vy \mid \vx}$.
+  Deci avem la rândul nostru
+  \begin{equation}
+    \nabla_{\vxi} \log p_{\vy \mid \vx_t}(\vnu \mid \vxi)
+    \approx
+    \nabla_{\vxi} \log p_{\vy \mid \vx}(\vnu \mid \bE[\vx \mid \vx_t = \vxi]).
+    \label{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}
+  \end{equation}
+
+  \begin{figure}[tbp]
+    \centering
+    \begin{subfigure}{0.32\textwidth}
+      \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/samples_step_000_t_100_largenoise.png}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}{0.32\textwidth}
+      \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/samples_step_050_t_50_largenoise.png}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}{0.32\textwidth}
+      \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/samples_step_100_t_0_largenoise.png}
+    \end{subfigure}
+
+    \vspace{2mm} %
+
+    \begin{subfigure}{0.32\textwidth}
+      \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/samples_step_000_t_100_smallnoise.png}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}{0.32\textwidth}
+      \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/samples_step_010_t_90_smallnoise.png}
+    \end{subfigure}
+    \hfill
+    \begin{subfigure}{0.32\textwidth}
+      \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/samples_step_100_t_0_smallnoise.png}
+    \end{subfigure}
+
+    \caption{Simulare numerică a configurației de eșantionare condiționată
+    \eqref{eq:measurement-matching-observation}, cu date Gaussiene, măsurători
+    liniare și zgomot Gaussian. Simulăm $D=2$ și $d=1$, cu $\vSigma
+    = \ve_1 \ve_1^\top + \tfrac{1}{4} \ve_2 \ve_2^\top$, $\vmu = \Zero$ și
+    $\vA = \ve_1^\top$. Semnalul de bază $\vx$ este marcat cu o stea neagră,
+    iar măsurătoarea $\vy$ este marcată cu un cerc negru.
+    Fiecare grafic individual corespunde unei valori diferite a timpului de eșantionare
+    $t_{\ell}$, cu rânduri diferite corespunzând nivelurilor diferite de zgomot de observație
+    $\sigma^2$.
+    În fiecare grafic, matricea de covarianță a $\vx$ este trasată în gri, matricea
+    de covarianță posterioară și media posterioară a $p_{\vx \mid \vy}$ sunt
+    trasate în albastru (cu media posterioară marcată cu un ``x'' albastru), iar
+    contururile pentru $p_{\vx_{t_{\ell}} \mid \vy}$ sunt desenate în verde. Hiperparametrii
+    eșantionatorului sunt $T=1$, $L=100$ și desenăm $100$
+    de eșantioane independente pentru a inițializa eșantionatoarele. Eșantionatoarele sunt implementate
+    cu denoiser-ele în formă închisă derivate în
+    \Cref{example:denoising-conditional-gaussian}, cu cele care folosesc
+    aproximarea
+    \eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}
+    marcate cu triunghiuri roșii și cele care folosesc denoiser-ul posterior condiționat
+    exact marcate cu cercuri albastre.
+    \textbf{Sus:} Pentru zgomot de observație mare $\sigma = 0.5$, atât
+    denoiser-ul posterior condiționat exact, cât și cel aproximativ fac o treabă bună de
+    convergență către posteriorul $p_{\vx \mid \vy}$. Timpul de eșantionare (corespunzând
+    timpului în ``procesul direct'', deci timpii mai mari înseamnă zgomot mai mare)
+    scade de la stânga la dreapta. Dinamica de convergență pentru termenul exact și
+    aproximativ de potrivire a măsurătorii sunt similare. \textbf{Jos:} Pentru
+    zgomot de observație mai mic $\sigma = 0.1$,
+    termenul aproximativ de potrivire a măsurătorii duce la o distorsiune extremă în eșantionator
+    (triunghiuri roșii): eșantioanele converg rapid către un subspațiu afin
+    de puncte care sunt consistente, modulo o anumită contracție de la denoiser-ul mediei posterioare,
+    cu adevărul de bază măsurat, iar iterațiile ulterioare de eșantionare sunt
+    incapabile să recupereze varianța posterioară pierdută de-a lungul acestei dimensiuni. Observați
+    că timpi diferiți $t_{\ell}$ sunt reprezentați în rândul de jos, comparativ cu
+    rândul de sus, pentru a arăta colapsul rapid al aproximării către
+    posterior de-a lungul dimensiunii măsurătorii.}
+    \label{fig:conditional_sampling_computational_gaussian}
+  \end{figure}
+
+  \Cref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}
+  este, desigur, o consecință directă a calculelor noastre de mai sus. Totuși, observați
+  că dacă interpretăm direct această aproximare, este \textit{ab initio}
+  tractabilă: verosimilitatea $p_{\vy \mid \vx} = \cN(\vA\vx, \sigma^2 \vI)$ este
+  o distribuție Gaussiană simplă centrată la observație, iar
+  aproximarea termenului de potrivire a măsurătorii la care ajungem poate fi
+  interpretată ca simpla evaluare a log-verosimilității la așteptarea
+  condiționată $\bE[\vx \mid \vx_t = \vxi]$, apoi luarea gradienților cu privire
+  la $\vxi$ (și retropropagarea prin așteptarea condiționată, care este
+  dată aici de \Cref{eq:posterior-denoiser-gaussian-case}).
+  Cu toate acestea, observați că aproximarea din
+  \Cref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}
+  necesită $t \ll \sqrt{\lambda_{\min}(\vSigma)}$ și că nu este niciodată precisă
+  în general când această condiție nu este îndeplinită, chiar în această setare Gaussiană.
+
+  Pentru a obține o perspectivă asupra efectului aproximării convenabile
+  \eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx},
+  implementăm și simulăm un experiment numeric simplu în
+  setarea Gaussiană în \Cref{fig:conditional_sampling_computational_gaussian}. 
+  Eșantionatorul pe care îl implementăm este o implementare directă a schemei simple
+  \eqref{eq:denoising-iteration-basic} pe care am dezvoltat-o în \Cref{ch:compression}
+  și am reamintit-o mai sus, folosind denoiser-ul posterior condiționat adevărat, adică
+  \Cref{eq:conditional-posterior-denoiser-gaussian-case} (rândul de sus din
+  \Cref{fig:conditional_sampling_computational_gaussian}), și 
+  aproximarea convenabilă a acestui denoiser făcută cu descompunerea
+  \eqref{eq:posterior-sampling-denoiser-decomposition}, denoiser-ul posterior
+  \eqref{eq:posterior-denoiser-gaussian-case} și aproximarea de
+  potrivire a măsurătorii
+  \eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}
+  (rândul de jos din \Cref{fig:conditional_sampling_computational_gaussian}).
+  Vedem că chiar și în setarea Gaussiană simplă, aproximarea termenului de
+  potrivire a măsurătorii pe care am făcut-o nu este lipsită de
+  dezavantaje---specific, la niveluri mici de zgomot $\sigma^2 \ll 1$, aceasta duce la
+  colapsul rapid al varianței distribuției de eșantionare de-a lungul direcțiilor
+  care sunt paralele cu rândurile operatorului de măsurare liniar $\vA$, care
+  nu poate fi corectat de iterațiile ulterioare de eșantionare. Putem intui aceasta din
+  aproximarea
+  \eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}
+  și definiția iterației de denoising
+  \eqref{eq:denoising-iteration-basic}, dată
+  \Cref{eq:posterior-sampling-denoiser-decomposition}: pentru $\sigma^2 \ll 1$,
+  pașii timpurii de eșantionare efectiv fac pași de coborâre gradient cu un
+  pas foarte mare pe verosimilitate, prin
+  \Cref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx},
+  ceea ce face ca distribuția de eșantionare să rămână ``blocată'' într-o stare colapsată.
+
+\end{example}
+
+
+\Cref{example:denoising-conditional-gaussian} sugerează o aproximare convenabilă
+pentru termenul de potrivire a măsurătorii
+\eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx},
+care poate fi făcută dincolo de setarea Gaussiană a exemplului. Pentru a
+motiva această aproximare într-o generalitate mai mare, observați că
+prin independența condiționată a $\vy$ și $\vx_t$ date $\vx$, putem scrie
+\begin{equation}
+  p_{\vy \mid \vx_t}(\vnu \mid \vxi)
+  =
+  \int p_{\vy \mid \vx}(\vnu \mid \vxi') p_{\vx \mid \vx_t}(\vxi' \mid \vxi)
+  \odif  \vxi'.
+\end{equation}
+Formal, când posteriorul $p_{\vx\mid \vx_t}$ este o funcție delta centrată la
+media sa $\bE[\vx \mid \vx_t=\vxi]$, aproximarea
+\eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx} este
+exactă. Mai general, când posteriorul $p_{\vx \mid \vx_t}$ este foarte
+concentrat în jurul mediei sale, aproximarea
+\eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx} este
+precisă. Aceasta este valabilă, de exemplu, pentru $t$ suficient de mic, ceea ce am văzut
+explicit în setarea Gaussiană din
+\Cref{example:denoising-conditional-gaussian}.
+Deși simularea numerică din
+\Cref{fig:conditional_sampling_computational_gaussian} sugerează că această
+aproximare nu este lipsită de avertismente în anumite regimuri, s-a dovedit a fi
+o bază de referință fiabilă în practică, după ce a fost propusă de Chung et al.\ ca
+``Eșantionare Posterioară prin Difuzie'' (DPS) \cite{chung2023diffusion}.
+În plus, există chiar abordări principiale și generalizabile pentru a o îmbunătăți prin
+încorporarea unor estimări mai bune ale varianței posterioare (care se dovedesc a fi
+exacte în setarea Gaussiană din \Cref{example:denoising-conditional-gaussian}),
+pe care le discutăm mai departe în rezumatul de la sfârșitul capitolului.
+
+Astfel, cu aproximarea DPS, ajungem la următoarea aproximare pentru
+denoiser-ele posterioare condiționate $\bE[\vx \mid \vy, \vx_t]$, prin
+\Cref{eq:posterior-sampling-denoiser-decomposition}:
+\begin{equation}
+  \bE[ \vx \mid \vx_t=\vxi, \vy=\vnu]
+  \approx
+  \bE[\vx \mid \vx_t=\vxi] 
+  + t^2 \nabla_{\vxi} \log p_{\vy \mid \vx}(\vnu \mid \bE[\vx \mid \vx_t = \vxi]).
+  \label{eq:posterior-sampling-denoiser-decomposition-dps}
+\end{equation}
+Și, pentru o rețea neuronală sau alt model $\bar{\vx}_{\theta}(t, \vxi)$ 
+antrenat ca în \Cref{sub:compression_denoising} pentru a aproxima denoiser-ele
+$\bE[\vx \mid \vx_t = \vxi]$ pentru fiecare $t \in [0, T]$, ajungem la denoiser-ele
+posterioare condiționate învățate
+\begin{equation}
+  \bar{\vx}_{\theta}(t, \vxi, \vnu) 
+  = \bar{\vx}_{\theta}(t, \vxi)
+  + t^2 \nabla_{\vxi} \log p_{\vy \mid \vx}(\vnu \mid \bar{\vx}_{\theta}(t,
+  \vxi)).
+  \label{eq:posterior-sampling-denoiser-learned-dps}
+\end{equation}
+Observați că aproximarea
+\eqref{eq:posterior-sampling-denoiser-decomposition-dps} este validă pentru modele
+directe arbitrare $h$ în
+modelul de observație \eqref{eq:measurement-matching-observation}, inclusiv
+$h$ neliniar, și chiar pentru
+modele arbitrare de zgomot pentru care o expresie clară pentru verosimilitatea $p_{\vy
+\mid \vx}$ este cunoscută. Într-adevăr, în cazul zgomotului Gaussian, avem
+\begin{equation}
+  p_{\vy \mid \vx}(\vnu \mid \vxi)
+  \propto
+  \exp\left(
+    -\frac{1}{2\sigma^2} \norm*{ h(\vxi) - \vnu }_2^2
+  \right).
+\end{equation}
+Prin urmare, evaluarea părții drepte a
+\eqref{eq:posterior-sampling-denoiser-learned-dps}
+necesită doar
+\begin{enumerate}
+  \item Un denoiser pre-antrenat $\bar{\vx}_{\theta}(t, \vxi)$ pentru distribuția datelor $p$
+    (a $\vx)$, învățat ca în \Cref{sub:compression_denoising} prin
+    \Cref{alg:learning_denoiser};
+  \item Acces la trecerea directă și inversă la modelul direct $h$ pentru
+    măsurători \eqref{eq:measurement-matching-observation};
+  \item O trecere directă și inversă prin $\bar{\vx}_{\theta}(t, \vxi)$, care poate fi evaluată
+    eficient folosind (să zicem) retropropagarea.
+\end{enumerate}
+
+\begin{algorithm}
+  \caption{Eșantionare condiționată sub măsurători
+  \eqref{eq:measurement-matching-observation}, cu un denoiser necondiționat și DPS.}
+	\label{alg:iterative_denoising_conditional_DPS}
+	\begin{algorithmic}[1]
+		\Require{O listă ordonată de pași de timp \(0 \leq t_{0} < \cdots < t_{L} \leq T\) de folosit pentru eșantionare.}
+    \Require{Un denoiser necondiționat \(\bar{\vx}_{\theta} \colon
+    \{t_{\ell}\}_{\ell = 1}^{L} \times \R^{D} \to \R^{D}\) pentru $p_{\vx}$.}
+    \Require{Realizarea măsurătorii $\vnu$ a $\vy$ (\Cref{eq:measurement-matching-observation}) pe care să condiționăm.}
+    \Require{Modelul direct $h : \bR^D \to \bR^d$ și varianța zgomotului de măsurare
+    $\sigma^2 > 0$.}
+		\Require{Funcțiile de scară și nivel de zgomot \(\alpha, \sigma \colon \{t_{\ell}\}_{\ell = 0}^{L} \to \R_{\geq 0}\).}
+    \Ensure{Un eșantion \(\hat{\vx}\), aproximativ din \(p_{\vx \mid \vy}\).}
+    \Function{DDIMSamplerConditionalDPS}{$\bar{\vx}_{\theta}, \vnu, h, \sigma^2,
+    (t_{\ell})_{\ell = 0}^{L}$}
+		\State{Inițializează \(\hat{\vx}_{t_{L}} \sim\) distribuție aproximativă a \(\vx_{t_{L}}\)} \Comment{VP \(\implies \dNorm(\vzero, \vI)\), VE \(\implies \dNorm(\vzero, t_{L}^{2}\vI)\).}
+		\For{\(\ell = L, L - 1, \dots, 1\)}
+		\State{Calculează
+			\begin{equation*}
+				\hat{\vx}_{t_{\ell - 1}} \doteq \frac{\sigma_{t_{\ell
+        - 1}}}{\sigma_{t_{\ell}}}\hat{\vx}_{t_{\ell}} + \bp{\alpha_{t_{\ell
+        - 1}} - \frac{\sigma_{t_{\ell
+        - 1}}}{\sigma_{t_{\ell}}}\alpha_{t_{\ell}}}\left(
+        \bar{\vx}_{\theta}(t_{\ell}, \hat{\vx}_{t_{\ell}})
+        - \frac{\sigma_{t_{\ell}}^2}{2\alpha_{t_\ell}\sigma^2}
+        \nabla_{\vxi}\left[ \norm*{h( \bar{\vx}_{\theta}(t_{\ell}, \vxi)
+        ) - \vnu}_2^2 \right]\biggl|_{\vxi = \hat{\vx}_{t_{\ell}}}\biggr.
+        \right)
+			\end{equation*}
+		}
+		\EndFor
+		\State{\Return{\(\hat{\vx}_{t_{0}}\)}}
+		\EndFunction
+	\end{algorithmic}
+\end{algorithm}
+
+Combinând această schemă cu implementarea de bază a eșantionării necondiționate pe care am
+dezvoltat-o în \Cref{sub:compression_denoising}, obținem un algoritm practic pentru
+eșantionarea condiționată a posteriorului $p_{\vx \mid \vy}$ date măsurătorile
+care urmează \eqref{eq:measurement-matching-observation}.
+\Cref{alg:iterative_denoising_conditional_DPS} înregistrează această schemă
+pentru cazul
+zgomotului de observație Gaussian cu deviație standard cunoscută $\sigma$, cu modificări minore
+pentru a extinde la un proces general de zgomot, ca în
+\Cref{eq:gen_additive_gaussian_noise_model} și discuția înconjurătoare din
+\Cref{ch:compression} (discuția noastră de mai sus a făcut alegerile simplificatoare $\alpha_t = 1$, $\sigma_t = t$ și
+$t_{\ell} = T\ell / L$, ca pentru \Cref{eq:denoising-iteration-basic} în
+\Cref{sub:compression_denoising}).
+
+
+
+\subsection{Generarea Pozei Corpului Condiționată de Cap și Mâini}\label{sub:ego-allo}
+Acest tip de
+problemă de estimare sau generare condiționată apare destul de natural în multe
+aplicații practice. 
+O problemă tipică de acest gen este cum să estimăm și să generăm poza corpului și gestul mâinilor condiționat de o poză dată a capului și imagini egocentrice, așa cum este ilustrat în Figura \ref{fig:pose-teaser}. Aceasta este adesea problema pe care trebuie să o rezolvăm când cineva poartă un dispozitiv montat pe cap, cum ar fi Vision Pro de la Apple sau Project Aria de la Meta. Poza întregului corp și gestul mâinilor trebuie inferate astfel încât să putem folosi informația pentru a controla obiecte virtuale cu care persoana interacționează.
+\begin{figure*}[t]
+  \centering
+  \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/pose-teaser.pdf}
+    \caption{
+Un sistem care estimează înălțimea, poza și parametrii mâinilor corpului uman (mijloc), condiționat de pozele SLAM egocentrice și imagini (stânga). Ieșirile captează acțiunile purtătorului în cadrul de referință alocentric al scenei, pe care îl vizualizăm aici cu reconstrucții 3D (dreapta).
+  }
+  \label{fig:pose-teaser}
+
+\end{figure*}
+
+Observați că în acest caz, avem doar poza capului furnizată de dispozitiv și un câmp vizual foarte limitat pentru o parte din mâini și membrele superioare. Poza restului corpului trebuie să fie ``inferată'' sau ``completată'' pe baza unor astfel de informații parțiale. Singura modalitate prin care se poate estima poza corpului în timp este învățând distribuția comună a secvențelor de poză a capului și corpului în avans și apoi eșantionând această distribuție prioră condiționată de intrările parțiale în timp real. Figura \ref{fig:pose-method} conturează un sistem numit EgoAllo \cite{yi2024egoallo} pentru a rezolva această problemă bazat pe un model de difuzie-denoising condiționat învățat.
+
+\begin{figure*}[t]
+  \centering
+  \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/pose-method.pdf}
+\caption{
+    \textbf{Prezentare generală a componentelor tehnice ale EgoAllo \cite{yi2024egoallo}.}
+    Un model de difuzie este pre-antrenat care poate genera secvențe de poză a corpului bazate pe parametri locali ai corpului (mijloc).
+    O parametrizare invariantă $g(\cdot)$ a pozelor SLAM (stânga) este folosită pentru a condiționa modelul de difuzie. Acestea pot fi plasate în cadrul de coordonate global prin aliniere globală la pozele de intrare.
+    Când sunt disponibile, videoclipurile egocentrice sunt folosite pentru detectarea mâinilor (stânga) prin HaMeR~\cite{pavlakos2023reconstructing}, care pot fi încorporate în eșantioane prin ghidare de gestul generat.
+  }
+  \label{fig:pose-method}
+\end{figure*}
+
+
+Figura \ref{fig:comparison} compară unele secvențe de mișcare adevărate cu rezultatele eșantionate generate de EgoAllo. Deși figura arată un rezultat pentru fiecare secvență de poză a capului de intrare, rulări diferite pot genera secvențe diferite de poză a corpului care sunt consistente cu poza capului dată, toate extrase din distribuția secvențelor naturale de mișcare a întregului corp.
+\begin{figure}[t]
+\centering
+\begin{subfigure}{0.45\textwidth}
+  \centering
+  \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/qual0_gt.png}
+  \caption{\centering Adevăr de bază}
+\end{subfigure}
+\hfill
+\begin{subfigure}{0.45\textwidth}
+  \centering
+  \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/qual0_ours.png}
+  \caption{EgoAllo}
+\end{subfigure}
+
+\begin{subfigure}{0.45\textwidth}
+  \centering
+  \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/qual1_gt.png}
+  \caption{\centering Adevăr de bază}
+\end{subfigure}
+\hfill
+\begin{subfigure}{0.45\textwidth}
+  \centering
+  \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/qual1_ours.png}
+  \caption{EgoAllo}
+\end{subfigure}
+
+\caption{
+\textbf{Estimarea mișcării umane egocentrice pentru o secvență de alergare (sus) și ghemuit (jos).}
+Mișcarea adevărului de bază este comparată cu o ieșire din EgoAllo care este consistentă cu secvența de poză a capului dată. 
+}
+\label{fig:comparison}
+\end{figure}
+
+Strict vorbind, soluția propusă în EgoAllo \cite{yi2024egoallo} nu
+impune potrivirea măsurătorii folosind tehnicile introduse mai sus. În schimb,
+impune euristic condiția utilizând mecanismul de atenție încrucișată
+într-o arhitectură transformer. După cum vom descrie cu mai multă precizie
+în setarea datelor pereche în \Cref{sub:text-cond}, există motive să credem că mecanismul
+de atenție încrucișată realizează într-un fel aproximativ eșantionarea condiționată
+a denoising-ului a posteriori. Credem că tehnicile mai principiale
+introduse aici, dacă sunt implementate corespunzător, pot duce la metode mai bune
+care îmbunătățesc în continuare estimarea pozei corpului și a gestului mâinilor.
+
+\section{Inferență Condiționată cu Date Pereche și Măsurători}
+În multe aplicații practice, nu cunoaștem nici distribuția datelor $\x$ de interes, nici relația explicită dintre date și anumite atribute observate $\y$ ale datelor. Avem doar un set (mare) de eșantioane pereche $(\X, \Y) = \{ (\x_1, \y_1), \ldots, (\x_N, \y_N) \}$ din care trebuie să inferăm distribuția datelor și o mapare care modelează relația lor:
+\begin{equation}
+  h: \x \mapsto \y.
+\end{equation}
+
+Problema clasificării imaginilor poate fi văzută ca un astfel de exemplu. Într-un sens, problema de clasificare este să învățăm un codificator compresiv (extrem de cu pierderi) pentru imagini naturale. Să zicem, dată o mostră aleatorie a unei imagini $\x$, am dori să prezicem eticheta sa de clasă $\y$ care corelează cel mai bine conținutul din $\x$. Știm că distribuția imaginilor naturale ale obiectelor este de dimensiune redusă comparativ cu dimensiunea spațiului pixelilor. Din capitolele anterioare, am învățat că, date suficiente eșantioane, în principiu, putem învăța o reprezentare structurată de dimensiune redusă $\z$ pentru $\x$ printr-o codare compresivă învățată:
+\begin{equation}
+    f: \x \mapsto \z. 
+\end{equation}
+Reprezentarea $\z$ poate fi văzută și ca un cod învățat (cu pierderi dar structurat) pentru $\x$. Este destul de rezonabil să presupunem că dacă atribuirea clasei $\y$ depinde cu adevărat de structurile de dimensiune redusă ale lui $\x$ și codul învățat $\z$ reflectă cu adevărat astfel de structuri, $\y$ și $\z$ pot fi făcute foarte corelate și, prin urmare, distribuția lor comună $p(\z, \y)$ ar trebui să fie extrem de redusă dimensional. Prin urmare, putem combina cele două coduri dorite $\y$ și $\z$ împreună și încerca să învățăm un codificator combinat:
+\begin{equation}
+    f: \x \mapsto (\z, \y) 
+\end{equation}
+unde distribuția comună a $(\z, \y)$ este foarte redusă dimensional.
+
+Din studiul nostru în capitolele anterioare, maparea $f$ este de obicei învățată ca o secvență de operatori de compresie sau denoising în același spațiu. Prin urmare, pentru a valorifica o astfel de familie de operații, putem introduce un vector auxiliar $\vw$ care poate fi văzut ca o estimare aleatorie inițială a etichetei de clasă $\y$. În acest fel, putem învăța o mapare de compresie sau denoising:
+\begin{equation}\label{eq:classifier-with-class-token}
+    f: (\x, \vw) \mapsto (\z, \y)
+\end{equation}
+într-un spațiu comun. De fapt, practica comună de a introduce un ``token de clasă'' auxiliar în antrenarea unui transformer pentru sarcini de clasificare, cum ar fi în ViT, poate fi văzută ca învățarea unei astfel de reprezentări prin comprimarea (ratei de codare a) eșantioanelor date (zgomotoase) ale $(\x, \vw)$. Dacă distribuția datelor $\x$ este deja un amestec de Gaussiene (de dimensiune redusă), lucrarea \cite{wright2008classification} a arătat că clasificarea poate fi făcută eficient prin minimizarea directă a {\em lungimii de codare (cu pierderi)} asociată cu eșantioanele date.
+
+
+\subsection{Generarea de Imagini Condiționată de Clasă}\label{sub:cfg} 
+În timp ce un clasificator învățat ne permite să clasificăm o imagine dată $\x$ la
+clasa sa corespunzătoare, adesea am dori să generăm o imagine dintr-o clasă dată, prin
+eșantionarea distribuției învățate a imaginilor naturale. Într-o anumită măsură, aceasta poate fi
+văzută ca problema ``inversă'' a clasificării imaginilor. Fie $p_{\x}$ să denoteze
+distribuția imaginilor naturale, să zicem modelată printr-un proces de
+difuzie-denoising. Dată o variabilă aleatoare de etichetă de clasă $y \in [K]$ cu realizare $\nu$, să zicem
+un ``Măr'', am dori să eșantionăm distribuția condiționată $p_{\x \mid
+y}(\,\cdot\, \mid \nu)$ pentru a genera o imagine a unui măr:
+\begin{equation}
+  \hat{\x} \sim p_{\x\mid \y}(\,\cdot\, \mid \vnu).
+\end{equation}
+Numim aceasta {\em generare de imagini condiționată de clasă}.
+
+În \Cref{sec:conditioned-decoding}, am văzut cum să folosim paradigma de denoising-difuzie pentru
+eșantionarea condiționată din posteriorul $p_{\vx \mid \vy}$ date
+măsurători \textit{bazate pe model} $\vy = h(\vx) + \vw$
+(\Cref{eq:measurement-matching-observation}), culminând cu
+algoritmul DPS (\Cref{alg:iterative_denoising_conditional_DPS}). Acesta este un cadru puternic,
+dar nu se aplică problemei de generare de imagini condiționată de clasă (sau text)
+de aici, unde un model generativ explicit $h$ pentru
+observații/atribute $y$ nu este disponibil din cauza
+intractabilității modelării analitice. În această secțiune, vom prezenta tehnici pentru extinderea
+eșantionării condiționate la această setare.
+
+
+Astfel, presupunem acum doar că avem acces la eșantioane din distribuția comună
+a $(\vx, y)$:
+\begin{equation}
+  (\vx, y) \sim p_{\vx, y}.
+\end{equation}
+Ca în secțiunea anterioară, definim $\vx_t = \alpha_t \vx + \sigma_t \vg$
+cu $\vg \sim \cN(\Zero, \vI)$ independent de $(\vx, \vy)$, ca în
+\Cref{eq:gen_additive_gaussian_noise_model} în \Cref{ch:compression},
+și vom folosi în mod repetat notația $\vxi$ pentru a denota realizările lui $\vx$
+și $\vx_t$.
+
+Pentru a continua, observăm că dezvoltarea noastră a eșantionării condiționate sub
+măsurători $\vy = h(\vx) + \vw$ a folosit doar explicit
+modelul direct $h$ în realizarea aproximării DPS
+\eqref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}.
+În particular, descompunerea denoiser-ului posterior condiționat
+\eqref{eq:posterior-sampling-denoiser-decomposition} \textit{încă este valabilă în
+setarea datelor pereche}, în virtutea regulii lui Bayes
+și a independenței condiționate a $\vy$ și $\vx_t$ date $\vx$ (reamintiți
+\Cref{fig:posterior-sampling-cds}). Astfel putem încă scrie în setarea
+datelor pereche
+\begin{equation}\label{eq:conditional-denoising-mmse-denoiser-paired-data}
+  \bE[ \vx \mid \vx_t=\vxi, y=\nu]
+  =
+  \bE[\vx \mid \vx_t=\vxi] 
+  + \frac{\sigma_t^2}{\alpha_t} 
+  \nabla_{\vxi}\log p_{y \mid \vx_t}(\nu\mid \vxi).
+\end{equation}
+O idee naturală este atunci să implementăm direct termenul de corecție a verosimilității din
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data} folosind o rețea profundă
+$f_{\theta_{\mathrm{c}}}$ cu parametri $\theta_{\mathrm{c}}$, ca în
+\Cref{eq:classifier-with-class-token}: 
+\begin{equation}
+  f_{\theta_{\mathrm{c}}} : (t, \vx_t) \mapsto \softmax(\vW_{\mathrm{head}}
+  \vz(t, \vx_t)).
+\end{equation}
+Această expresie combină reprezentările finale $\vz(t, \vx_t)$ (care de asemenea depind de
+$\theta_{\mathrm{c}}$) ale intrărilor zgomotoase
+$\vx_t$ cu un cap de clasificare $\vW_{\mathrm{head}} \in \bR^{K \times d}$, care mapează
+reprezentările la o distribuție de probabilitate peste cele $K$ clase posibile.
+După cum este obișnuit în practică, ia de asemenea timpul $t$ din procesul de zgomot ca
+intrare.
+Astfel, cu antrenament adecvat, oferă o aproximare a log-verosimilității
+$\log p_{y \mid \vx_t}$, și diferențierea $\log f_{\theta_{\mathrm{c}}}$ cu
+privire la intrarea sa $\vx_t$
+permite o aproximare a celui de-al doilea termen din
+\Cref{eq:conditional-denoising-mmse-denoiser-paired-data}:
+\begin{equation}\label{eq:conditional-denoising-mmse-denoiser-paired-data-approx}
+  \bar{\vx}_{\theta}^{\mathrm{naive}}(t, \vx_t, y)
+  =
+  \bar{\vx}_{\theta_{\mathrm{d}}}(t, \vx_t)
+  + \frac{\sigma_t^2}{\alpha_t}
+  \nabla_{\vx_t}
+  \ip*{
+    \log f_{\theta_{\mathrm{c}}}(t, \vx_t)
+  }{
+    \ve_{y}
+  }
+\end{equation}
+unde, ca de obicei, aproximăm primul termen din
+\Cref{eq:conditional-denoising-mmse-denoiser-paired-data} prin un denoiser
+necondiționat învățat pentru $\vx_t$ cu parametri $\theta_{\mathrm{d}}$, și
+unde scriem $\ve_k$ pentru $k \in [K]$ pentru a denota al $k$-lea vector bază
+canonic pentru $\R^K$ (adică, vectorul cu
+un unu în poziția $k$ și zerouri în rest).
+Cititorul ar trebui să observe că denoiser-ul condiționat $\bar{\vx}_{\theta}$
+necesită două rulări separate de antrenament, cu pierderi separate: una pentru parametrii
+clasificatorului $\theta_{\mathrm{c}}$, pe o pierdere de
+clasificare,\footnote{În \Cref{ch:applications}, revizuim procesul de antrenare a unui astfel
+de clasificator în detaliu complet.} și una pentru parametrii denoiser-ului
+$\theta_{\mathrm{d}}$, pe o pierdere de denoising. O astfel de abordare a eșantionării
+condiționate a fost deja recunoscută și exploatată pentru a efectua eșantionarea condiționată în
+lucrări pioniere timpurii asupra modelelor de difuzie, în special cele de
+\citet{Sohl-Dickstein2015} și de \citet{song2020score}.
+
+
+Cu toate acestea, această metodologie directă are două dezavantaje cheie (motiv pentru care o
+etichetăm ca ``naivă''). Primul este
+că, empiric, un astfel de clasificator de rețea profundă antrenat frecvent nu
+oferă un semnal de ghidare suficient de puternic (în
+\Cref{eq:conditional-denoising-mmse-denoiser-paired-data}) pentru a asigura că
+eșantioanele generate reflectă informația de condiționare $y$. Acest lucru a fost subliniat
+pentru prima dată de \citet{Dhariwal2021-hg}, care au observat că în setarea
+generării ImageNet condiționate de clasă, ieșirile de probabilitate ale clasificatorului
+de rețea profundă învățat pentru clasa $y$ condiționată erau
+frecvent în jurul valorii de
+$0.5$---suficient de mari pentru a fi clasa dominantă, dar nu suficient de mari pentru a oferi
+un semnal de ghidare puternic---și că la inspecție, generările nu erau
+consistente cu clasa de condiționare $y$. \citet{Dhariwal2021-hg} au propus să
+abordeze aceasta euristic prin încorporarea unui hiperparametru de ``temperatură inversă''
+$\gamma > 0$
+în definiția denoiser-ului condiționat naiv
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data-approx}, referindu-se la
+denoiser-ul condiționat rezultat ca având încorporată ``ghidare prin clasificator''
+(CG):
+\begin{equation}\label{eq:conditional-denoising-mmse-denoiser-paired-data-approx-cg}
+  \bar{\vx}_{\theta}^{\mathrm{CG}}(t, \vx_t, y)
+  =
+  \bar{\vx}_{\theta_{\mathrm{d}}}(t, \vx_t)
+  + \gamma\frac{\sigma_t^2}{\alpha_t}
+  \nabla_{\vx_t}
+  \ip*{
+    \log f_{\theta_{\mathrm{c}}}(t, \vx_t)
+  }{
+    \ve_{y}
+  }
+\end{equation}
+cu cazul $\gamma = 1$ coincizând cu
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data-approx}.
+\citet{Dhariwal2021-hg} au găsit că o setare $\gamma > 1$ a funcționat cel mai bine empiric.
+O posibilă interpretare pentru aceasta este următoarea: observați că, în contextul
+termenului de verosimilitate \textit{adevărat}
+\Cref{eq:conditional-denoising-mmse-denoiser-paired-data}, scalarea cu $\gamma$
+dă în mod echivalent
+\begin{align}
+  \gamma\frac{\sigma_t^2}{\alpha_t} \nabla_{\vxi}\log p_{\vy \mid \vx_t}(\vnu\mid
+  \vxi)
+  &=
+  \frac{\sigma_t^2}{\alpha_t} \nabla_{\vxi}\log \left(
+  p_{\vy \mid \vx_t}(\vnu\mid \vxi)^\gamma
+  \right), %
+\end{align}
+ceea ce sugerează interpretarea naturală a parametrului $\gamma$ efectuând
+scalare de \textit{temperatură} (inversă) asupra verosimilității
+$p_{\vy \mid \vx_t}$, care este precisă dacă considerăm distribuția renormalizată
+$ { p_{\vy \mid \vx_t}(\vnu\mid \vxi)^\gamma } / { \int p_{\vy \mid \vx_t}(\vnu'\mid
+\vxi)^\gamma \odif \vnu' } $.
+Cu toate acestea, observați că aceasta \textit{nu este} o interpretare riguroasă în contextul
+\Cref{eq:conditional-denoising-mmse-denoiser-paired-data}, deoarece
+gradienții sunt luați cu privire la $\vxi$, iar constanta de normalizare în
+distribuția scalată în temperatură este în general o funcție de $\vxi$.
+În schimb, parametrul $\gamma$ ar trebui înțeles pur și simplu ca amplificând valorile
+mari ale probabilităților de ieșire ale clasificatorului de rețea profundă
+$f_{\theta_{\mathrm{c}}}(t, \vx_t)$ \textit{relativ la} cele mai mici,
+ceea ce amplifică efectiv semnalul de ghidare furnizat în cazurile în care rețeaua profundă
+$f$ îi atribuie cea mai mare probabilitate dintre cele $K$ clase.
+
+
+Cu toate acestea, ghidarea prin clasificator nu abordează al doilea dezavantaj cheie al
+metodologiei naive: este atât greoaie, cât și risipitoare să trebuiască să
+antrenezi un clasificator auxiliar $f_{\theta_{\mathrm{c}}}$ în plus față de denoiser-ul
+necondiționat $\bar{\vx}_{\theta_{\mathrm{d}}}$, dat fiind
+că nu este posibil să adaptezi direct un clasificator pre-antrenat
+din cauza necesității ca acesta să funcționeze bine pe intrări zgomotoase $\vx_t$ și să încorporeze
+alte modificări arhitecturale motivate empiric.
+În particular, \citet{Dhariwal2021-hg} au găsit că era necesar să proiecteze explicit
+arhitectura rețelei profunde care implementează clasificatorul pentru a se potrivi
+cu cea a denoiser-ului.
+Mai mult, dintr-o perspectivă pur practică---încercând să obțină cea mai bună
+performanță posibilă de la eșantionatorul rezultat---configurația cu cea mai bună performanță
+a eșantionării bazate pe ghidare prin clasificator se îndepărtează și mai mult de
+cadrul idealizat și solid conceptual pe care l-am prezentat mai sus.
+Pentru a obține cea mai bună performanță, \citet{Dhariwal2021-hg} au găsit că era
+necesar să furnizeze eticheta de clasă $y$ ca intrare suplimentară la denoiser-ul
+$\bar{\vx}_{\theta_{\mathrm{d}}}$. Ca rezultat, denoiser-ul idealizat ghidat prin clasificator
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data-approx-cg},
+derivat de \citet{Dhariwal2021-hg} așa cum am făcut noi mai sus din descompunerea
+denoiser-ului posterior condiționat
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data}, nu reflectă exact
+cel mai performant denoiser în practică---un astfel de denoiser
+combină de fapt un denoiser \textit{condiționat} pentru $\vx_t$ dat $y$ cu un
+semnal de ghidare suplimentar de la un clasificator auxiliar!
+
+Această stare de lucruri, motivată empiric cum este, l-a condus pe \citet{Ho2022-ry} în
+lucrări ulterioare să propună o metodologie mai pragmatică empiric, cunoscută sub numele de
+ghidare fără clasificator (CFG). În loc să reprezinte denoiser-ul condiționat
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data} ca o sumă ponderată
+a unui denoiser necondiționat pentru $\vx_t$ cu un termen de corecție log-verosimilitate
+(cu ponderi posibil modificate, ca în ghidarea prin clasificator), ei acceptă
+necesitatea aparentă de a antrena un denoiser condiționat pentru $\vx_t$ dat $y$, așa cum
+demonstrează rezultatele experimentale ale \citet{Dhariwal2021-hg}, și înlocuiesc
+termenul gradient log-verosimilitate cu o sumă corect ponderată a acestui
+denoiser condiționat cu un denoiser \textit{necondiționat} pentru $\vx$ dat
+$\vx_t$.\footnote{Acestea fiind spuse, \textcite{Ho2022-ry} au propus de fapt să folosească
+o ponderare diferită de cea pe care o prezentăm aici, bazată pe faptul că
+\textcite{Dhariwal2021-hg} au înlocuit euristic denoiser-ul necondiționat din
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data} cu
+un denoiser condiționat. De fapt, ponderarea pe care o derivăm și o prezentăm aici
+reflectă practica modernă și, în particular, este folosită în modelele de
+difuzie de ultimă generație precum Stable Diffusion 3.5
+\cite{DBLP:conf/icml/EsserKBEMSLLSBP24}.} Pentru a vedea cum apare această structură,
+începem cu o versiune `idealizată' a denoiser-ului de ghidare prin clasificator
+$\bar{\vx}_{\theta}^{\mathrm{CG}}$ definit în
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data-approx-cg},
+pentru care denoiser-ul $\bar{\vx}_{\theta_{\mathrm{d}}}$ și clasificatorul
+$f_{\theta_{\mathrm{c}}}$ aproximează perfect țintele lor, prin
+\eqref{eq:conditional-denoising-mmse-denoiser-paired-data}:
+\begin{equation}\label{eq:conditional-denoising-mmse-denoiser-paired-data-exact-cg}
+  \bar{\vx}_{\theta}^{\mathrm{CG,\,ideal}}(t, \vxi, \nu)
+  =
+  \bE[\vx \mid \vx_t=\vxi]
+  + \gamma\frac{\sigma_t^2}{\alpha_t}
+  \nabla_{\vxi}\log p_{y \mid \vx_t}(\nu\mid \vxi).
+\end{equation}
+Apoi folosim regula lui Bayes, în forma
+\begin{equation}
+  \log p_{y \mid \vx_t}
+  =
+  \log p_{\vx_t \mid y} + \log p_{y} - \log p_{\vx_t},
+\end{equation}
+împreună cu formula lui Tweedie (\Cref{thm:tweedie}, modificată ca în
+\Cref{eq:gen_tweedie}) pentru a converti între funcțiile scor și denoiser-e,
+pentru a obține
+\begin{align*}
+  \bar{\vx}_{\theta}^{\mathrm{CG,\,ideal}}(t, \vxi, \nu)
+  &=
+  \frac{1}{\alpha_t} \vxi 
+  + (1-\gamma) \frac{\sigma_t^2}{\alpha_t} 
+  \nabla_{\vxi}\log p_{\vx_t}(\vxi)
+  + \gamma \frac{\sigma_t^2}{\alpha_t} 
+  \nabla_{\vxi}\log p_{\vx_t \mid y}(\vxi \mid \nu)
+  \\
+  &=
+  (1 - \gamma) \bE[\vx \mid \vx_t=\vxi]
+  +
+  \gamma \bE[\vx \mid \vx_t=\vxi, y=\nu],
+  \labelthis\label{eq:ideal-cfg-denoiser}
+\end{align*}
+unde în ultima linie, aplicăm
+\Cref{eq:conditional-denoising-conditioning-order-irrelevant}.
+Acum, \Cref{eq:ideal-cfg-denoiser} sugerează o strategie naturală de aproximare: combinăm
+un denoiser necondiționat învățat pentru $\vx$ dat $\vx_t$, ca anterior,
+cu un denoiser \textit{condiționat} învățat pentru $\vx$ dat $\vx_t$ și $y$.
+
+
+Cu toate acestea, urmând \textcite{Ho2022-ry} și practica comună de antrenare a
+denoiser-elor de rețea profundă, este standard să folosim \textit{aceeași} rețea profundă pentru a reprezenta
+atât denoiser-ele condiționate, cât și cele necondiționate prin introducerea unei etichete
+suplimentare, pe care o vom denota cu $\varnothing$, pentru a denota cazul ``necondiționat''.
+Aceasta duce la forma denoiser-ului CFG:
+\begin{equation}\label{eq:conditional-denoising-mmse-denoiser-paired-data-approx-cfg}
+  \bar{\vx}_{\theta}^{\mathrm{CFG}}(t, \vx_t, y)
+  =
+  (1 - \gamma) \bar{\vx}_{\theta}(t, \vx_t, \varnothing)
+  +
+  \gamma \bar{\vx}_{\theta}(t, \vx_t, y).
+\end{equation}
+Pentru a antrena un denoiser $\bar{\vx}_{\theta}(t, \vx_t, y^+)$ pentru utilizare cu
+eșantionarea prin ghidare fără clasificator, unde $y^+ \in
+\set{1, \dots, K, \varnothing}$, procedăm aproape identic cu procedura de
+antrenare necondiționată din \Cref{alg:learning_denoiser}, dar cu două
+modificări:
+\begin{enumerate}
+  \item Când eșantionăm din setul de date, eșantionăm o pereche $(\vx, y)$ mai degrabă decât
+    doar un eșantion $\vx$.
+  \item De fiecare dată când eșantionăm o pereche din setul de date, eșantionăm eticheta
+    augmentată $y^+$ prin
+    \begin{equation}
+      y^+ = \begin{cases}
+        \varnothing & \text{cu probabilitate } p_{\mathrm{uncond}}; \\
+        y & \text{altfel}.
+      \end{cases}
+    \end{equation}
+    Aici, $p_{\mathrm{uncond}} \in [0, 1]$ este un nou hiperparametru.
+    Aceasta poate fi văzută ca o formă de dropout \cite{srivastava2014dropout}.
+\end{enumerate}
+În acest fel, antrenăm un denoiser condiționat potrivit pentru utilizare în eșantionarea
+prin ghidare fără clasificator. Rezumăm procesul general de eșantionare pentru
+eșantionarea condiționată de clasă cu ghidare fără clasificator în
+\Cref{alg:iterative_denoising_conditional_CFG}.
+
+
+\begin{algorithm}
+  \caption{Eșantionare condiționată cu date de clasificare, folosind denoiser condiționat de clasă.}
+	\label{alg:iterative_denoising_conditional_CFG}
+	\begin{algorithmic}[1]
+		\Require{O listă ordonată de pași de timp \(0 \leq t_{0} < \cdots < t_{L} \leq T\) de folosit pentru eșantionare.}
+    \Require{Eticheta de clasă $\nu \in \set{1, \dots, K}$ pe care să condiționăm.}
+    \Require{Un denoiser \(\bar{\vx}_{\theta} \colon
+    \{t_{\ell}\}_{\ell = 1}^{L} \times \R^{D} \times \set{1, \dots, K,
+    \varnothing} \to \R^{D}\) pentru $p_{\vx \mid y}$ și $p_{\vx}$ (intrare $\varnothing$ pentru
+    $p_{\vx}$).}
+		\Require{Funcțiile de scară și nivel de zgomot \(\alpha, \sigma \colon \{t_{\ell}\}_{\ell = 0}^{L} \to \R_{\geq 0}\).}
+    \Require{Puterea de ghidare $\gamma \geq 0$ ($\gamma > 1$ preferată pentru
+    performanță).}
+    \Ensure{Un eșantion \(\hat{\vx}\), aproximativ din \(p_{\vx \mid y}(\,\cdot\,
+    \mid \nu)\).}
+    \Function{DDIMSamplerConditionalCFG}{$\bar{\vx}_{\theta}, \nu, \gamma,
+    (t_{\ell})_{\ell = 0}^{L}$}
+		\State{Inițializează \(\hat{\vx}_{t_{L}} \sim\) distribuție aproximativă a \(\vx_{t_{L}}\)} \Comment{VP \(\implies \dNorm(\vzero, \vI)\), VE \(\implies \dNorm(\vzero, t_{L}^{2}\vI)\).}
+		\For{\(\ell = L, L - 1, \dots, 1\)}
+		\State{Calculează
+			\begin{equation*}
+				\hat{\vx}_{t_{\ell - 1}} \doteq \frac{\sigma_{t_{\ell
+        - 1}}}{\sigma_{t_{\ell}}}\hat{\vx}_{t_{\ell}} + \bp{\alpha_{t_{\ell
+        - 1}} - \frac{\sigma_{t_{\ell
+        - 1}}}{\sigma_{t_{\ell}}}\alpha_{t_{\ell}}}\bigl(
+        (1 - \gamma) \bar{\vx}_{\theta}(t_{\ell}, \hat{\vx}_{t_{\ell}}, \varnothing)
+        + \gamma \bar{\vx}_{\theta}(t_{\ell}, \hat{\vx}_{t_{\ell}}, \nu)
+        \bigr)
+			\end{equation*}
+		}
+		\EndFor
+		\State{\Return{\(\hat{\vx}_{t_{0}}\)}}
+		\EndFunction
+	\end{algorithmic}
+\end{algorithm}
+
+\textcite{Ho2022-ry} raportează performanță empirică puternică pentru generarea
+de imagini condiționată de clasă cu ghidare fără clasificator, și a devenit un element de bază al
+modelelor de difuzie practice la scară largă, cum ar fi Stable Diffusion
+\cite{rombach2022high} și derivatele sale.
+În același timp, derivarea sa este destul de opacă și motivată empiric,
+oferind puțină înțelegere în mecanismele din spatele performanței sale puternice.
+O serie de lucrări teoretice au studiat aceasta, oferind explicații pentru unele
+părți ale metodologiei CFG generale
+\cite{Bradley2024-jg,Li2025-li,Wu2024-js}---aceasta cuprinzând
+parametrizarea și antrenarea denoiser-ului, precum și configurarea puterii de ghidare
+și performanța la momentul eșantionării.
+Mai jos, vom da o interpretare în setarea simplificatoare
+a unei distribuții de date model de amestec Gaussian și denoiser, care va
+demonstra o înțelegere a \textit{parametrizării} denoiser-ului în prezența
+unor astfel de structuri de dimensiune redusă.
+
+
+\begin{example}\label{example:denoising-gaussian-mixture-cfg}
+  Să ne reamintim procesul de generare a datelor amestec de Gaussiene de rang redus pe care l-am studiat în
+  \Cref{example:denoising_gaussian_mixture} (și în mod specific, forma din
+  \Cref{eq:MoG1}). Date $K \in \bN$ clase, presupunem că
+  \begin{equation}\label{eq:MoG1-ch6}
+    \vx \sim \frac{1}{K}\sum_{k = 1}^{K}\dNorm(\vzero, \vU_{k}\vU_{k}^{\top}),
+  \end{equation}
+  unde fiecare \(\vU_{k} \in \O(D, P) \subseteq \R^{D \times P}\) este o matrice cu
+  coloane ortogonale, și $P \ll D$.
+  Mai mult, presupunem că eticheta de clasă $y \in [K]$ este o funcție deterministă
+  a $\vx$ care mapează un exemplu la componenta sa de amestec corespunzătoare.
+  Aplicând analiza din \Cref{example:denoising_gaussian_mixture} (și
+  analiza ulterioară a cazului de rang redus, culminând în
+  \Cref{eq:gmm_lowrank_denoiser}), obținem pentru denoiser-ele optime
+  condiționate de clasă
+  \begin{equation}\label{eq:gmm_lowrank_denoiser-ch6-classcond}
+    \bE[ \vx \mid \vx_t = \vxi, y = \nu ]
+    = \frac{1}{1 + t^{2}}
+    \vU_{\nu}\vU_{\nu}^{\top}\vxi
+  \end{equation}
+  pentru fiecare $\nu \in [K]$, și pentru denoiser-ul optim necondiționat, obținem
+  \begin{equation}\label{eq:gmm_lowrank_denoiser-ch6-uncond}
+    \bE[ \vx \mid \vx_t = \vxi ]
+    = \frac{1}{1 + t^{2}}\sum_{k = 1}^{K}\frac{\exp\rp{\frac{1}{2t^{2}(1 + t^{2})}\norm{\vU_{k}^{\top}\vxi}_{2}^{2}}}{\sum_{i = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1 + t^{2})}\norm{\vU_{i}^{\top}\vxi}_{2}^{2}}}\vU_{k}\vU_{k}^{\top}\vxi.
+  \end{equation}
+  Ca rezultat, putem exprima denoiser-ul CFG cu putere de ghidare $\gamma
+  > 1$ ca
+  \begin{equation}\label{eq:cfg-denoiser-mog-low-rank}
+    \bar{\vx}^{\mathrm{CFG,\,ideal}}(t, \vx_t, y)
+    =
+    \frac{1}{1 + t^{2}}
+    \left(
+    (1 - \gamma) 
+    \sum_{k = 1}^{K}\frac{\exp\rp{\frac{1}{2t^{2}(1
+    + t^{2})}\norm{\vU_{k}^{\top}\vx_t}_{2}^{2}}}{\sum_{i
+    = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+    + t^{2})}\norm{\vU_{i}^{\top}\vx_t}_{2}^{2}}}\vU_{k}\vU_{k}^{\top}
+    +
+    \gamma 
+    \vU_{y}\vU_{y}^{\top}
+    \right)
+    \vx_t.
+  \end{equation}
+  Acest denoiser are o formă simplă, interpretabilă. Primul termen, corespunzând
+  denoiser-ului necondiționat, efectuează denoising-ul semnalului $\vx_t$
+  față de o medie a denoiser-elor asociate cu fiecare subspațiu, ponderată de
+  cât de corelat este $\vx_t$ cu fiecare subspațiu. Al doilea termen, corespunzând
+  denoiser-ului condiționat, efectuează pur și simplu denoising cu denoiser-ul
+  clasei de condiționare. Schema CFG mediază în continuare aceste două denoiser-e:
+  efectul poate fi înțeles din refactorizarea
+  \begin{equation}\label{eq:cfg-denoiser-mog-low-rank-2}
+    \begin{split}
+      \bar{\vx}^{\mathrm{CFG,\,ideal}}(t, \vx_t, y)
+      =
+      \frac{1}{1 + t^{2}}
+      &\Biggl(
+      \left[\gamma + (1 - \gamma) 
+      \frac{\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{y}^{\top}\vx_t}_{2}^{2}}}{\sum_{i
+      = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{i}^{\top}\vx_t}_{2}^{2}}}
+      \right]
+      \vU_{y}\vU_{y}^{\top}
+      \\
+      &\quad+
+      (1 - \gamma) 
+      \sum_{k \neq y}\frac{\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{k}^{\top}\vx_t}_{2}^{2}}}{\sum_{i
+      = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{i}^{\top}\vx_t}_{2}^{2}}}\vU_{k}\vU_{k}^{\top}
+      \Biggr)
+      \vx_t.
+    \end{split}
+  \end{equation}
+  Avem
+  \begin{equation}
+    \sum_{k=1}^K
+    \frac{\exp\rp{\frac{1}{2t^{2}(1
+    + t^{2})}\norm{\vU_{k}^{\top}\vx_t}_{2}^{2}}}{\sum_{i
+    = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+    + t^{2})}\norm{\vU_{i}^{\top}\vx_t}_{2}^{2}}}
+    = 1,
+  \end{equation}
+  și fiecare termen din sumă este nenegativ, deci de asemenea mărginit superior de $1$.
+  Deci putem concluziona două regimuri pentru termenii din
+  \Cref{eq:cfg-denoiser-mog-low-rank-2}: 
+  \begin{enumerate}
+    \item \textbf{Regim bine corelat:} Dacă $\vx_t$ se corelează bine cu
+      $\vU_y$, atunci ponderea normalizată corespunzătoare termenului $k=y$ din sumă în
+      denoiser-ul necondiționat este aproape de $1$. 
+      Atunci 
+      \begin{equation}
+        \gamma + (1 - \gamma) 
+      \frac{\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{y}^{\top}\vx_t}_{2}^{2}}}{\sum_{i
+      = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{i}^{\top}\vx_t}_{2}^{2}}}
+        \approx 1,
+      \end{equation}
+      toate celelalte ponderi sunt în mod necesar aproape de zero, iar denoiser-ul CFG
+      este aproximativ egal cu denoiser-ul asociat clasei de
+      condiționare $y$.
+    \item \textbf{Regim slab corelat:} În contrast, dacă $\vx_t$
+      \textit{nu} se corelează bine cu $\vU_y$ (să zicem pentru că $t$ este mare),
+      atunci ponderea normalizată corespunzătoare termenului $k=y$ din sumă în
+      denoiser-ul necondiționat este aproape de $0$. Ca rezultat, 
+      \begin{equation}
+        \gamma + (1 - \gamma) 
+      \frac{\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{y}^{\top}\vx_t}_{2}^{2}}}{\sum_{i
+      = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\norm{\vU_{i}^{\top}\vx_t}_{2}^{2}}}
+        \approx \gamma,
+      \end{equation}
+      și astfel puterea de ghidare $\gamma \gg 1$ plasează o pondere pozitivă mare
+      pe denoiser-ul asociat cu $y$.
+      Între timp, în al doilea termen din \Cref{eq:cfg-denoiser-mog-low-rank-2},
+      orice clase $k \neq y$ care sunt bine corelate cu $\vx_t$ 
+      primesc o pondere \textit{negativă} mare de la
+      coeficientul $1 - \gamma$.
+      Aceasta are simultan efectul de a face semnalul de denoising mult
+      mai corelat cu clasa de condiționare $y$, și de a-l face negativ
+      corelat cu iteratul anterior (adică, iteratul înainte de denoising).
+      Cu alte cuvinte, CFG direcționează procesul de denoising iterativ către
+      clasa de condiționare și departe de iteratul anterior, o dinamică diferită
+      de eșantionarea pur condiționată (adică, cazul $\gamma = 1$).
+  \end{enumerate}
+
+  Efectuăm acum o analiză suplimentară a formei acestui denoiser ghidat pentru
+  a face unele inferențe despre rolul CFG. Multe dintre aceste perspective
+  vor fi relevante și pentru distribuțiile de date \textit{generale} cu
+  structură geometrică de dimensiune redusă.
+  Mai întâi, observați că denoiser-ul CFG \eqref{eq:cfg-denoiser-mog-low-rank}
+  ia o formă simplă în setarea unde $\vx_t$ se corelează semnificativ mai
+  puternic cu un singur subspațiu $\vU_y$ decât cu oricare alt $\vU_{y'}$. Într-adevăr,
+  deoarece raportul ponderilor în denoiser-ul condiționat de clasă este dat de
+  \begin{equation}
+    \frac{
+      \exp\rp{\frac{1}{2t^{2}(1 + t^{2})}\norm{\vU_{y}^{\top}\vx_t}_{2}^{2}}
+    }{
+      \exp\rp{\frac{1}{2t^{2}(1 + t^{2})}\norm{\vU_{y'}^{\top}\vx_t}_{2}^{2}}
+    }
+    =
+    \exp\rp{
+      \frac{1}{2t^{2}(1 + t^{2})}\left(
+      \norm{\vU_{y}^{\top}\vx_t}_{2}^{2}
+      -
+      \norm{\vU_{y'}^{\top}\vx_t}_{2}^{2}
+      \right)
+    },
+  \end{equation}
+  o separare mare între corelația lui $\vx_t$ cu $\vU_{y}$ și alte
+  subspații $\vU_{y'}$ implică că suma peste $k$ se concentrează pe termenul $k=y$,
+  dând că \textit{denoiser-ul CFG rămâne egal cu denoiser-ul
+  condiționat de clasă}. Mai mult, când $t \approx 0$, magnitudinea
+  oricărei astfel de diferențe este amplificată în exponențială, făcând această concentrare pe
+  termenul $k=y$ și mai puternică. În particular, pentru timpi mici $t$ (adică, aproape de
+  suportul distribuției datelor), denoising-ul CFG nu este diferit de
+  denoising-ul standard condiționat de clasă---implicând că va converge stabil
+  odată ce a ajuns la o astfel de configurație.
+  Astfel, beneficiile empirice ale CFG ar trebui să se datoreze comportamentului său în cazurile
+  în care $\vx_t$ nu este neambiguu dintr-o singură clasă.
+
+  În continuare, considerăm problema parametrizării unui denoiser învățabil
+  $\vx_{\theta}^{\mathrm{CFG}}$ pentru a reprezenta denoiser-ul optim
+  \eqref{eq:cfg-denoiser-mog-low-rank}.
+  Aici, poate părea inițial că setarea clasificării unei distribuții de amestec
+  este prea mult un caz special relativ la învățarea distribuțiilor practice de date,
+  deoarece denoiser-ul ideal \eqref{eq:cfg-denoiser-mog-low-rank} are
+  în această setare forma simplă a unei \textit{atribuiri dure} a
+  semnalului zgomotos $\vx_t$ la (denoiser-ul asociat cu) subspațiul $\vU_y$
+  corespunzător etichetei de clasă adevărate $y$ a lui $\vx$, mediat cu
+  denoiser-ul de \textit{atribuire soft} asociat cu toate subspațiile $\vU_k$, cu
+  ponderi date de corelațiile lui $\vx_t$ cu aceste diferite subspații.
+  Cu toate acestea, putem extrage o formă mai generală pentru denoiser-ul condiționat de clasă
+  în acest exemplu, care este relevantă pentru parametrizarea practică folosind
+  structura geometrică a distribuției amestecului de Gaussiene, care de fapt
+  paralelizează tipurile de structură geometrică comune în datele din lumea reală.
+  Mai precis, adăugăm o ipoteză suplimentară asociată cu subspațiile
+  $\vU_k$ fiind `distingibile' unele de altele, ceea ce este natural în
+  practică: în mod specific, presupunem că pentru orice pereche de indici $k, k' \in
+  [K]$ cu $k \neq k'$, putem găsi un set de $K$ direcții $\vv_{k} \in \bR^D$ astfel încât
+  \begin{equation}
+    \vU_{k}\vU_{k}^\top \vv_k = \vv_k, \quad
+    \vU_{k'}\vU_{k'}^\top \vv_k = \Zero, \enspace k' \neq k.
+  \end{equation}
+  Aceasta este o ipoteză puțin mai puternică decât simpla distingibilitate, dar ar trebui
+  notat că nu este excesiv de restrictivă: de exemplu, încă
+  permite subspațiilor $\vU_{k}$ să aibă corelații semnificative unele cu
+  altele.\footnote{ Mai general, această ipoteză este formulată natural ca o
+  \textit{condiție de incoerență} între subspațiile $\vU_{[K]}$, o noțiune familiară
+  din teoria detecției compresive.}
+  Acești vectori $\vv_k$ pot fi apoi gândiți ca \textit{încorporări} ale
+  etichetei de clasă $y \in [K]$, și le putem folosi pentru a defini un operator mai general
+  care poate reprezenta atât denoiser-ele necondiționate, cât și cele condiționate de clasă.
+  Mai precis, considerați maparea
+  \begin{equation}\label{eq:mog-conditional-denoising-unified-operator}
+    (\vx_t, \vv) \mapsto
+    \sum_{k = 1}^{K}\frac{
+      \exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vU_k \vU_k^\top \vv}
+    }
+    {
+      \sum_{i
+      = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vU_i \vU_i^\top \vv}
+    }
+    \vU_{k}\vU_{k}^{\top}\vx_t.
+  \end{equation}
+  Dacă înlocuim $\vv = \vv_y$ pentru un anumit $y \in [K]$, obținem
+  \begin{align}
+    \begin{split}
+    \sum_{k = 1}^{K}
+    \frac{
+      \exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vU_k \vU_k^\top \vv_y}
+    }
+    {
+      \sum_{i
+      = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vU_i \vU_i^\top \vv_y}
+    }
+    \vU_{k}\vU_{k}^{\top}\vx_t
+    &=
+    \frac{
+      \exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vv_y}
+    }
+    {
+      \exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vv_y}
+      + K-1
+    }
+    \vU_{y}\vU_{y}^{\top}\vx_t
+    \\
+    &\quad+
+    \sum_{k \neq y}
+    \frac{
+      1
+    }
+    {
+      \exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vv_y}
+      + K-1
+    }
+    \vU_{k}\vU_{k}^{\top}\vx_t.
+    \end{split}
+  \end{align}
+  Acum, deoarece $\vx_t = \alpha_t \vx + \sigma_t \vg$, dacă dimensiunea subspațiului
+  $P$ este suficient de mare---de exemplu, dacă considerăm un regim asimptotic
+  la scară largă unde $P, D \to \infty$ cu raportul lor $P/D$ convergând la
+  o constantă fixă---avem pentru $t \approx 0$ că $\norm{\vx_t}_2$ este aproape de
+  $\sqrt{P}$, prin fenomenul de concentrare a măsurii\footnote{Una dintre
+  puținele \textit{binecuvântări ale dimensionalității}---vezi
+  \textcite{Wright-Ma-2022}.}. Atunci
+  prin argumentul din paragraful anterior, avem în acest regim că pentru
+  \textit{aproape toate} realizările lui $\vx_t$, următoarea aproximare
+  este valabilă:
+  \begin{equation}
+    \sum_{k = 1}^{K}
+    \frac{
+      \exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vU_k \vU_k^\top \vv_y}
+    }
+    {
+      \sum_{i
+      = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+      + t^{2})}\vx_t^\top \vU_i \vU_i^\top \vv_y}
+    }
+    \vU_{k}\vU_{k}^{\top}\vx_t
+    \approx
+    \vU_{y}\vU_{y}^{\top}\vx_t.
+  \end{equation}
+  Acest argument arată că operatorul
+  \eqref{eq:mog-conditional-denoising-unified-operator} este, cu probabilitate covârșitoare,
+  \textit{egal cu denoiser-ul optim condiționat de clasă
+  \eqref{eq:gmm_lowrank_denoiser-ch6-classcond} pentru $y$
+  când $\vv = \vv_y$}! În termeni intuitivi, la niveluri mici de zgomot $t \approx
+  0$---corespunzând porțiunii de impunere a structurii din procesul de
+  denoising---introducerea încorporării pentru o clasă dată $y$ în al doilea
+  argument al operatorului \eqref{eq:mog-conditional-denoising-unified-operator}
+  face ca funcția rezultată de $\vx_t$ să aproximeze bine denoiser-ul optim
+  condiționat de clasă \eqref{eq:gmm_lowrank_denoiser-ch6-classcond} pentru
+  $y$. Mai mult, este evident că introducerea $\vv = \vx_t$ în operatorul
+  \eqref{eq:mog-conditional-denoising-unified-operator} produce (exact) denoiser-ul
+  optim necondiționat \eqref{eq:gmm_lowrank_denoiser-ch6-uncond} pentru $\vx_t$.
+  Astfel, acest operator oferă o modalitate unificată de a parametriza operatorii
+  constituenți în denoiser-ul optim pentru $\vx$ \textit{într-o singură
+  `rețea'}: este suficient să adăugăm ieșirea unei instanțieri a
+  \eqref{eq:mog-conditional-denoising-unified-operator} cu intrare $(\vx_t,
+  \vx_t)$ la o instanțiere cu intrare $(\vx_t, \vv_y$). Operatorul rezultat
+  este o funcție de $(\vx_t, y)$, iar computațional, subspațiile
+  $(\vU_k)_{k=1}^K$ și încorporările $y \mapsto \vv_y$ devin parametrii săi învățabili.
+\end{example}
+
+\Cref{example:denoising-gaussian-mixture-cfg} arată că în cazul special al
+unei distribuții de date amestec de Gaussiene de rang redus pentru $\vx$ cu
+componente incoerente, operatorii de forma
+\begin{equation}\label{eq:operator-for-parameterizing-cfg-denoiser-mog}
+  (\vx_t, \vv) \mapsto
+  \sum_{k = 1}^{K}\frac{
+    \exp\rp{\frac{1}{2t^{2}(1
+    + t^{2})}\vx_t^\top \vU_k \vU_k^\top \vv}
+  }
+  {
+    \sum_{i
+    = 1}^{K}\exp\rp{\frac{1}{2t^{2}(1
+    + t^{2})}\vx_t^\top \vU_i \vU_i^\top \vv}
+  }
+  \vU_{k}\vU_{k}^{\top}\vx_t
+\end{equation}
+oferă o clasă de operatori suficient de bogată pentru a parametriza denoiser-ul
+optim MMSE pentru observații zgomotoase $\vx_t$ ale lui $\vx$, în setarea
+ghidării fără clasificator unde o rețea urmează să fie folosită pentru a reprezenta atât
+denoiser-ele necondiționate, cât și cele condiționate de clasă pentru $\vx_t$. Pentru astfel de operatori,
+intrarea auxiliară $\vv$ poate fi luată fie ca $\vx_t$, fie ca o încorporare adecvată
+a etichetei de clasă $y \mapsto \vv_y$ pentru a realiza un astfel de denoiser.
+Bazat pe cadrul din \Cref{ch:unrolling}, care dezvoltă arhitecturi de rețea profundă
+adecvate pentru transformarea distribuțiilor de date mai generale în
+reprezentări structurate folosind modelul amestec de Gaussiene de rang redus ca
+o primitivă, este natural să ne imaginăm că operatorii de tipul
+\eqref{eq:operator-for-parameterizing-cfg-denoiser-mog} pot fi valorificați în
+denoiser-e pentru
+distribuții de date generale $\vx$ cu componente structurate geometric de dimensiune
+redusă care sunt suficient de distingibile (să zicem, incoerente) unele de
+altele.
+Secțiunea următoare demonstrează că acesta este într-adevăr cazul.
+
+
+
+\subsection{Generarea de Imagini Condiționată de Legendă}\label{sub:text-cond}
+
+În subsecțiunea anterioară, am formulat denoiser-e pentru denoising condiționat
+de clasă cu ghidare fără clasificator, o metodologie practică omniprezentă folosită
+în modelele de difuzie la scară mare, și am arătat cum să le parametrizăm (în
+\Cref{example:denoising-gaussian-mixture-cfg}) în cazul special al unei distribuții de date
+model de amestec Gaussian de rang redus.
+Un produs secundar interesant al acestui exemplu este că evidențiază rolul crucial
+al \textit{încorporărilor} etichetei de clasă $y$ într-un spațiu comun cu imaginea $\vx$ pentru
+a oferi o schemă concisă și unificată pentru parametrizarea denoiser-elor
+optime (condiționate și necondiționate).
+Mai jos, vom descrie o astfel de instanțiere timpurie, care
+a format baza pentru implementarea originală open-source Stable Diffusion
+\cite{rombach2022high}.
+În această setare, încorporarea și condiționarea ulterioară este efectuată nu pe
+o etichetă de clasă, ci pe un prompt text, care descrie conținutul dorit al imaginii
+(\Cref{fig:text-to-image}). Denotăm promptul text tokenizat brut ca $\vY \in
+\bR^{D_{\mathrm{text}} \times N}$ în acest context, deoarece corespunde unei secvențe de
+vectori---în \Cref{sec:clm_text}, descriem procesul de codare a unei secvențe
+text ca o reprezentare vectorială în detaliu.
+
+\begin{figure}[tbp]
+  \centering
+  \begin{subfigure}{0.47\textwidth}
+    \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/tti-train.pdf}
+    \caption{}
+  \end{subfigure}
+  \hfill
+  \begin{subfigure}{0.47\textwidth}
+    \includegraphics[width=\linewidth]{\toplevelprefix/chapters/chapter6/figs/tti-inf.pdf}
+    \caption{}
+  \end{subfigure}
+
+  \caption{O schemă de nivel înalt a antrenării și aplicării unui model generativ
+  text-la-imagine, prin generare condiționată cu un prompt text. \textbf{Stânga:}
+  Pentru a antrena un model text-la-imagine, se folosește un set mare de date de imagini pereche cu
+  legende text corespunzătoare. Un codificator este folosit pentru a mapa legendele la
+  secvențe de vectori, care sunt folosite ca semnale de condiționare pentru un denoiser
+  condiționat, antrenat așa cum este descris în \Cref{sub:cfg}. Codificatorul de text poate fi
+  pre-antrenat și înghețat, sau antrenat în comun cu denoiser-ul. \textbf{Dreapta:}
+  Când se aplică un model antrenat, un prompt text dorit este folosit ca condiționare,
+  apoi se efectuează eșantionarea cu modelul antrenat, ca în
+  \Cref{alg:iterative_denoising_conditional_CFG} (\textit{mutatis mutandis} pentru
+  utilizare cu un prompt text codat). Pentru detalii complete ale procesului de codare
+  a textului într-o secvență de vectori, vezi \Cref{sec:clm_text}.}
+  \label{fig:text-to-image}
+\end{figure}
+
+Stable Diffusion urmează metodologia de generare condiționată pe care o conturăm în
+\Cref{sub:cfg}, cu două modificări cheie: (i) Semnalul de condiționare este un
+prompt text tokenizat $\vY$, mai degrabă decât o etichetă de clasă; (ii) Denoising-ul imaginii este
+efectuat în spațiul ``latent'' mai degrabă decât pe pixeli bruti, folosind o pereche specializată,
+pre-antrenată de autocodor variațional $f : \bR^{D_{\mathrm{img}}} \to
+\bR^{d_{\mathrm{img}}}$, $g : \bR^{d_{\mathrm{img}}} \to
+\bR^{D_{\mathrm{img}}}$ (vezi \Cref{sec:vae}), unde $f$
+este codificatorul și $g$ este decodificatorul. Dezvoltarea ulterioară a modelului a arătat că
+punctul (ii) este o problemă de eficiență, mai degrabă decât una conceptuală de bază, așa că nu ne vom
+concentra pe ea, altfel decât să menționăm că duce pur și simplu la următoarele
+modificări simple ale conductei text-la-imagine schițate în
+\Cref{fig:text-to-image}: 
+\begin{enumerate}
+  \item \textbf{La momentul antrenării},
+    codificatorul $f : \vx \mapsto \vz$ este folosit pentru a genera țintele de denoising, și
+    tot denoising-ul este efectuat pe reprezentările codate $\vz_t \in
+    \bR^{d_{\mathrm{img}}}$;
+  \item \textbf{La momentul generării}, eșantionarea este efectuată pe
+    reprezentările $\hat{\vz}_t$, și
+    imaginea finală este generată prin aplicarea decodificatorului $g(\hat{\vz}_0)$.
+\end{enumerate}
+În contrast, problema (i) este esențială, iar abordarea propusă pentru a o aborda
+reprezintă una dintre inovațiile metodologice durabile ale
+\textcite{rombach2022high}.
+În contextul cadrului de denoising condiționat iterativ pe care l-am
+dezvoltat în \Cref{sub:cfg}, aceasta privește parametrizarea denoiser-elor
+$\bar{\vz}_{\theta}(t, \vz_t, \vY^+)$.\footnote{În setarea condiționării pe text,
+eticheta `augmentată' $\vY^+$, care este fie promptul text codat,
+fie $\varnothing$, denotând denoising necondiționat, este adesea implementată
+prin maparea $\varnothing$ la șirul gol ``'', apoi codarea acestui prompt
+text cu tokenizatorul ca de obicei. Aceasta oferă o modalitate simplă și unificată de a trata
+denoising-ul condiționat și necondiționat cu condiționare pe text.}
+\textcite{rombach2022high} implementează condiționarea pe text în denoiser folosind
+un strat cunoscut sub numele de atenție încrucișată, inspirat de arhitectura originală
+transformer codificator-decodificator a \textcite{vaswani2017attention}. Atenția încrucișată este
+implementată după cum urmează. Notăm $\tau : \bR^{D_{\mathrm{text}} \times N} \to
+\bR^{d_{\mathrm{model}} \times N_{\mathrm{text}}}$
+o rețea de codare pentru încorporările text (adesea un transformer
+cauzal---vezi \Cref{sec:clm_text}), și notăm $\psi : \bR^{d_{\mathrm{img}}}
+\to \bR^{d_{\mathrm{model}} \times N_{\mathrm{img}}}$ maparea corespunzătoare uneia dintre
+reprezentările intermediare în denoiser.\footnote{În practică,
+denoiser-ele condiționate pe text adaugă straturi de atenție încrucișată la intervale regulate
+în cadrul trecerii directe a denoiser-ului, deci $\psi$ ar trebui văzut ca
+dependent de strat, în contrast cu $\tau$. Vezi \textcite{rombach2022high} pentru
+detalii.} Aici, $N_{\mathrm{text}}$ este lungimea maximă a promptului text tokenizat,
+și $N_{\mathrm{img}}$ corespunde aproximativ numărului de canale de imagine
+(dependent de strat) în reprezentare, care este fix dacă rezoluția imaginii de intrare este fixă. Atenția încrucișată (cu $K$ capete, și fără bias) este definită ca
+    \begin{equation}
+      \mathrm{MHCA}(\vz_t, \vY^+) \label{eq:mhca}
+        = \vU_{\out}\mat{\SA([\vU_{\query}^{1}]^{\top}\psi(\vz_t),
+        [\vU_{\attnkey}^{1}]^{\top}\tau(\vY^+), [\vU_{\val}^{1}]^{\top}\tau(\vY^+)) \\ \vdots \\
+        \SA([\vU_{\query}^{K}]^{\top}\psi(\vz_t),
+        [\vU_{\attnkey}^{K}]^{\top}\tau(\vY^+),
+        [\vU_{\val}^{K}]^{\top}\tau(\vY^+))}, %
+    \end{equation}
+unde $\mathrm{SA}$ denotă operația omniprezentă de auto-atenție
+în transformer (pe care o reamintim în detaliu în \Cref{ch:applications}: vezi
+\Cref{eq:mhsa,eq:self_attention}), și $\vU_{*}^{k} \in \bR^{d_{\mathrm{model}}\times
+d_{\mathrm{attn}} }$ pentru $* \in \set{\mathrm{qry}, \mathrm{key}, \mathrm{val}}$
+(precum și proiecția de ieșire $\vU_{\mathrm{out}}$) sunt parametrii
+învățabili ai stratului.
+
+Observați că, prin definiția operației de auto-atenție, atenția încrucișată
+\textit{produce combinații liniare ale încorporărilor text proiectate pe valoare
+ponderate de corelațiile dintre caracteristicile imaginii și încorporările text.}
+În arhitectura denoiser-ului folosită de \textcite{rombach2022high}, 
+blocurile reziduale de auto-atenție din arhitectura denoiser-ului, aplicate la
+reprezentarea imaginii la stratul curent și definite analog
+celor din \Cref{eq:vit-res-block} pentru transformerul de viziune, sunt urmate de blocuri
+reziduale de atenție încrucișată de forma \eqref{eq:mhca}.
+O astfel de structură necesită ca codificatorul de text $\tau$ să, într-un anumit sens, împărtășească o anumită
+structură în ieșirea sa cu încorporarea caracteristicilor imaginii $\psi$: aceasta poate fi
+impusă fie prin pre-antrenare comună adecvată text-imagine (cum ar fi cu CLIP
+\cite{Radford2021-ir}), fie prin antrenare comună cu
+denoiser-ul însuși (care a fost propusă și demonstrată de
+\textcite{rombach2022high}, dar a căzut în dizgrație din cauza costurilor ridicate de date și
+antrenare pentru performanță puternică).
+Conceptual, acest spațiu comun de încorporare text-imagine și stratul de atenție încrucișată
+în sine au o asemănare puternică cu
+denoiser-ul condiționat de amestec de Gaussiene pe care l-am derivat în secțiunea
+anterioară (reamintiți \eqref{eq:mog-conditional-denoising-unified-operator}), în
+cazul special al unei secvențe cu un singur token. Conexiuni mai profunde
+pot fi trasate în setarea multi-token urmând cadrul de reducere a ratei
+pentru derivarea arhitecturilor de rețea profundă discutat în
+\Cref{ch:unrolling}, și manifestat în derivarea arhitecturii CRATE
+asemănătoare transformer-ului.
+
+Același design de bază a fost scalat în continuare la dimensiuni și mai mari de model și set de date,
+în particular în instanțierile moderne ale Stable Diffusion
+\cite{DBLP:conf/icml/EsserKBEMSLLSBP24}, precum și în modele concurente precum
+FLUX.1 \cite{Labs2025-fb}, Imagen \cite{Saharia2022-na} și DALL-E \cite{Ramesh2022-nu}. 
+Mecanismul de condiționare al atenției încrucișate a devenit de asemenea omniprezent în
+alte aplicații, ca în EgoAllo (\Cref{sub:ego-allo}) pentru generarea condiționată de poză și în Michelangelo \cite{zhao2023michelangelo} pentru generarea condiționată de forme 3D bazată pe imagini sau texte.
+
+
+
+
+
+
+\section{Inferență Condiționată cu Auto-Consistență a Măsurătorilor}
+\label{sec:measurement-self-consistency}
+În această ultimă secțiune, considerăm cazul mai extrem, dar de fapt omniprezent, pentru învățarea distribuției în care avem doar un set de eșantioane observate $\Y = \{\y_1,\ldots, \y_N\}$ ale datelor $\x$, dar niciun eșantion direct al lui $\x$! În general, observația $\y \in \mathbb{R}^d$ este de dimensiune mai mică decât $\x \in \mathbb{R}^D$. Pentru a face problema bine definită, presupunem că modelul de observație dintre $\y$ și $\x$ este cunoscut ca aparținând unei anumite familii de modele analitice, notate ca $\y = h(\x, \theta) +\vw$, cu $\theta$ fie cunoscut, fie necunoscut.
+
+Să încercăm mai întâi să înțelegem problema conceptual cu cazul simplu când funcția de măsurare $h$ este cunoscută și $\y = h(\x) + \vw$ observat este informativ despre $\x$. Adică, presupunem că $h$ este surjectivă de la spațiul lui $\x$ la cel al lui $\y$ și suportul distribuției $\y_0 = h(\x_0)$ este de dimensiune redusă. Aceasta necesită de obicei ca dimensiunea \textit{extrinsecă} $d$ a lui $\y$ să fie mai mare decât dimensiunea \textit{intrinsecă} a suportului distribuției lui $\x$. Fără pierderea generalității, putem presupune că există funcții:
+\begin{equation}
+F(\x) = \boldsymbol{0},\quad     G(\y) = \boldsymbol{0}.
+\end{equation}
+Observați că aici putem presupune că cunoaștem $G(\y)$ dar nu $F(\x)$. Fie $\mathcal{S}_{\y} \doteq \{\y \mid G(\y) = \boldsymbol{0}\}$ suportul lui $p(\y)$. În general, $h^{-1}(\mathcal{S}_{\y}) = \{\x \mid G(h(\x)) = \boldsymbol{0}\}$ este o supramulțime a $\mathcal{S}_{\x} \doteq \{\x \mid F(\x) = \boldsymbol{0}\}$. Adică, avem $h(\mathcal{S}_{\x}) \subseteq \mathcal{S}_{\y}$.
+
+
+
+\subsection{Modele de Măsurare Liniare}
+Mai întâi, pentru simplitate, să considerăm că măsurătoarea este o funcție liniară a datelor $\x$ de interes:
+\begin{equation}
+    \y = \vA\x.
+\end{equation}
+Aici matricea $\vA \in \mathbb{R}^{m\times n}$ este de rang complet pe rânduri și $m$ este de obicei mai mic decât $n$. Presupunem că $\vA$ este cunoscut deocamdată. Suntem interesați de cum să învățăm distribuția lui $\x$ din astfel de măsurători. Deoarece nu mai avem eșantioane directe ale lui $\x$, ne întrebăm dacă putem încă dezvolta un denoiser pentru $\x$ cu observații $\y$. Să considerăm următorul proces de difuzie:
+\begin{equation}
+    \y_t = \y_0 + t \vg, \quad \y_0 = \vA(\x_0), 
+\end{equation}
+unde $\vg \sim \mathcal{N}(\boldsymbol{0}, \vI)$.
+
+
+
+Fără pierderea generalității, presupunem că $\vA$ este de rang complet pe rânduri, adică subdeterminat. Să definim procesul corespunzător $\x_t$ ca unul care satisface:
+\begin{equation}
+\y_t = \vA \x_t.   
+\end{equation}
+
+Din procesul de denoising al lui $\y_t$, avem
+\begin{equation}
+    \y_{t-s} \approx  \y_t + st \nabla \log p_t(\y_t).
+\end{equation}
+Atunci avem:
+\begin{equation}
+    \vA\x_{t-s} \approx   \vA\x_t + st \nabla \log p_t(\vA \x_t),
+\end{equation}
+pentru un $s >0$ mic. Deci $\x_{t-s}$ și $\x_t$ trebuie să satisfacă:
+\begin{equation}
+    \vA(\x_{t-s} - \x_t) \approx st \nabla \log p_t(\vA\x_t). 
+\end{equation}
+Dintre toți $\x_{t_s}$ care satisfac constrângerea de mai sus, alegem arbitrar pe cel care minimizează distanța $\|\x_{t-s} - \x_t\|_2^2$. Prin urmare, obținem un proces de ``denoising'' pentru $\x_t$:
+\begin{equation}
+    \x_{t-s}  \approx \x_t + st\vA^\dagger \nabla \log p_t(\vA\x_t). 
+\label{eqn:denoising-projection}
+\end{equation}
+Observați că acest proces nu eșantionează din distribuția lui $\vx_t$. În particular, există componente ale lui $\vx$ în spațiul nul/nucleul lui $\vA$ care nu pot fi niciodată recuperate din observații. Astfel, mai multe informații sunt necesare pentru a recupera distribuția completă a lui $\vx$, strict vorbind. Dar aceasta recuperează componenta lui $\vx$ care este ortogonală pe spațiul nul al lui $\vA$.
+
+
+
+
+
+\subsection{Model Vizual 3D din Imagini Calibrate}
+În practică, modelul de măsurare este adesea neliniar sau doar parțial cunoscut. O problemă tipică de acest gen este de fapt în spatele modului în care putem învăța un model funcțional al lumii externe din imaginile percepute, să zicem prin ochii noștri, telescoape sau microscoape. În particular, oamenii și animalele sunt capabile să construiască un model al lumii 3D (sau 4D pentru o lume dinamică) printr-o secvență a proiecțiilor sale 2D—o secvență de imagini 2D (sau perechi stereo). Modelul matematic sau geometric al proiecției este în general cunoscut:
+\begin{equation}
+    \y^i = h(\x, \theta^i) +\vw^{i}, 
+\end{equation}
+unde $h(\cdot)$ reprezintă o proiecție (perspectivă) a scenei 3D (sau 4D) dintr-o anumită vedere a camerei la timpul $t_i$ la o imagine 2D (sau o pereche stereo) și $\vw$ este un zgomot de măsurare posibil aditiv mic. \Cref{fig:projection-2D} ilustrează această relație concret, în timp ce \Cref{fig:inference_distributed} ilustrează problema model în abstract. O expunere completă a geometriei legate de vederi multiple 2D ale unei scene 3D este dincolo de scopul acestei cărți. Cititorii interesați pot consulta cartea \cite{MaY2003}. Pentru moment, tot ce avem nevoie pentru a continua este că astfel de proiecții sunt bine înțelese și imaginile multiple ale unei scene conțin informații suficiente despre scenă.
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.7\linewidth]{\toplevelprefix/chapters/chapter6/figs/3D-2D-projection.png}
+    \caption{Relația dintre un obiect/scenă 3D și proiecțiile sale 2D. Aici ilustrăm proiecția unui punct $\x$ și a unei linii care intersectează punctul.}
+    \label{fig:projection-2D}
+\end{figure}
+
+\begin{figure}[t]
+  \centering 
+  \includegraphics[width=0.7\linewidth]{\toplevelprefix/chapters/chapter6/figs/inference_distributed.pdf}
+  \caption{\small \textbf{Inferență cu măsurători distribuite.} Avem o distribuție de dimensiune redusă \(\vx\) (aici, similar cu \Cref{fig:inference_roadmap}, reprezentată ca o uniune de două varietăți \(2\)-dimensionale în \(\R^{3}\)) și un model de măsurare \(\y^{i} = h^{i}(\vx) + \vw^{i}\). Ca înainte, vrem să inferăm diverse proprietăți ale distribuției condiționate a lui \(\vx\) dat \(\vy\), unde \(\vy\) este colecția tuturor măsurătorilor \(\y^{i}\).}
+  \label{fig:inference_distributed}
+\end{figure}
+
+În general, am dori să învățăm distribuția $p(\x)$ a scenei lumii 3D (sau 4D) $\x$\footnote{Aici, prin abuz de notație, folosim $\x$ pentru a reprezenta fie un punct în 3D, fie o mostră a unui întreg obiect 3D sau o scenă care constă din multe puncte.} din imaginile 2D percepute ale lumii până acum. Funcția principală a unui astfel de model (vizual) al lumii este să ne permită să recunoaștem locuri unde am fost înainte sau să prezicem cum ar arăta scena curentă într-un timp viitor dintr-un nou punct de vedere.
+
+Să examinăm mai întâi cazul special dar important al viziunii stereo. În acest caz, avem două vederi calibrate ale scenei 3D $\x$:
+\begin{equation}
+    \y^0 = h(\x, \theta^0) +\vw^0, \quad \y^1 = h(\x, \theta^1) +\vw^1, 
+\end{equation}
+unde parametrii $\theta_0$ și $\theta_1$ pentru pozele vederilor pot fi presupuși a fi cunoscuți. $\y^0$ și $\y^1$ sunt două proiecții 2D ale scenei 3D $\x$. Putem presupune de asemenea că au aceeași distribuție marginală $p(\y)$ și am învățat un model de difuzie și denoisificare pentru aceasta. Adică, cunoaștem denoiser-ul:
+\begin{equation}
+  \bE[\vy \mid \vy_t=\vnu] =
+  \vnu + t^2 \nabla_{\vnu}\log p_t(\vnu). 
+ \label{eq:y-posterior-sampling-denoiser}    
+\end{equation}
+Sau, mai mult, putem presupune că avem un număr suficient de mostre de perechi stereo $(\y^0, \y^1)$ și am învățat de asemenea distribuția comună a perechilor. Prin un mic abuz de notație, folosim de asemenea $\y = h(\x)$ pentru a indica perechea $\y = (\y^0, \y^1)$ și $p(\y)$ ca distribuția de probabilitate învățată a perechii (să zicem prin intermediul unui denoiser ca mai sus).
+
+Întrebarea principală acum este: Cum să învățăm (o reprezentare pentru) distribuția scenei 3D $\x$ din cele două proiecții ale sale cu relații cunoscute?
+Oamenii ar putea pune la îndoială rațiunea pentru a face acest lucru: de ce este necesar dacă funcția $h(\cdot)$ este în mare parte inversabilă? Adică, observația $\y$ poate determina în mare parte necunoscuta $\x$, ceea ce este cumva cazul pentru stereo—în general, două imagini (calibrate) conțin informații suficiente despre adâncimea scenei, din punctul de vedere dat. Cu toate acestea, imaginile 2D sunt departe de a fi cea mai compactă reprezentare a scenei 3D, deoarece aceeași scenă poate produce infinit de multe imagini 2D (foarte corelate) sau perechi de imagini. De fapt, o bună reprezentare a unei scene 3D ar trebui să fie invariantă la punctul de vedere. Prin urmare, o reprezentare corectă a distribuției scenelor 3D ar trebui să fie mult mai compactă și structurată decât distribuția imaginilor 2D, a perechilor stereo sau a perechilor imagine-adâncime.
+
+Considerați procesul (invers) de denoisificare pentru difuzie: $\y_t = \y + t\vg $ în \eqref{eq:y-posterior-sampling-denoiser}, unde $\vg$ este Gaussian standard. Din procesul de denoisificare din \eqref{eq:y-posterior-sampling-denoiser}, avem
+\begin{equation}
+    \y_{t-s} =  \y_t + st \nabla_{\y} \log p_t(\y_t).
+\end{equation}
+Încercăm să găsim un proces corespunzător de „denoisificare" al lui $\x_t$ astfel încât $\x$ să fie legat de $y$ ca:
+\begin{equation}
+    \y =  h(\x).
+\end{equation}
+
+Atunci avem:
+\begin{equation}
+    h(\x_{t-s}) \approx  h(\x_t) + st \nabla_{\y} \log p_t(h(\x_t)),
+\end{equation}
+pentru un $s >0$ mic.
+Presupunem că $\x_{t-s} = \x_t + s \vv$ pentru un anumit vector $\vv$ și increment mic $s$. Avem
+\begin{equation}
+    h(\x_{t-s}) \approx h(\x_t) + \frac{\partial h}{\partial \x}(\vx_{t}) \cdot \vv s \doteq h(\x_t) + \vA(\x_t) \vv s. 
+\end{equation}
+Prin urmare, avem
+\begin{equation}
+    \vA(\x_t) \vv = t \nabla_{\y} \log p_t(h(\x_t)).
+    \label{eqn:pushforward}
+\end{equation}
+Geometric, vectorul $\vv$ în domeniul lui $\x$ poate fi văzut ca pullback-ul câmpului vectorial $t \nabla \log p_t(\y)$ sub harta $\y = h(\x)$. În general, ca înainte, putem alege (arbitrar) $\vv$ să fie vectorul cu norma 2 minimă care satisface relația de pullback. Prin urmare, putem exprima $\hat{\x}_{t-s}$ aproximativ ca:
+\begin{equation}
+    \hat{\x}_{t-s} \approx \x_t + st\vA(\x_t)^\dagger \nabla_{\y} \log p_t(h(\x_t)). 
+\label{eqn:pullback-denoise}
+\end{equation}
+
+
+\begin{remark}[Detectare Paralelă și Denoisificare Distribuită.]
+{Există ceva foarte interesant despre ecuația de mai sus \eqref{eqn:pullback-denoise}. Pare să sugereze că am putea încerca să învățăm distribuția lui $\x$ printr-un proces care este cuplat cu (multe dintre) observațiile sale (parțiale):
+\begin{equation}
+\y^i = h^i(\x) +\vw^i, i =1, \ldots, K.
+\end{equation} În acest caz, obținem un set de ecuații pe care câmpul vectorial $\vv$ în domeniul lui $\x$ ar trebui să le satisfacă:
+\begin{equation}
+    \vA^i(\x_t) \vv = t \nabla_{\y^i} \log p_t(h^i(\x_t)),
+\label{eqn:federated-pushforward}
+\end{equation}
+unde $\vA^i(\x_t) = \frac{\partial h^i}{\partial \x}(\vx_t)$. $\vv$ final poate fi ales ca o soluție „centralizată" care satisface toate ecuațiile de mai sus, sau ar putea fi ales ca o versiune „agregată" (stocastic) a tuturor $\vv^i$:
+\begin{equation}
+    \vv^i = t\vA^i(\x_t)^\dagger \big[\nabla_{\y^i} \log p_t(h^i(\x_t))\big], \quad i = 1, \ldots, K,
+\end{equation}
+care sunt calculate într-o manieră paralelă și distribuită? O întrebare deschisă aici este exact la ce converge procesul de „denoisificare" astfel definit pentru $\x_t$, chiar și în cazul modelului de măsurare liniară. Când ar converge la o distribuție care are același suport de dimensiune redusă ca $\x_0$ original, pe măsură ce $\y_t$ converge la $\y = h(\x_0)$? }
+\end{remark}
+
+
+
+\paragraph{Model Vizual al Lumii din Secvențe de Imagini Necalibrate}
+
+În derivarea de mai sus, am presupus că modelul de măsurare $h(\cdot)$ este complet cunoscut. În cazul viziunii stereo, acest lucru este destul de rezonabil, deoarece poza relativă (și calibrarea) celor două vederi ale camerei (sau a celor doi ochi\footnote{Poza relativă a celor doi ochi ai noștri este bine cunoscută creierului nostru.}) este de obicei cunoscută în avans. Prin urmare, prin perechile de imagini stereo, în principiu ar trebui să putem învăța distribuția scenelor 3D, cel puțin distribuția ego-centrică a scenelor 3D. Cu toate acestea, structurile de dimensiune redusă ale așa-numitei distribuții învățate conțin variații cauzate de schimbarea punctelor de vedere. Adică, aspectul imaginilor stereo variază când ne schimbăm punctele de vedere în raport cu aceeași scenă 3D. Pentru multe sarcini practice de viziune (cum ar fi localizarea și navigarea), este important să putem decupla această variație a punctelor de vedere de o reprezentare invariantă a (distribuției) scenelor 3D.
+
+\begin{remark}Rețineți că obiectivul de mai sus se aliniază bine cu Programul Erlangen al lui Klein pentru geometria modernă, care este de a studia invarianții unei varietăți sub un grup de transformări. Aici, putem vedea varietatea de interes ca distribuția reprezentărilor ego-centrice ale scenelor 3D. Am învățat că admite un grup de mișcare rigidă tridimensională care acționează asupra ei. Este remarcabil că creierul nostru a învățat să decupleze eficient astfel de transformări de lumea 3D observată.
+\end{remark}
+
+
+Observați că am studiat învățarea reprezentărilor care sunt invariante la translație și rotație într-o setare limitată în Capitolul \ref{ch:representation}. Știm că operatorii de compresie asociați iau forma necesară de convoluții (multi-canal), conducând astfel la rețelele neuronale convoluționale (profunde). Cu toate acestea, operatorii care sunt asociați cu compresia sau denoisificarea care sunt invariante la grupuri de transformare mai generale rămân evazivi de caracterizat \cite{cohen2016group}.
+Pentru problema Viziunii 3D în setarea sa cea mai generală, știm că schimbarea punctelor noastre de vedere poate fi bine modelată ca o mișcare de corp rigid. Cu toate acestea, mișcarea relativă exactă a ochilor noștri între diferite puncte de vedere nu este de obicei cunoscută. Mai general, ar putea exista și obiecte (de exemplu, mașini, oameni, mâini) care se mișcă în scenă și în mod normal nu știm mișcarea lor. Cum putem generaliza problema învățării distribuției scenelor 3D cu perechi stereo calibrate la astfel de setări mai generale? Mai precis, vrem să învățăm o reprezentare compactă $\x$ a scenelor 3D care este invariantă la mișcările camerei/ochiului. Odată ce o astfel de reprezentare este învățată, am putea eșantiona și genera o scenă 3D și reda imagini sau perechi stereo din poze arbitrare.
+
+
+În acest scop, rețineți că putem modela o secvență de perechi stereo ca:
+\begin{equation}
+    \y^k = h(\x^k, \theta^k), \quad k=1, \ldots, K,
+\end{equation}
+unde $h(\cdot)$ reprezintă harta de proiecție de la 3D la 2D. $\theta^k$ denotă parametrii de mișcare de corp rigid ai vederii $k$, în raport cu un anumit cadru canonic în lume. $\x^k$ reprezintă scena 3D la timpul $k$. Dacă scena este statică, $\x^k$ ar trebui să fie toate la fel $\x^k = \x$. Pentru a simplifica notația, putem denota setul de $k$ ecuații ca una:
+\begin{equation}
+    \Y = H(\x,\Theta). 
+\end{equation}
+Putem presupune că ni se dau multe mostre de astfel de secvențe de imagini stereo $\{\Y_i\}$. Problema este cum să recuperăm secvența de mișcare asociată $\{\Theta_i\}$ și să învățăm distribuția scenei $\x$ (care este invariantă la mișcare). După cunoștințele noastre, aceasta rămâne o problemă deschisă provocatoare, probabil ca frontiera finală pentru problema Viziunii 3D.
+
+
+
+
+\section{Rezumat și Note}
+\paragraph{Potrivirea măsurătorilor fără mostre curate.} În dezvoltarea noastră a
+eșantionării condiționate, am considerat potrivirea măsurătorilor sub un model
+de observare \eqref{eq:measurement-matching-observation}, unde presupunem că avem
+date împerecheate $(\vx, \vy)$—adică, adevărul de bază pentru fiecare observație $\vy$.
+În multe probleme inverse relevante practic, acesta nu este cazul: unul dintre
+cele mai fundamentale exemple este în contextul detectării comprimate, pe care am
+reamintit-o în \Cref{ch:classic}, unde trebuie să reconstruim $\vx$ din $\vy$
+folosind cunoștințe anterioare despre $\vx$ (adică, raritate).
+În setarea denoisificare-difuzie, avem acces la o prioritate implicită pentru
+$\vx$ prin intermediul denoiser-ilor învățați $\bar{\vx}_{\theta}(t, \vxi)$. Putem totuși efectua
+eșantionare condiționată fără acces la mostre de adevăr de bază $\vx$?
+
+Pentru intuiție cu privire la de ce acest lucru ar putea fi posibil, ne amintim un exemplu clasic
+din statistică cunoscut sub numele de estimatorul de risc imparțial al lui Stein (SURE).
+Sub un model de observare $\vx_t = \vx + t \vg$ cu $\vg \sim \cN(\Zero,
+\vI)$ și $t>0$, se dovedește că pentru orice $f : \bR^D \to \bR^D$ slab diferențiabil,
+\begin{equation}\label{eq:sure-risk}
+  \bE_{\vg}\left[
+    \norm*{\vx - f(\vx + t \vg)}_2^2
+    \right]
+  =
+  \bE_{\vg}\left[
+    \norm*{\vx+t\vg - f(\vx + t \vg)}_2^2
+    + 2t^2 \nabla \cdot f(\vx + t\vg)
+    \right]
+  - t^2 D,
+\end{equation}
+unde $\nabla \cdot$ denotă operatorul de divergență:
+\begin{equation*}
+	\nabla \cdot f = \sum_{i=1}^D \partial_i f_i.
+\end{equation*}
+Partea dependentă de $\vx$ din RHS din \Cref{eq:sure-risk} se numește estimatorul
+de risc imparțial al lui Stein (SURE). Dacă luăm așteptări peste $\vx$ în \Cref{eq:sure-risk},
+rețineți că RHS poate fi scris ca o așteptare în raport cu $\vx_t$---în
+special, eroarea pătratică medie a \textit{oricărui denoiser $f$} poate fi estimată
+\textit{doar din mostre zgomotoase}!
+Acest fapt remarcabil, în forme rafinate, constituie baza pentru multe tehnici
+practice pentru efectuarea restaurării imaginii, denoisificare-difuzie, etc.\ folosind
+doar date zgomotoase: exemple notabile includ paradigma „noise2noise"
+\cite{pmlr-v80-lehtinen18a}
+și Ambient Diffusion \cite{daras2023ambient}.
+
+Ca o paranteză amuzantă, subliniem că \Cref{eq:sure-risk} conduce la o dovadă
+alternativă a formulei lui Tweedie (\Cref{thm:tweedie}). La un nivel înalt, se iau
+așteptări peste $\vx$ și se exprimă partea principală a RHS din
+\Cref{eq:sure-risk} echivalent, prin integrare prin părți, ca
+\begin{equation}
+  \bE_{\vx_t}\left[
+    \norm*{\vx_t - f(\vx_t)}_2^2
+    + 2t^2 \nabla \cdot f(\vx_t)
+    \right]
+  =
+  \bE_{\vx_t}\left[
+    \norm*{\vx_t - f(\vx_t)}_2^2
+    \right]
+  - 2t^2 \int
+  \ip*{\nabla p_{\vx_t}(\vxi)}{f(\vxi)}
+  \odif \vxi.
+\end{equation}
+Aceasta este o funcție pătratică a lui $f$, și luarea formală a derivatelor dă
+că $f$ optim satisface formula lui Tweedie (\Cref{thm:tweedie}). Acest
+argument poate fi făcut riguros folosind idei de bază din calculul variațiilor.
+
+
+\paragraph{Corecții la aproximarea Diffusion Posterior Sampling (DPS).}
+În \Cref{example:denoising-conditional-gaussian} și în special în
+\Cref{fig:conditional_sampling_computational_gaussian}, am subliniat
+o limitare a aproximării DPS
+\Cref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx} la
+niveluri mici de zgomot de măsurare.
+Această limitare este bine înțeleasă, și o abordare principială pentru ameliorarea ei
+a fost propusă de Rozet et al.\ \cite{rozet2024learning}.
+Abordarea implică încorporarea unei estimări suplimentare pentru varianța
+posteriorului zgomotos $p_{\vx \mid \vx_t}$ la
+\Cref{eq:conditional-posterior-measurementmatching-gaussian-case-dps-approx}---ne
+referim la lucrare pentru detalii.
+Estimările naturale pentru varianța posterioară sunt ușor mai puțin scalabile decât DPS
+în sine din cauza necesității de a inversa o transformare afină a Jacobianului
+denoiser-ului posterior $\bE[\vx \mid \vx_t=\vxi]$ (o matrice mare). Acest lucru se face
+relativ eficient de Rozet et al.\ \cite{rozet2024learning} folosind diferențiere automată și o
+aproximare pentru inversă bazată pe gradienți conjugați. Se pare că ar trebui
+să fie posibil să se îmbunătățească în continuare această abordare (să zicem, folosind idei
+clasice din optimizarea de ordinul doi).
+
+
+\paragraph{Mai multe despre potrivirea măsurătorilor și modelele de difuzie pentru probleme
+inverse.}
+
+Modelele de difuzie au devenit un instrument extrem de popular pentru rezolvarea problemelor
+inverse care apar în aplicațiile științifice. Multe mai multe metode dincolo de simplul
+algoritm DPS pe care l-am prezentat în \Cref{alg:iterative_denoising_conditional_DPS} au fost
+dezvoltate și continuă să fie dezvoltate, deoarece zona evoluează rapid.
+Clasele populare și performante de abordări dincolo de DPS, pe care le-am prezentat
+din cauza generalității sale, includ abordări de împărțire a variabilelor precum DAPS
+\cite{Zhang2024-ha},
+care permit ca constrângerile specifice de măsurare să fie impuse mult mai
+puternic decât în DPS, și abordări exacte care pot evita utilizarea
+aproximărilor ca în DPS, cum ar fi TDS \cite{wu2023practical}.
+Pentru mai multe despre această zonă, recomandăm \cite{zheng2025inversebench}, care
+funcționează simultan ca un sondaj și un benchmark al mai multor metode populare
+pe seturi de date specifice de probleme inverse științifice.
+
+\section{Exerciții și Extensii}
+
+
+\begin{exercise}[Corecția Varianței Posterioare la DPS]
+
+  \begin{enumerate}
+    \item Folosind codul furnizat în GitHub-ul cărții pentru implementarea
+      \Cref{fig:conditional_sampling_computational_gaussian}, implementați
+      corecția varianței posterioare propusă de \textcite{rozet2024learning}.
+    \item Verificați că ameliorează problema colapsului posterior la varianță
+      scăzută a zgomotului observată în
+      \Cref{fig:conditional_sampling_computational_gaussian}.
+    \item Discutați orice probleme de corectitudine a eșantionării care sunt reținute sau
+      introduse de metoda corectată, precum și eficiența sa, relativ la
+      diffusion posterior sampling (DPS).
+  \end{enumerate}
+
+\end{exercise}
+
+\begin{exercise}[Eșantionare Condiționată pe MNIST]
+  \begin{enumerate}
+    \item Antrenați un clasificator simplu pentru setul de date MNIST, folosind o arhitectură
+      la alegerea dumneavoastră. În plus, antrenați un denoiser potrivit pentru utilizare în
+      eșantionarea condiționată (\Cref{alg:iterative_denoising_conditional_CFG},
+      deoarece acest denoiser poate fi folosit și pentru denoisificare necondiționată).
+    \item Integrați clasificatorul într-un eșantionator condiționat bazat pe
+      ghidare prin clasificator, așa cum este descris în prima parte a \Cref{sub:cfg}.
+      Evaluați mostrele rezultate în termeni de fidelitate față de
+      clasa de condiționare (vizual; în termeni de cel mai apropiat vecin; în termeni de
+      ieșirea clasificatorului).
+    \item Integrați clasificatorul într-un eșantionator condiționat bazat pe
+      ghidare fără clasificator, așa cum este descris în \Cref{sub:cfg} și
+      \Cref{alg:iterative_denoising_conditional_CFG}. Efectuați aceeași
+      evaluare ca în pasul anterior și comparați rezultatele.
+    \item Repetați experimentul pe setul de date CIFAR-10.
+  \end{enumerate}
+
+
+\end{exercise}
+
+
+\end{document}
+

--- a/chapters/chapter7/applications_ro.tex
+++ b/chapters/chapter7/applications_ro.tex
@@ -1,0 +1,1219 @@
+\providecommand{\toplevelprefix}{../..}
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Învățarea Reprezentărilor pentru Date din Lumea Reală}
+\label{ch:applications}
+
+\begin{quote}
+\hfill    ``{\em Cea mai bună teorie este inspirată de practică, iar cea mai bună practică este inspirată de teorie}.''
+
+$~$ \hfill --- Donald Knuth   
+\end{quote}
+\vspace{5mm}
+
+Capitolele anterioare au prezentat o introducere sistematică în problemele matematice, cadrele computaționale și algoritmii practici asociați cu învățarea distribuțiilor de dimensiune redusă din date de dimensiune înaltă. Deși majoritatea justificărilor teoretice ale acestor metode au fost stabilite pentru modele idealiste de date, cum ar fi (amestecuri de) subspații și/sau Gaussiane, principiile și ideile din spatele acestor metode computaționale sunt totuși puternice și generale, și sunt de fapt menite să fie aplicabile pentru seturi de date și sarcini din lumea reală.
+
+Pentru a ajuta cititorii să înțeleagă mai bine materialul din această carte și să învețe cum să aplice ceea ce ați învățat până acum la date din lumea reală, spre sfârșitul cărții, oferim câteva demonstrații și viniete ale mai multor aplicații reprezentative. Fiecare aplicație propune o soluție la o sarcină din lumea reală cu un set de date din lumea reală (cum ar fi date vizuale și date text), folosind metodele pe care le-am introdus în această carte. Rezultatele prezentate în acest capitol sunt menite să servească următoarele două scopuri:
+\begin{itemize}
+    \item în primul rând, să ofere detalii experimentale suplimentare și dovezi empirice care validează metodele prezentate mai devreme în carte și demonstrează potențialul lor semnificativ în contexte din lumea reală;
+    \item în al doilea rând, să introducă cititorul în anumite metode și sarcini empirice moderne în învățarea profundă care nu sunt bine documentate în afara bazelor de cod de cercetare sau producție.
+\end{itemize}
+Cu toate acestea, în opinia noastră sinceră, soluțiile și rezultatele date aici sunt concepute pur și simplu pentru a verifica că metodologia funcționează. Ca atare, există mult spațiu pentru îmbunătățiri viitoare, atât în inginerie cât și în înțelegerea teoretică, pentru a îmbunătăți potențial starea actuală a artei. Vom discuta câteva direcții viitoare în \Cref{ch:future}.
+
+
+
+
+\section{Configurare Tehnică și Schema Capitolului}\label{sec:experiment_setup}
+
+În capitolele anterioare, am făcut aluzie la diferite configurări în care am folosit tehnici de învățare a reprezentărilor pentru a procesa date reale la scară. În acest capitol, vom descrie astfel de configurări în detaliu mare. Obiectivul acestei secțiuni este să vă facem pe dumneavoastră, cititorul, să puteți reproduce orice experiment discutat în această secțiune (sau într-adevăr în carte) folosind doar descrierea pe care o vom da în carte, principiile introduse în capitolele anterioare și extinse în acest capitol, și hiperparametri luați dintr-o serie de lucrări ale căror rezultate sunt discutate în acest capitol. În acest scop, vom descrie \textit{precis} toate procedurile într-un limbaj detaliat, pseudocod sau notație matematică care pot fi implementate direct în cod. Oriunde este posibil, vom discuta cum se conectează implementările concrete la principiile prezentate mai devreme în carte.
+
+\begin{figure}
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/encoder_pipeline.pdf}
+    \caption{\small\textbf{O diagramă a pipeline-ului encoder.} Datele \(\vX \in \cD\) sunt introduse prin încorporarea \(f_{\theta}^{\emb}\) pentru a obține o secvență în \((\R^{d})^{*}\). Încorporarea este introdusă printr-o coloană vertebrală \(f_{\theta}^{\mathrm{bb}}\) pentru a obține caracteristici \(\vZ_{\theta}(\vX)\) pentru fiecare token. Putem extrage o caracteristică agregată \(\vz_{\theta}(\vX)\) folosind harta de extracție \(f_{\theta}^{\mathrm{ext}}\). În cele din urmă, pentru a folosi caracteristica agregată în sarcini în aval, putem folosi capul specific sarcinii \(h_{\theta}\).}
+    \label{fig:overall_encoder_pipeline}
+\end{figure}
+
+\begin{figure}
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/autoencoder_pipeline.pdf}
+    \caption{\small\textbf{O diagramă a pipeline-ului autoencoder.} Datele \(\vX \in \cD\) sunt introduse prin încorporarea \(f_{\theta}^{\emb}\) pentru a obține o secvență în \((\R^{d})^{*}\). Încorporarea este introdusă printr-o coloană vertebrală encoder \(f_{\theta}^{\mathrm{bb}}\) pentru a obține caracteristici \(\vZ_{\theta}(\vX)\) pentru fiecare token. Pentru a decoda \(\vZ_{\theta}(\vX)\), o trecem printr-o coloană vertebrală decoder \(g_{\eta}^{\mathrm{bb}}\). Pentru a mapa ieșirea coloanei vertebrale decoder înapoi în spațiul datelor \(\cD\), folosim un strat de \textit{dezîncorporare} \(g_{\eta}^{\mathrm{unemb}}\), obținând în general o reconstrucție \(\hat{\vX}_{\theta, \eta}(\vX)\) (aici stilizată să fie o reconstrucție pixelată a intrării).}
+    \label{fig:overall_autoencoder_pipeline}
+\end{figure}
+
+Să definim setul de date posibile ca \(\cD\) (în cele din urmă acesta va fi setul de imagini \(\cI\), de exemplu, sau setul de text \(\cT\)), și setul de secvențe finite de token-uri în \(\R^{d}\) (adică, setul de matrice cu \(d\) rânduri) ca \((\R^{d})^{*} \doteq \bigcup_{T = 1}^{\infty}\R^{d \times T}\). Pentru a discuta bogăția de aplicații pe care le introducem în acest capitol, ne amintim mai întâi că în restul cărții, discutăm două tipuri diferite de arhitecturi de model.
+\begin{itemize}
+    \item O arhitectură \textit{encoder}, parametrizată de \(\theta\), care este compusă din mai multe componente:
+    \begin{itemize}
+        \item O \textit{încorporare} \(f_{\theta}^{\emb} \colon \cD \to (\R^{d})^{*}\), care convertește datele de intrare \(\cD\) într-o serie de \textit{token-uri} care sunt mapate în, sau \textit{încorporate} în, spațiul \(d\)-dimensional. \textit{În restul capitolului, vom identifica adesea token-urile și încorporările unul cu celălalt.}
+        \item O \textit{coloană vertebrală encoder} \(f_{\theta}^{\backbone} \colon (\R^{d})^{*} \to (\R^{d})^{*}\), care procesează seria de încorporări folosind o operație secvență-la-secvență. Această coloană vertebrală este implementată de arhitecturile de rețea discutate în capitolele anterioare, dar vom da o descriere mai formală pe măsură ce avansăm.
+        \item Un \textit{extractor de caracteristici agregate} \(f_{\theta}^{\ext} \colon (\R^{d})^{*} \to \R^{d}\), care extrage o reprezentare agregată a întregii secvențe. Aceasta este folosită pentru a defini o singură caracteristică pentru întreaga mostră de date.
+        \item Un \textit{cap specific sarcinii} \(h_{\theta} \colon \R^{d} \to \R^{m}\), care extrage o ieșire \(m\)-dimensională pentru predicție.
+    \end{itemize}
+    De asemenea, definim \(f_{\theta} \doteq f_{\theta}^{\backbone} \circ f_{\theta}^{\emb} \colon \cD \to (\R^{d})^{*}\). Dată o intrare \(\vX\), scriem \(\vZ_{\theta}(\vX) \doteq f_{\theta}(\vX)\) și \(\vz_{\theta}(\vX) \doteq f_{\theta}^{\ext}(\vZ_{\theta}(\vX))\). Pipeline-ul general este ilustrat în \Cref{fig:overall_encoder_pipeline}.
+    \item O arhitectură \textit{autoencoder}, care este compusă din mai multe componente:
+    \begin{itemize}
+        \item O \textit{încorporare} \(f_{\theta}^{\emb} \colon \cD \to (\R^{d})^{*}\), care convertește datele de intrare \(\cD\) într-o serie de \textit{token-uri} care sunt încorporate în spațiul \(d\)-dimensional.
+        \item O \textit{coloană vertebrală encoder} \(f_{\theta}^{\backbone} \colon (\R^{d})^{*} \to (\R^{d})^{*}\), care procesează seria de încorporări folosind o operație secvență-la-secvență.
+        \item O \textit{coloană vertebrală decoder} \(g_{\eta}^{\backbone} \colon (\R^{d})^{*} \to (\R^{d})^{*}\), care anulează conceptual operația coloanei vertebrale encoder.
+        \item O \textit{dezîncorporare} \(g_{\eta}^{\unemb} \colon (\R^{d})^{*} \to \cD\), care acționează ca o inversă a încorporării.
+    \end{itemize}
+    De asemenea, definim \(f_{\theta} \doteq f_{\theta}^{\backbone} \circ f_{\theta}^{\emb} \colon \cD \to (\R^{d})^{*}\) și \(g_{\eta} \doteq g_{\eta}^{\unemb} \circ g_{\eta}^{\backbone} \colon (\R^{d})^{*} \to \cD\). Dată o intrare \(\vX\), scriem \(\vZ_{\theta}(\vX) \doteq f_{\theta}(\vX)\) și \(\hat{\vX}_{\theta, \eta}(\vX) \doteq g_{\eta}(\vZ_{\theta}(\vX))\). Pipeline-ul general este ilustrat în \Cref{fig:overall_autoencoder_pipeline}.
+\end{itemize}
+
+Vom folosi în mod repetat această notație de multe ori în acest capitol, așa că vă rugăm să vă simțiți liberi să vă referiți înapoi la ea dacă ceva nu are sens. Această descompunere a rețelelor noastre oglindește de asemenea îndeaproape majoritatea implementărilor de cod, și puteți începe proiectele dvs. de codare prin definirea acestor rețele.
+
+În acest capitol, vom discuta aplicațiile principiilor cărții la învățarea contrastivă în \Cref{sec:contrastive_learning}. Aceasta va servi atât ca o introducere în datele de imagine, tehnicile de augmentare a datelor și arhitectura comună cunoscută sub numele de transformer, \textit{precum și} o primă demonstrație a tipurilor drastice de simplificări pe care le putem face folosind principiile demonstrate. Vom continua cu modificări ale \textit{arhitecturii rețelei} în \Cref{sec:image_classification,sec:clm_text}, care demonstrează capacitățile arhitecturilor simplificate pentru \textit{encodare} în domeniile imagine și text. Apoi demonstrăm arhitecturi simplificate pentru \textit{autoencodare} în \Cref{sec:image_completion}.
+
+
+\section{Învățare Contrastivă Simplificată}\label{sec:contrastive_learning}
+
+Învățarea reprezentărilor de înaltă calitate și fidele ale datelor este o problemă fundamentală în învățarea profundă, cunoscută sub numele de \textit{învățare auto-supervizată}. Au fost propuse multe abordări pentru această sarcină, multe dintre ele nefolosind în mod evident tehnicile și principiile prezentate în acest manuscris. O astfel de abordare se numește \textit{învățare contrastivă}, numită astfel deoarece obiectivul de învățare este (vorbind în general) despre asigurarea că caracteristicile datelor „similare" sunt similare, iar caracteristicile datelor „disimilare" sunt departe. Soluțiile de învățare contrastivă sunt adesea abordări foarte inginerești, concepute empiric. În această secțiune, vom descrie o astfel de abordare numită DINO \citep{caron2021emerging} și vom folosi principiile descrise în capitolele anterioare pentru a simplifica drastic deciziile lor de design, îmbunătățind în același timp reprezentările învățate.
+
+\subsection{Date}\label{sub:contrastive_learning_data}
+
+Datele pe care le vom folosi pentru a explora și simplifica metodologia DINO sunt toate date de imagine bidimensionale. Pentru \textit{antrenament}, vom folosi seturile de date ImageNet-1K și ImageNet-21K. Fiecare mostră din setul de date este o imagine RGB, de rezoluție variabilă, și o etichetă care indică obiectul sau scena pe care o conține imaginea (adică, \textit{clasa} imaginii). Setul de date ImageNet-1K conține 1,28M imagini de antrenament și 50K imagini de validare partiționare în 1K clase. Setul de date ImageNet-21K conține 14,2M imagini de antrenament și 21,8K clase, dar clasele nu sunt disjuncte (adică, unele clase sunt subseturi ale altora). Deoarece facem învățare auto-supervizată, etichetele nu vor fi folosite în timpul antrenamentului, doar în timpul evaluării. Pentru \textit{evaluare}, vom folosi o multitudine de seturi de date. Dintre acestea, cel mai comun este CIFAR-10. CIFAR-10 este un set de date de 60K imagini naturale RGB 32 \(\times\) 32 partiționare în 10 clase, cu un set de antrenament prestabilit de 50K mostre și un set de validare de 10K mostre. Scopul utilizării CIFAR-10 este de a ne asigura că modelele care se antrenează pe o distribuție de imagini (ImageNet) pot generaliza la o altă distribuție de imagini (CIFAR-10). Ne referim de asemenea la alte seturi de date similare, cum ar fi CIFAR-100 (disjunct de CIFAR-10), Oxford Flowers și Oxford Pets. Exemplare de date ImageNet-1K și CIFAR-10 sunt prezentate în \Cref{fig:in1k_cifar10_examples}. Pentru a crește robustețea modelului nostru, aplicăm adesea \textit{augmentări mici de date} la fiecare imagine în timpul procesării, cum ar fi răsturnări, adăugarea de zgomot aleatoriu mic sau decupări aleatorii mari; nu includem acest lucru în notația noastră, deoarece fiecare augmentare a unei imagini naturale este ea însăși (foarte aproape de) o imagine naturală în setul nostru de date.
+
+\begin{figure}
+    \centering
+    
+    \hfill 
+    \begin{subfigure}{0.3\textwidth}
+        \centering 
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/imagenet.pdf}
+        \caption{\small Mostre ImageNet-1K.}
+    \end{subfigure}
+    \hfill 
+    \begin{subfigure}{0.26\textwidth}
+        \centering 
+        \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/cifar10.pdf}
+        \caption{\small Mostre CIFAR10.}
+    \end{subfigure}
+    \hfill 
+    \phantom{}
+
+    \caption{\small\textbf{Imagini din ImageNet-1K \textit{(stânga)} și CIFAR-10 \textit{(dreapta)}.} Observați că imaginile CIFAR-10 au o rezoluție mult mai mică, în general vorbind, reducând complexitatea învățării acelei distribuții.}
+    \label{fig:in1k_cifar10_examples}
+\end{figure}
+
+La un nivel puțin mai formal, datele noastre \(\vX\) vor fi imagini; lăsăm \(\cI\) să fie setul tuturor imaginilor. Deoarece o imagine este o matrice dreptunghiulară de pixeli, iar fiecare pixel are o culoare dată de RGB, CMYK sau alt format de culoare, spunem că o imagine este un element al \(\R^{c \times h \times w}\) --- aici \(c\) este numărul de canale (adică, \(3\) pentru RGB și \(4\) pentru CMYK), \(h\) este înălțimea imaginii și \(w\) este lățimea imaginii. În consecință, setul tuturor imaginilor \(\cI \doteq \bigcup_{c, h, w = 1}^{\infty}\R^{c \times h \times w}\) este setul tuturor acestor date posibile. Din nou, vom folosi această notație în mod repetat.
+
+
+\subsection{Sarcină și Funcție Obiectiv} \label{sub:contrastive_learning_objective}
+
+Sarcina noastră este să învățăm o reprezentare bună a datelor. Învățarea contrastivă, în general, face acest lucru prin definirea proprietăților imaginii de intrare pe care dorim ca caracteristicile să le reflecte, construind imagini care împărtășesc aceste proprietăți dar variază altele, și stabilind o pierdere care promovează că caracteristicile imaginilor cu proprietăți comune sunt apropiate și imaginile cu proprietăți diferite sunt diferite. Soluția naturală optimă la această problemă de învățare este că caracteristicile învățate păstrează proprietățile dorite ale intrării. Cu toate acestea, există multe complicații practice și empirice care apar în cursul antrenării modelelor contrastive.
+
+În cazul DINO, autorii propun să folosească o metodologie care produce un singur vector de caracteristici pentru întreaga imagine și dorește ca vectorul de caracteristici să conțină informații „globale" (adică, la nivel de imagine). În consecință, pierderea va promova că imaginile cu informații globale similare au caracteristici similare și imaginile cu informații globale diferite au caracteristici diferite.
+
+Acest lucru pare intuitiv, dar așa cum am menționat anterior, există mai multe considerații empirice, chiar și în timpul configurării pierderii. În primul și în primul rând, cum ar trebui să promovăm similaritățile și diferențele? Răspunsul de la DINO \citep{caron2021emerging} este\footnote{În opinia autorului, inexplicabil...} să convertească caracteristicile de ieșire în „logit-uri" corespunzătoare unei distribuții de probabilitate și să ia entropia încrucișată a acestora. Mai specific, fie \(\Delta_{m} \doteq \{\vx \in \R^{m} \colon x_{i} \geq 0\ \forall i \in [m], \sum_{i = 1}^{m}x_{i} = 1\}\) spațiul vectorilor de probabilitate în \(\R^{m}\) și definim funcția \(d_{\CE} \colon \R^{m} \times \R^{m} \to \R\) prin
+ \begin{equation}\label{eq:cross_entropy_difference}
+    d_{\CE}(\vp, \vq) \doteq \CE(\vp, \vq), \quad \forall \vp, \vq \in \Delta_{m}
+ \end{equation}
+ unde \(\CE \colon \Delta_{m} \times \Delta_{m} \to \R\) este entropia încrucișată, definită ca 
+ \begin{equation}\label{eq:expts_def_ce}
+    \CE(\vp, \vq) \doteq -\sum_{i = 1}^{m}p_{i}\log q_{i}, \quad \forall \vp = (p_{1}, \dots, p_{m}), \vq = (q_{1}, \dots, q_{m}) \in \Delta_{m}.
+ \end{equation}
+ Înainte de a continua discuția noastră, să construim o intuiție despre această funcție de distanță. Avem, în particular,
+ \begin{align}
+    \CE(\vp, \vq)
+    &= -\sum_{i = 1}^{m}p_{i}\log q_{i} = \sum_{i = 1}^{m}p_{i}\log(p_{i}/q_{i})
+     - \sum_{i = 1}^{m}p_{i}\log p_{i} = \KL(\vp\mmid \vq) + H(\vp)
+ \end{align}
+ unde \(\KL \colon \Delta_{m} \times \Delta_{m} \to \R\) este divergența KL, definită ca 
+ \begin{equation}
+    \KL(\vp\mmid \vq) \doteq \sum_{i = 1}^{m}p_{i}\log(p_{i}/q_{i}),
+ \end{equation}
+ și \(H \colon \Delta_{m} \to \R\) este entropia unei variabile aleatoare. Observați
+ că \(\KL(\vp\mmid \vq)\) este minimizată dacă și numai dacă \(\vp = \vq\). Deci minimizarea \(d_{\CE}\) face două lucruri: face \(\vp = \vq\), și face \(\vp\) și \(\vq\) să aibă entropie minimă (adică, vectori cu \(1\) într-o componentă și \(0\) în altă parte --- aceștia se numesc \textit{vectori one-hot}). În general, scopul acestui obiectiv nu este \textit{doar} să potrivească \(\vp\) și \(\vq\), ci și să le modeleze într-un anumit mod pentru a le face cu entropie scăzută. Păstrați acest lucru în minte când discutăm formularea.
+
+Următoarea întrebare este, cum ar trebui să obținem mostre cu informații globale similare? Răspunsul de la DINO (precum și aproape toată învățarea contrastivă) este \textit{augmentarea datelor} --- din fiecare mostră, facem mai multe mostre corelate care împărtășesc proprietățile dorite. În cazul DINO, folosim diferite decupări sau \textit{vederi} ale imaginii de intrare. Amintiți-vă că modelăm o imagine ca un element al setului \(\cI\). În această notație, o vedere este o funcție \(v \colon \cI \to \cI\). În cazul DINO, vederea este o \textit{decupare redimensionată aleatorie}: ia o decupare dreptunghiulară aleasă aleatoriu a imaginii (care are un procent fix \(p_{v} \in [0, 1]\) din suprafața totală a imaginii), o redimensionează proporțional astfel încât \textit{marginea mai scurtă} să aibă \(S_{\rsz}\) pixeli lungime, apoi o redimensionează la o formă fixă \((C, S_{v}, S_{v})\) unde \(S_{v} \geq 1\) este dimensiunea vederii și \(C\) este numărul de canale din imaginea originală.
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=0.7\textwidth]{\toplevelprefix/chapters/chapter7/figs/global_local_views.pdf}
+    \caption{\textbf{Vederi locale și globale în DINO.} Vederile locale și vederile globale iau o decupare dreptunghiulară a imaginii de intrare și o redimensionează la o formă pătrată, care este apoi introdusă în rețea pentru procesare.}
+    \label{fig:dino_local_global_views}
+\end{figure}
+
+Există două tipuri de vederi pe care vrem să le folosim, ilustrate în \Cref{fig:dino_local_global_views}: 
+\begin{itemize}
+    \item \textit{vederi globale}, care sunt decupări redimensionate aleatorii cu parametru de procent de suprafață \(p_{\glo} \in [0, 1]\) și formă de ieșire \((C, S_{\glo}, S_{\glo})\);
+    \item \textit{vederi locale}, care sunt decupări redimensionate aleatorii cu parametru de procent de suprafață \(p_{\loc} \in [0, 1]\) și formă de ieșire \((C, S_{\loc}, S_{\loc})\). Aici \(p_{\loc} < p_{\glo}\) și \(S_{\loc} < S_{\glo}\).
+\end{itemize}
+
+DINO dorește ca caracteristicile agregate \(\vz_{\theta}(\vX_{v}) \doteq (f_{\theta}^{\ext} \circ f_{\theta})(\vX_{v})\) ale tuturor vederilor \(\vX_{v} \doteq v(\vX)\) ale unei imagini de intrare \(\vX\) să fie consistente între ele. DINO face acest lucru folosind un \textit{„cap DINO"}\footnote{Observați că \(h_{\vW, \vmu}\) este capul specific sarcinii, care în \Cref{sec:experiment_setup} este parametrizat doar de \(\theta\) spre deosebire de orice parametri specifici, dar deoarece folosim două invocări ale lui \(h\) cu valori diferite ale celui de-al doilea parametru, păstrăm notația specificată.} \(h_{\vW, \vmu}\), parametrizat de o matrice \(\vW \in \R^{s \times d}\) și un vector \(\vmu \in \R^{s}\), pentru a extrage un vector de probabilitate \(\vp_{\theta, \vW, \vmu}(\vX_{v}) \doteq h_{\vW, \vmu}(\vz_{\theta}(\vX_{v}))\) din caracteristica agregată \(\vz_{\theta}(\vX_{v})\), folosind următoarea rețetă simplă:
+\begin{equation}
+    h_{\vW, \vmu}(\vz) \doteq \softmax([\vW\vz - \vmu]/\tau), \qquad \forall \vz \in \R^{d},
+\end{equation}
+unde funcția \(\softmax \colon \R^{s} \to \Delta_{s}\) este definită de 
+\begin{equation}
+    \softmax\rp{\mat{x_{1} \\ \vdots \\ x_{s}}} \doteq \frac{1}{\sum_{i = 1}^{s}e^{x_{i}}}\mat{e^{x_{1}} \\ \vdots \\ e^{x_{s}}}
+\end{equation}
+și \(\tau > 0\) este un parametru de „temperatură" care controlează entropia ieșirii softmax.
+
+În special, DINO minimizează diferența dintre vectorul de probabilitate \(\vp_{\theta, \vW, \vmu}(\vX_{g}) \doteq h_{\vW, \vmu}(\vz_{\theta}(\vX_{g}))\) pentru fiecare vedere globală \(\vX_{g} \doteq v_{g}(\vX)\) și vectorul de probabilitate \(\vp_{\theta, \vW}(\vX_{c}) \doteq h_{\vW, \vzero_{m}}(\vz_{\theta}(\vX_{c}))\) pentru fiecare vedere \(\vX_{c} \doteq v_{c}(\vX)\). Aici, \(v_{c}\) poate fi \textit{fie} o vedere locală sau o vedere globală. Vom discuta implementarea lui \(f_{\theta}\) și \(f_{\theta}^{\ext}\) în curând în \Cref{sub:contrastive_learning_architecture}. În general, DINO rezolvă problema
+ \begin{equation}\label{eq:dino_loss}
+     \min_{\theta, \vW, \vmu}\cL_{\dino}(\theta, \vW, \vmu) \qquad \text{unde} \qquad \cL_{\dino}(\theta, \vW, \vmu) \doteq \Ex[d_{\CE}(\vp_{\theta, \vW, \vmu}(\vX_{g}), \vp_{\theta, \vW}(\vX_{c}))],
+\end{equation}
+unde așteptarea este peste date \(\vX\), vederi globale \(v_{g}\), și alte vederi \(v_{c}\).
+
+În acest caz specific, totuși, dacă încercați să implementați \eqref{eq:dino_loss} și să o optimizați pe o rețea reală, este foarte probabil să întâmpinați o problemă: după rularea câtorva iterații ale algoritmului de învățare, maparea caracteristicilor \(f_{\theta}^{\ext} \circ f_{\theta}\) va \textit{deveni funcția constantă}! Acest lucru optimizează cu siguranță pierderea de mai sus, deoarece minimizează distanța dintre caracteristicile diferitelor vederi ale aceleiași imagini. Dar evident nu vrem să învățăm această soluție.
+
+De fapt, evitarea colapsului este o considerație foarte comună în învățarea contrastivă. Deci, cum o facem în acest caz? Soluția de la DINO, din nou, este proiectată empiric și ajustează cu atenție optimizarea parametrului \(\vmu\) (care este actualizat folosind toate mostrele din lot) și un hiperparametru de „temperatură" \(\tau\) care face parte din implementarea lui \(h_{\vW, \vmu}\) și este discutat în \Cref{sub:contrastive_learning_architecture}. Dat un anumit set special de hiperparametri care funcționează bine, acest lucru este într-adevăr suficient pentru a asigura ne-colapsul reprezentării. Cu toate acestea, în afara acestei configurații speciale, antrenarea modelelor pentru a converge este dificilă, iar antrenamentul este foarte instabil.
+
+Pentru a remedia această stare de lucruri, să discutăm simplificări ale formulării. În primul rând, în loc să calculăm un vector de probabilitate folosind o transformare învățată \(h_{\vW, \vmu}\) a caracteristicilor agregate \(\vz_{\theta}\), putem \textit{folosi direct reprezentarea agregată}, ignorând capul specific sarcinii (sau echivalent, setându-l la maparea identitate). Dar acum avem nevoie de o modalitate de a compara vectorii direct. Folosind ipoteza noastră din \Cref{ch:representation} că reprezentările bune ar trebui să aibă geometrie euclidiană (de subspațiu), o măsură mult mai naturală a diferenței este \textit{distanța \(\ell^{2}\) la pătrat} \(d_{\ell^{2}} \colon \R^{d} \times \R^{d} \to \R\), definită ca 
+\begin{equation}\label{eq:cosine_similarity}
+    d_{\ell^{2}}(\vx, \vy) \doteq \frac{1}{2}\norm{\vx - \vy}_{2}^{2}, \qquad  \forall \vx, \vy \in \R^{d}.
+\end{equation}
+Acest scor bazat pe distanță este chiar mai eficient de calculat decât scorul de entropie încrucișată. Astfel, \(d_{\ell^{2}}\) ia locul lui \(d_{\CE}\) în simplificarea noastră.
+
+Înainte, colapsul era evitat folosind trucuri pentru a actualiza \(\vmu\) și \(\tau\). În simplificarea noastră, dacă comparăm caracteristicile în spațiul de reprezentare în loc să le convertim în probabilități, nu avem niciunul dintre acești parametri și astfel trebuie să considerăm o modalitate diferită de a evita colapsul. Pentru a face acest lucru, ne întoarcem la fundamente. Ideea de bază a evitării colapsului este că, pentru a ne asigura că toate mostrele nu returnează exact aceleași caracteristici, avem nevoie ca mostre diferite să aibă caracteristici diferite. Cu alte cuvinte, am dori ca \textit{covarianța} caracteristicilor să fie \textit{mare} într-un anumit sens. Dar din \Cref{ch:compression,ch:representation}, avem deja o cantitate care măsoară dimensiunea matricei de covarianță. Anume, folosim rata directă (la nivel de populație) \textit{de codare Gaussiană} \(R\) pentru a ne asigura că caracteristicile vederilor globale ale diferitelor imagini, care au informații globale diferite, sunt bine separate și nu colapsate (deci extinse). Pierderea generală modificată \(\cL_{\simdino}\) devine:
+\begin{equation}\label{eq:simdino_loss}
+    \cL_{\simdino}(\theta) \doteq \Ex[d_{\ell^{2}}(\vz_{\theta}(\vX_{g}),
+    \vz_{\theta}(\vX_{c}))] - \frac{\gamma}{2}\log\det\rp{\vI + \frac{d}{\eps^{2}}\Cov(\vz_{\theta}(\vX_{g}))},
+\end{equation}
+unde \(\eps > 0\) este fix și așteptările corespunzătoare sunt, ca înainte, luate peste date \(\vX\), vedere globală \(v_{g}\), și altă vedere (locală sau globală) \(v_{c}\). Pierderea din \eqref{eq:simdino_loss} este pierderea folosită pentru DINO simplificat („SimDINO"). Așa cum vom vedea, când este implementat corespunzător, funcționează cel puțin la fel de bine ca DINO original.
+
+\subsection{Arhitectură: Vision Transformer}\label{sub:contrastive_learning_architecture}
+
+Pentru arhitectură, folosim un transformer de viziune standard. Iată cum funcționează formal o astfel de arhitectură în contextul datelor de imagine. Amintiți-vă din \Cref{sec:experiment_setup} că există patru componente pentru o arhitectură encoder, și anume o încorporare, o coloană vertebrală, un extractor de caracteristici și un cap specific sarcinii. Discutăm aceste patru părți în prezent.
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=0.8\textwidth]{\toplevelprefix/chapters/chapter7/figs/patchify.pdf}
+    \caption{\small\textbf{Un exemplu de imagine transformată în patch-uri pătrate \(5 \times 5\), care sunt plasate în ordine raster.} Fiecare patch are aceeași dimensiune, iar grila de patch-uri are forma \((N_{H}, N_{W}) = (5, 5)\). Grila de patch-uri este apoi desfășurată într-o secvență de lungime \(5 \times 5 = 25\) în ordine raster.}
+    \label{fig:patchify_rasterize}
+\end{figure}
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/transformer_embedding.pdf}
+    \caption{\small\textbf{Pipeline-ul de încorporare transformer.} Dată o secvență de patch-uri desfășurate în ordine raster \(\vX^{\patch}\), fiecare patch desfășurat este proiectat liniar în spațiul caracteristicilor și echipat cu o codare pozițională (aditivă) și un token suplimentar cunoscut ca token de clasă. Ieșirea este caracteristica de intrare în primul strat \(\vZ_{\theta}^{1}(\vX) = f_{\theta}^{\emb}(\vX)\).}
+    \label{fig:transformer_embedding}
+\end{figure}
+
+\paragraph{Încorporare.} Date fiind datele de imagine \(\vX \in \cI\), le încorporăm ca o secvență de token-uri în \(\R^{d}\) folosind harta \(f_{\theta}^{\emb}\), după cum urmează. Primii doi pași sunt ilustrați în \Cref{fig:patchify_rasterize}, iar ultimii doi sunt ilustrați în \Cref{fig:transformer_embedding}.
+\begin{enumerate}
+    \item Mai întâi, transformăm datele de imagine \(\vX\) într-o secvență de patch-uri de formă \((C, P_{H}, P_{W})\) unde \(P_{H}\) și \(P_{W}\) sunt dimensiunile patch-urilor. Presupunem că \(P_{H}\) și \(P_{W}\) împart în mod egal înălțimea și lățimea lui \(\vX\), respectiv (în notația din \Cref{sub:contrastive_learning_objective} presupunem că \(P_{H}\) și \(P_{W}\) împart în mod egal \(S_{\loc}\) și \(S_{\glo}\)). Fie grila rezultată de patch-uri să aibă \(N_{H}\) rânduri și \(N_{W}\) coloane.
+    \item Desfășurăm fiecare patch într-un vector de lungime \(D \doteq CP_{H}P_{W}\). Există \(N \doteq N_{H}N_{W}\) vectori patch, pe care îi plasăm în „ordine raster" (stânga sus \(\to\) dreapta sus \(\to\) stânga jos \(\to\) dreapta jos) într-o matrice \(\vX^{\patch} \in \R^{D \times N}\), unde \(\vX^{\patch} \doteq f^{\patch}(\vX)\). Observați că \(D\) depinde doar de dimensiunea patch-ului și numărul de canale. Deoarece ultima cantitate este în mod normal constantă între mostrele din același set de date, \(D\) este același pentru toate imaginile din setul de date, în timp ce \(N\) este diferit pentru imagini mai mari și mai mici.
+    \item Apoi efectuăm următoarea operație pe \(\vX^{\patch} \in \R^{D \times N}\) pentru a o proiecta la \(\R^{d \times n}\) unde \(n \doteq N + 1\):
+    \begin{equation}
+        \vX^{\patch} \mapsto [\vz_{\cls}^{1}, \vW^{\emb}\vX] + \vE^{\pos}.
+    \end{equation}
+    Aici avem trei parametri antrenabili \(\vW^{\emb}\), \(\vz_{\cls}^{1}\), și \(\vE^{\pos}\) al căror scop este următorul:
+    \begin{itemize}
+        \item \(\vW^{\emb} \in \R^{d \times D}\) este o matrice care proiectează fiecare vector patch la o caracteristică token.
+        \item \(\vz_{\cls}^{1} \in \R^{d}\) este un așa-numit \textit{token de clasă} sau \textit{token registru}. Token-ul de clasă deține euristic informații globale despre toate datele și este folosit pentru sarcini în aval. În cadrul rețelelor profunde compresive din \Cref{ch:representation}, ne așteptăm ca token-ul de clasă să fie proiectat pe aceleași subspații ca token-urile saliente sau semantic relevante în timpul progresiei trecerii înainte.
+        \item \(\vE^{\pos} \in \R^{d \times N}\) este o așa-numită \textit{codare pozițională} care distinge token-urile diferitelor patch-uri unul de celălalt. Adică, caracteristicile token ar trebui să aibă informații poziționale, astfel încât harta generală \(f^{\pre}\) să nu fie invariantă la permutările patch-urilor, iar \(\vE^{\pos}\) inserează aceste informații poziționale. 
+        \begin{itemize}
+            \item În acest caz DINO, unde transformerul primește imagini de dimensiuni diferite, învățăm o codare pozițională pentru cea mai mare dimensiune primită în timpul antrenamentului și interpolăm pentru a obține codările poziționale pentru intrările de dimensiuni mai mici.
+        \end{itemize}
+    \end{itemize}
+\end{enumerate}
+Astfel, în final avem 
+\begin{equation}\label{eq:definition_of_embedding_module}
+    f_{\theta}^{\emb}(\vX) \doteq \mat{\vz_{\cls}^{1}, \vW^{\emb}f^{\patch}(\vX) + \vE^{\pos}}.
+\end{equation}
+Toți parametrii \(\vz_{\cls}^{1}, \vW^{\emb}, \vE^{\pos}\) sunt conținuți în setul de parametri \(\theta\).
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/transformer_backbone.pdf}
+    \caption{\small\textbf{Un strat \(f_{\theta}^{\ell}\) al coloanei vertebrale transformer.} Caracteristicile de intrare trec prin blocuri de normalizare de strat, auto-atenție multi-cap și perceptron multi-strat în secvență pentru a forma caracteristicile de ieșire ale stratului.}
+    \label{fig:transformer_backbone}
+\end{figure}
+
+\paragraph{Coloană vertebrală.} Dată o secvență de încorporări \(\vZ_{\theta}^{1}(\vX) \doteq f_{\theta}^{\emb}(\vX) \in (\R^{d})^{*}\), o procesăm folosind harta coloană vertebrală \(f_{\theta}^{\backbone}\) după cum urmează și așa cum este ilustrat în \Cref{fig:transformer_backbone}. Funcția \(f_{\theta}^{\backbone}\) este compusă din \(L\) \textit{straturi} \(f_{\theta}^{\ell}\), adică,
+\begin{equation}
+    f_{\theta}^{\backbone} = f_{\theta}^{L} \circ \cdots \circ f_{\theta}^{1}.
+\end{equation}
+Stratul \(f_{\theta}^{\ell}\) are următoarea implementare:
+\begin{align}\label{eq:vit-res-block}
+    \vZ_{\theta}^{\ell + 1/2}(\vX)
+    &= \vZ_{\theta}^{\ell}(\vX) + \MHSA_{\theta}^{\ell}(\LN_{\theta}^{1, \ell}(\vZ_{\theta}^{\ell}(\vX))) \\ 
+    \vZ_{\theta}^{\ell + 1}(\vX)
+    &= \vZ_{\theta}^{\ell + 1/2}(\vX) + \MLP_{\theta}^{\ell}(\LN_{\theta}^{2, \ell}(\vZ_{\theta}^{\ell + 1/2}(\vX)))
+\end{align}
+și \(f_{\theta}^{\ell}\) este definit astfel încât \(f_{\theta}^{\ell}(\vZ_{\theta}^{\ell}(\vX)) \doteq \vZ_{\theta}^{\ell + 1}(\vX)\). Aici am folosit câțiva operatori, cum ar fi \(\MHSA_{\theta}^{\ell}, \MLP_{\theta}^{\ell}\) și \(\LN_{\theta}^{i, \ell}\) care sunt definiți după cum urmează:
+\begin{itemize}
+    \item Operatorul \(\MHSA_{\theta}^{\ell}\) este auto-atenție multi-cap, predecesorul auto-atenției de subspațiu multi-cap (cf \Cref{ch:representation}). Formularea este următoarea:
+    \begin{align}
+        \MHSA_{\theta}^{\ell}(\vZ) \label{eq:mhsa}
+        &\doteq \vU_{\out}^{\ell}\mat{\SA([\vU_{\query}^{1, \ell}]^{\top}\vZ, [\vU_{\attnkey}^{1, \ell}]^{\top}\vZ, [\vU_{\val}^{1, \ell}]^{\top}\vZ) \\ \vdots \\ \SA([\vU_{\query}^{K, \ell}]^{\top}\vZ, [\vU_{\attnkey}^{K, \ell}]^{\top}\vZ, [\vU_{\val}^{K, \ell}]^{\top}\vZ)} + \vb_{\out}^{\ell}\vone_{n}^{\top}, \\
+        \label{eq:self_attention}
+        \text{unde} \qquad \SA(\vQ, \vK, \vV)
+        &\doteq \vV \underbrace{\softmax\rp{\frac{\vK^{\top}\vQ}{\sqrt{p}}}}_{\doteq \vA(\vQ, \vK)}
+    \end{align}
+    unde \(p\) este un întreg pozitiv, \(\vU_{\query}^{k, \ell}, \vU_{\attnkey}^{k, \ell}, \vU_{\val}^{k, \ell} \in \R^{d \times p}\), \(\vU_{\out}^{\ell} \in \R^{d \times Kp}\), și \(\vb_{\out}^{\ell} \in \R^{d}\) sunt parametri antrenabili conținuți în setul de parametri \(\theta\), iar \(\softmax\) este definit pe coloane ca 
+    \begin{align}
+        \softmax(\vM) 
+        &\doteq \mat{\softmax(\vm_{1}) & \cdots & \softmax(\vm_{p})}, \\ 
+        \forall \vM 
+        &= \mat{\vm_{1}, \dots, \vm_{p}} \in \R^{n \times p}.
+    \end{align}
+    În practică, dimensiunile sunt de obicei alese astfel încât \(Kp = d\). Termenii 
+    \begin{equation}
+        \label{eq:attention_map}
+        \vA_{\theta}^{k, \ell}(\vZ) \doteq \vA([\vU_{\query}^{k, \ell}]^{\top}\vZ, [\vU_{\attnkey}^{k, \ell}]^{\top}\vZ), \qquad \SA_{\theta}^{k, \ell}(\vZ) \doteq \SA([\vU_{\query}^{k, \ell}]^{\top}\vZ, [\vU_{\attnkey}^{k, \ell}]^{\top}\vZ, [\vU_{\val}^{k, \ell}]^{\top}\vZ)
+    \end{equation}
+    sunt de asemenea cunoscuți ca \textit{harta de atenție \(k\)} și respectiv \textit{ieșirea capului de atenție \(k\)} la stratul \(\ell\). Mai mult, operația \(\SA(\vQ, \vK, \vV)\) poate fi calculată extrem de eficient folosind software specializat precum FlashAttention \citep{shah2025flashattention}.
+    \item \(\MLP_{\theta}^{\ell}\) este un perceptron cu două straturi, o neliniaritate regulată folosită în rețelele profunde, și are forma 
+    \begin{equation}
+        \MLP_{\theta}^{\ell}(\vZ) \doteq \vW_{\down}^{\ell}\ReLU(\vW_{\up}^{\ell}\vZ + \vb_{\up}^{\ell}\vone_{n}^{\top}) + \vb_{\down}^{\ell}\vone_{n}^{\top}
+    \end{equation}
+    unde \(\vW_{\up}^{\ell} \in \R^{q \times d}, \vW_{\down}^{\ell} \in \R^{d \times q}, \vb_{\up}^{\ell} \in \R^{q}, \vb_{\down}^{\ell} \in \R^{d}\) sunt parametri antrenabili conținuți de asemenea în setul de parametri \(\theta\), iar \(\ReLU\) este neliniaritatea ReLU element cu element, adică, \(\ReLU(\vM)_{ij} = \max\{M_{ij}, 0\}\). 
+    \item Fiecare layer-norm \(\LN_{\theta}^{i, \ell}\) pentru \(i \in \{1, 2\}\) este o normalizare standard, care se aplică pe coloane la fiecare caracteristică token independent:
+    \begin{equation}
+        \LN_{\theta}^{i, \ell}(\vZ) = \LN_{\theta}^{i, \ell}(\mat{\vz_{1}, \dots, \vz_{n}}) = \mat{\LN_{\theta}^{i, \ell}(\vz_{1}), \dots, \LN_{\theta}^{i, \ell}(\vz_{n})}
+    \end{equation}
+    și are forma 
+    \begin{equation}
+        \LN_{\theta}^{i, \ell}(\vz) = \frac{\vz
+        - \operatorname{mean}(\vz)\vone_{d}}{\norm{\vz
+        - \operatorname{mean}(\vz)\vone_{d}}_{2}} \hada \valpha^{i, \ell} + \vbeta^{i, \ell} \qquad \text{unde} \qquad \operatorname{mean}(\vz) = \frac{1}{d}\vone_{d}^{\top}\vz
+    \end{equation}
+    unde \(\hada\) denotă înmulțirea element cu element, iar \(\valpha^{i, \ell}, \vbeta^{i, \ell} \in \R^{d}\) sunt parametri antrenabili conținuți în setul de parametri \(\theta\). Operatorul layer-norm servește ca un fel de normalizare pe fiecare token, unde scala fiecărui token după aceea este învățabilă și împărtășită între toate token-urile. 
+\end{itemize}
+
+Transformerul este una dintre cele mai populare arhitecturi de rețele neuronale din istorie, alimentând aplicații în aproape toate domeniile învățării profunde.
+
+\paragraph{Extractor de caracteristici.} Folosim un pas de post-procesare \(f_{\theta}^{\ext}\) care extrage \textit{caracteristica token de clasă}, care (amintiți-vă) este caracteristica menită să conțină informații agregate despre imaginea de intrare, și aplică un MLP și normalizare la aceasta. Anume, avem 
+\begin{equation}
+    \vz_{\theta}(\vX) \doteq f_{\theta}^{\ext}(\vZ_{\theta}(\vX)) = f_{\theta}^{\ext}([\vz_{\theta}^{1}(\vX), \dots, \vz_{\theta}^{n}(\vX)]) \doteq \frac{\MLP_{\theta}^{\ext}(\vz_{\theta}^{1}(\vX))}{\norm{\MLP_{\theta}^{\ext}(\vz_{\theta}^{1}(\vX))}_{2}}.
+\end{equation} 
+
+\paragraph{Cap specific sarcinii („DINO").} Pentru DINO, folosim capul DINO specific sarcinii \(h_{\vW, \vmu}\). Pentru SimDINO, nu folosim \textit{niciun} cap specific sarcinii \textit{deloc}, așa cum a fost descris anterior.
+
+\subsection{Strategie de Optimizare}\label{sub:contrastive_learning_optimization}
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/dino_pipeline.pdf}
+    \caption{\small \textbf{Pipeline-ul DINO.} Caracteristicile student și caracteristicile profesor sunt calculate pentru fiecare intrare. Obiectivul încearcă să alinieze caracteristicile student cu caracteristicile profesor prin proiectarea ambelor seturi de caracteristici într-un simplex de probabilitate de dimensiune înaltă și calcularea unei pierderi de entropie încrucișată. În mod notabil, din cauza „stop-grad", gradientul este calculat doar în raport cu \textit{ieșirile parametrilor student}.}
+    \label{fig:dino_pipeline}
+\end{figure}
+
+\paragraph{Optimizarea DINO.} Avem o funcție de pierdere și o arhitectură, așa că acum discutăm strategia de optimizare. Strategia de optimizare pentru DINO folosește \textit{două seturi de ponderi pentru aceeași arhitectură}: ponderi \textit{student} \(\theta_{\student}\) și ponderi \textit{profesor} \(\theta_{\teacher}\). Acestea corespund la două rețele neuronale diferite, numite rețeaua profesor și rețeaua student, cu aceeași arhitectură. Rețeaua profesor codifică toate vederile globale, în timp ce rețeaua student codifică toate vederile „alte". Scopul pierderii este de a distila ieșirile profesorului în modelul student. Anume, antrenăm pe pierderea \(\cL_{\dino{}-\student\teacher}\):
+\begin{equation}\label{eq:dino_loss_teacherstudent}
+    \cL_{\dino{}-\student\teacher}(\theta_{\student}, \theta_{\teacher}, \vW_{\student}, \vW_{\teacher}, \vmu) \doteq \Ex[d_{\CE}(\vp_{\theta_{\teacher}, \vW_{\teacher}, \vmu}(\vX_{g}), \vp_{\theta_{\student}, \vW_{\student}}(\vX_{c}))].
+\end{equation}
+Acum, putem descrie complet pipeline-ul general al DINO, ilustrat în \Cref{fig:dino_pipeline}.
+
+Deși este ușor să raționăm despre \eqref{eq:dino_loss_teacherstudent}, este imposibil în practică să implementăm algoritmi de optimizare cum ar fi gradientul descendent cu o pierdere dată de \(\cL_{\dino{}-\student\teacher}\). Acest lucru se datorează faptului că așteptările din pierdere sunt imposibil de evaluat, cu atât mai puțin de a lua gradientul. În acest caz extrem de frecvent, aproximăm așteptarea prin mostre finite. Adică, la fiecare pas de timp \(k\):
+\begin{itemize}
+    \item Sub-eșantionăm \(B\) puncte de date din setul nostru de date \(\{\vX_{1}^{(k)}, \dots, \vX_{B}^{(k)}\} \subset \cI\).
+    \item Pentru fiecare punct de date \(\vX_{b}^{(k)}\), eșantionăm \(M_{\glo}\) vederi globale \(v_{b, g}^{(k), i}\) și \(M_{\loc}\) vederi locale \(v_{b, \ell}^{(k), i}\). Aplicăm vederile la \(\vX_{b}^{(k)}\) pentru a obține \(\vX_{b, g}^{(k), i} \doteq v_{b, g}^{(k), i}(\vX_{b}^{(k)})\) și \(\vX_{b, \ell}^{(k), i} \doteq v_{b, \ell}^{(k), i}(\vX_{b}^{(k)})\).
+    \item Pentru fiecare vedere \textit{locală} \(\vX_{b, \ell}^{(k), i}\), calculăm următoarele cantități:
+    \begin{equation}
+        \vz_{\theta_{\student}}(\vX_{b, \ell}^{(k), i}) \doteq (f_{\theta_{\student}}^{\ext} \circ f_{\theta_{\student}})(\vX_{b, \ell}^{(k), i}), \qquad \vp_{\theta_{\student}, \vW_{\student}}(\vX_{b, \ell}^{(k), i}) \doteq h_{\vW_{\student}, \vzero_{m}}(\vz_{\theta_{\student}}(\vX_{b, \ell}^{(k), i}(\theta)))
+    \end{equation}
+    și pentru fiecare vedere \textit{globală} \(\vX_{b, g}^{(k), i}\), calculăm următoarele cantități (prin abuz de notație):
+    \begin{align}
+        &\vz_{\theta_{\student}}(\vX_{b, g}^{(k), i}) \doteq (f_{\theta_{\student}}^{\ext} \circ f_{\theta_{\student}})(\vX_{b, g}^{(k), i}), \qquad \vp_{\theta_{\student}, \vW_{\student}}(\vX_{b, g}^{(k), i}) \doteq h_{\vW_{\student}, \vzero_{m}}(\vz_{\theta_{\student}}(\vX_{b, g}^{(k), i})), \\
+        &\vz_{\theta_{\teacher}}(\vX_{b, g}^{(k), i}) \doteq (f_{\theta_{\teacher}}^{\ext} \circ f_{\theta_{\teacher}})(\vX_{b, g}^{(k), i}), \qquad \vp_{\theta_{\teacher}, \vW_{\teacher}, \vmu}(\vX_{b, g}^{(k), i}) \doteq h_{\vW_{\teacher}, \vmu}(\vZ_{\theta_{\teacher}}(\vX_{b, g}^{(k), i})).
+    \end{align}
+    \item Calculăm \textit{pierderea surogat, aproximată} \(\hat{\cL}_{\dino-\student\teacher}^{(k)}\), definită după cum urmează: 
+    \begin{align}\label{eq:dino_loss_teacherstudent_empirical}
+        &\hat{\cL}_{\dino{}-\student\teacher}^{(k)}(\theta_{\student}, \theta_{\teacher}, \vW_{\student}, \vW_{\teacher}, \vmu) \doteq
+        \frac{1}{BM_{\glo}(M_{\glo} + M_{\loc} - 1)}\sum_{b = 1}^{B}\sum_{i = 1}^{M_{\glo}}\\
+        &\Bigg[\sum_{j = 1}^{M_{\loc}}d_{\CE}(\vp_{\theta_{\teacher}, \vW_{\teacher}, \vmu}(\vX_{b, g}^{(k), i}), \vp_{\theta_{\student}, \vW_{\student}}(\vX_{b, \ell}^{(k), j})) + \sum_{\substack{j = 1 \\ j \neq i}}^{M_{\glo}}d_{\CE}(\vp_{\theta_{\teacher}, \vW_{\teacher}, \vmu}(\vX_{b, g}^{(k), i}), \vp_{\theta_{\student}, \vW_{\student}}(\vX_{b, g}^{(k), j}))\Bigg]\nonumber
+    \end{align}
+    precum și gradienții săi în raport cu \(\theta_{\student}\) și \(\vW_{\student}\), care ar trebui calculați sub presupunerea că \(\theta_{\teacher}\), \(\vW_{\teacher}\), și \(\vmu\) sunt constante --- adică că sunt \textit{detașate de graficul computațional} și nu depind de \(\theta_{\student}\) și \(\vW_{\student}\).
+    \item Actualizăm parametrii student \(\theta_{\student}\) și \(\vW_{\student}\) prin intermediul unui algoritm de optimizare iterativ bazat pe gradient, și actualizăm \(\theta_{\teacher}\), \(\vW_{\teacher}\), și \(\vmu\) prin medii mobile exponențiale cu parametri de decay \(\nu^{(k)}\), \(\nu^{(k)}\), și \(\rho^{(k)}\) respectiv, adică, 
+    \begin{align}
+        (\theta_{\student}^{(k + 1)}, \vW_{\student}^{(k + 1)})
+        &= \textsc{OptUpdate}^{(k)}(\theta_{\student}^{(k)}, \vW_{\student}^{(k)}; \nabla_{(\theta_{\student}, \vW_{\student})}\hat{\cL}_{\dino-\student\teacher}^{(k)}) \\
+        \theta_{\teacher}^{(k + 1)}
+        &= \nu^{(k)}\theta_{\teacher}^{(k)} + (1 - \nu^{(k)})\theta_{\student}^{(k + 1)} \\
+        \vW_{\teacher}^{(k + 1)}
+        &= \nu^{(k)}\vW_{\teacher}^{(k)} + (1 - \nu^{(k)})\vW_{\student}^{(k + 1)} \\
+        \vmu^{(k + 1)}
+        &= \rho^{(k)}\vmu^{(k)} + (1 - \rho^{(k)})\cdot\frac{1}{BM_{\glo}}\sum_{b = 1}^{B}\sum_{i = 1}^{M_{\glo}}\vW^{(k)}\vz_{\theta_{\teacher}}(\vX_{b, g}^{(k), i}),
+    \end{align}
+    De exemplu, dacă algoritmul de optimizare ales ar fi gradientul descendent stocastic, am avea actualizarea \(\theta_{\student}^{(k + 1)} \doteq \theta_{\student}^{(k)} - \delta^{(k)}\nabla_{\theta_{\student}}\hat{\cL}_{\dino{}-\student\teacher}^{(k)}\), și așa mai departe.
+\end{itemize}
+Observați că procedura de optimizare este destul de neregulată: deși toți cei patru parametri se schimbă la fiecare iterație, doar doi dintre ei sunt actualizați direct dintr-o metodă bazată pe gradient. Ceilalți doi sunt actualizați din medii mobile exponențiale și într-adevăr tratați ca constante când se calculează orice gradienți. După antrenament, aruncăm ponderile student și folosim ponderile profesor pentru rețeaua noastră antrenată \(f\), deoarece această medie mobilă exponențială s-a dovedit empiric că stabilizează modelul rezultat (această idee este cunoscută ca medierea Polyak sau medierea iterațiilor).
+
+Modul în care \(\nu\) și \(\rho\) se schimbă de-a lungul traiectoriei de optimizare (adică, funcțiile \(k \mapsto \nu^{(k)}\) și \(k \mapsto \rho^{(k)}\)) sunt hiperparametri sau decizii de design, cu \(\nu^{(1)} < 1\) și \(\lim_{k \to \infty}\nu^{(k)} = 1\) de obicei, și similar pentru \(\rho\). Hiperparametrul de temperatură \(\tau\), folosit în capul DINO \(h_{\vW, \vmu}\), se schimbă de asemenea de-a lungul traiectoriei de optimizare (deși această dependență nu este notată explicit).
+
+Folosirea pierderii surogat („empirice") transformă problema noastră de optimizare intractabilă, ca în optimizarea pierderii din \eqref{eq:dino_loss_teacherstudent}, într-o problemă de optimizare stocastică tractabilă care este rulată pentru a antrena în esență fiecare model de învățare profundă din lume. Această conversie este extrem de naturală odată ce ați văzut câteva exemple, și sperăm să oferim aceste exemple pe parcursul capitolului.
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=0.7\textwidth]{\toplevelprefix/chapters/chapter7/figs/simdino_pipeline.pdf}
+    \caption{\small\textbf{Pipeline-ul SimDINO.} Aici, în contrast cu pipeline-ul DINO din \Cref{fig:dino_pipeline}, pierderea este calculată direct pe caracteristici fără necesitatea unei manipulări suplimentare. Acest lucru elimină parametrii a câtorva matrice mari și simplifică pipeline-ul, făcându-l simultan mai stabil de antrenat.}\label{fig:simdino_pipeline}
+\end{figure}
+
+\paragraph{Optimizarea SimDINO.} Obiectivul la nivel de populație DINO simplificat este foarte similar în spirit, dar mult mai simplu în execuție, adică,
+\begin{equation}\label{eq:simdino_loss_teacherstudent}
+    \cL_{\simdino-\student\teacher}(\theta_{\student}, \theta_{\teacher}) \doteq
+    \Ex\rs{d_{\ell^{2}}(\vz_{\theta_{\teacher}}(\vX_{g}),
+    \vz_{\theta_{\student}}(\vX_{c}))} - \frac{\gamma}{2}\log\det\rp{\vI + \frac{d}{\eps^{2}}\Cov(\vz_{\theta_{\student}}(\vX_{g})))}.
+\end{equation}
+Astfel, așa cum este elaborat în \Cref{fig:simdino_pipeline}, pipeline-ul SimDINO este strict mai simplu decât pipeline-ul DINO. Putem folosi o versiune mai simplă a pipeline-ului de antrenament DINO pentru a optimiza SimDINO. La fiecare pas de timp \(k\):
+\begin{itemize}
+    \item Sub-eșantionăm \(B\) puncte de date din setul nostru de date \(\{\vX_{1}^{(k)}, \dots, \vX_{B}^{(k)}\} \subset \cI\).
+    \item Pentru fiecare punct de date \(\vX_{b}^{(k)}\), eșantionăm \(M_{\glo}\) vederi globale \(v_{b, g}^{(k), i}\) și \(M_{\loc}\) vederi locale \(v_{b, \ell}^{(k), i}\). Aplicăm vederile la \(\vX_{b}^{(k)}\) pentru a obține \(\vX_{b, g}^{(k), i} \doteq v_{b, g}^{(k), i}(\vX_{b}^{(k)})\) și \(\vX_{b, \ell}^{(k), i} \doteq v_{b, \ell}^{(k), i}(\vX_{b}^{(k)})\).
+    \item Pentru fiecare vedere \textit{locală} \(\vX_{b, \ell}^{(k), i}\) calculăm \(\vz_{\theta_{\student}}(\vX_{b, \ell}^{(k), i}) \doteq (f_{\theta_{\student}}^{\ext} \circ f_{\theta_{\student}})(\vX_{b, \ell}^{(k), i})\). Pentru fiecare vedere \textit{globală} \(\vX_{b, g}^{(k), i}\) calculăm \(\vz_{\theta_{\student}}(\vX_{b, g}^{(k), i}) \doteq (f_{\theta_{\student}}^{\ext} \circ f_{\theta_{\student}})(\vX_{b, g}^{(k), i})\) și \(\vz_{\theta_{\teacher}}(\vX_{b, g}^{(k), i}) \doteq (f_{\theta_{\teacher}}^{\ext} \circ f_{\theta_{\teacher}})(\vX_{b, g}^{(k), i})\).
+    \item Calculăm \textit{pierderea surogat, aproximată} \(\hat{\cL}_{\simdino-\student\teacher}^{(k)}\), definită după cum urmează: 
+    \begin{align}\label{eq:simdino_loss_teacherstudent_empirical}
+        &\hat{\cL}_{\simdino{}-\student\teacher}^{(k)}(\theta_{\student}, \theta_{\teacher}) \doteq
+        \frac{1}{BM_{\glo}(M_{\glo} + M_{\loc} - 1)}\sum_{b = 1}^{B}\sum_{i = 1}^{M_{\glo}}\Bigg[\sum_{j = 1}^{M_{\loc}}d_{\ell^{2}}(\vz_{\theta_{\teacher}}(\vX_{b, g}^{(k), i}), \vz_{\theta_{\student}}(\vX_{b, \ell}^{(k), j})) \\ 
+        &\qquad \qquad + \sum_{j = 1}^{M_{\glo}}d_{\ell^{2}}(\vz_{\theta_{\teacher}}(\vX_{b, g}^{(k), i}), \vz_{\theta_{\student}}(\vX_{b, g}^{(k), j}))\Bigg] - \frac{\gamma}{M_{\glo}}\sum_{i = 1}^{M_{\glo}}R_{\eps}([\vz_{\theta_{\student}}(\vX_{1, g}^{(k), i}), \dots, \vz_{\theta_{\student}}(\vX_{B, g}^{(k), i})])\nonumber
+    \end{align}
+    unde \(R_{\eps}\) este rata de codare Gaussiană estimată pe mostre finite, descrisă în \Cref{ch:representation}. Gradientul lui \(\hat{\cL}_{\simdino-\student\teacher}^{(k)}\) în raport cu \(\theta_{\student}\) ar trebui (din nou) calculat, sub presupunerea că \(\theta_{\teacher}\) este constantă.
+    \item Actualizăm parametrii student \(\theta_{\student}\) prin intermediul unui algoritm de optimizare iterativ bazat pe gradient, și actualizăm \(\theta_{\teacher}\) prin intermediul unei medii mobile exponențiale cu parametru de decay \(\nu^{(k)}\), adică, 
+    \begin{align}
+        \theta_{\student}^{(k + 1)}
+        &= \textsc{OptUpdate}^{(k)}(\theta_{\student}^{(k)}; \nabla_{\theta_{\student}}\hat{\cL}_{\simdino-\student\teacher}^{(k)}) \\
+        \theta_{\teacher}^{(k + 1)}
+        &= \nu^{(k)}\theta_{\teacher}^{(k)} + (1 - \nu^{(k)})\theta_{\student}^{(k + 1)}.
+    \end{align}
+\end{itemize}
+Din nou, reiterăm că gradientul este luat doar în raport cu \(\theta_{\student}\), tratând \(\theta_{\teacher}\) ca o constantă. Aici, observați că, în timp ce alegerea lui \(\nu\) este încă o decizie de design, hiperparametrii \(\rho\) și \(\tau\) sunt eliminați.
+
+
+\subsection{Metodologie de Evaluare}\label{sub:contrastive_learning_evals}
+Există mai multe moduri de a evalua un model transformer antrenat. Evidențiem două în această secțiune. Să definim vederea \textit{decupare centrală} \(v_{\cc} \colon \cI \to \cI\) care este o \textit{decupare redimensionată deterministă}:
+\begin{itemize}
+    \item redimensionează imaginea astfel încât marginea cea mai scurtă să fie de dimensiune \(S_{\rsz}\) (similar cu decupările redimensionate aleatorii cu parametru de procent de suprafață \(1\));
+    \item apoi ia decuparea \textit{centrală} \(S_{\cc} \times S_{\cc}\);
+\end{itemize}
+astfel încât forma finală este \((C, S_{\cc}, S_{\cc})\). Observați că vederea \(v_{\cc}\) este complet deterministă dată o intrare. Pentru o intrare \(\vX\), scriem \(\vX_{\cc} \doteq v_{\cc}(\vX)\). Aici \(S_{\cc} \leq S_{\rsz}\).
+
+
+\paragraph{Sondare liniară.}
+
+Primul și cel mai agnostic arhitectural mod de a evalua un model encoder \(\vX \mapsto \vz_{\theta}(\vX)\) este să folosim \textit{sondarea liniară}. Sondarea liniară este, într-o propoziție, rularea regresiei logistice pe caracteristicile agregate calculate de encoder. Acest lucru ne spune câtă informație semantică există în reprezentări, precum și cât de ușor poate fi extrasă această informație. (Adică: în ce măsură caracteristicile imaginilor cu semantici diferite trăiesc pe subspații diferite ale spațiului caracteristicilor?)
+
+Mai formal, să presupunem că vrem să evaluăm calitatea și fidelitatea caracteristicilor encoder-ului pe date imagine-etichetă \((\vX, \vy)\), unde există \(N_{\cls}\) clase și \(\vy \in \{0, 1\}^{N_{\cls}}\) este o „codare one-hot" (adică, zerouri în toate pozițiile, cu excepția unui \(1\) în poziția \(i\) dacă \(\vX\) este în clasa \(i\)). O modalitate de a face acest lucru este să rezolvăm problema de regresie logistică 
+\begin{equation}\label{eq:linear_probing}
+    \min_{\vW \in \R^{N_{\cls} \times d}}\Ex[\CE(\vy, \vW \vz_{\theta}(\vX_{\cc}))].
+\end{equation}
+Mai practic, dacă avem date etichetate \(\{(\vX_{b}, \vy_{b})\}_{b = 1}^{B}\), putem rezolva problema de regresie logistică \textit{empirică} (asemănătoare cu \eqref{eq:dino_loss_teacherstudent} vs.~\eqref{eq:dino_loss_teacherstudent_empirical}) dată de 
+\begin{equation}\label{eq:linear_probing_empirical}
+    \min_{\vW \in \R^{N_{\cls} \times d}}\frac{1}{B}\sum_{b = 1}^{B}\CE(\vy_{b}, \vW \vz_{\theta}(\vX_{b, \cc})).
+\end{equation}
+Această problemă este o problemă de optimizare convexă în \(\vW\), și astfel poate fi rezolvată eficient prin gradient descendent (stocastic) sau o multitudine de alți algoritmi. Această sondă liniară, împreună cu encoder-ul, poate fi folosită ca un clasificator, și putem evalua acuratețea clasificării. Practica obișnuită este să antrenăm modelul mai întâi pe un set de date mare (cum ar fi ImageNet-1K), apoi să antrenăm sonda liniară pe un set de date (cum ar fi setul de date de antrenament al CIFAR-10), și să o evaluăm pe un al treilea set de date („holdout") care este extras din aceeași distribuție ca al doilea (cum ar fi setul de date de evaluare al CIFAR-10).
+
+\paragraph{\(k\)-vecini cei mai apropiați.} Putem evalua de asemenea performanța caracteristicilor pe sarcini de clasificare \textit{fără a fi nevoie să antrenăm explicit un clasificator} folosind algoritmul \(k\)-vecini cei mai apropiați pentru a obține o etichetă medie prezisă. Anume, dat un set de date \(\{\vz_{b}\}_{b = 1}^{B} \subseteq \R^{d}\), definim cei \(k\)-vecini cei mai apropiați ai unui alt punct \(\vz \in \R^{d}\) ca \(\operatorname{NN}_{k}(\vz, \{\vz_{b}\}_{b = 1}^{B})\). Folosind această notație, putem calcula eticheta prezisă \(\hat{\vy}_{\theta}(\vX \mid \{(\vX_{b}, \vy_{b})\}_{b = 1}^{B})\) ca 
+\begin{equation}
+    \hat{\vy}_{\theta}(\vX \mid \{(\vX_{b}, \vy_{b})\}_{b = 1}^{B}) = \vone(i^{\star}) \quad \text{unde} \quad i^{\star} \doteq \argmax_{i \in [Q]}\sum_{b = 1}^{B}\vy_{b}\indvar[\vz_{\theta}(\vX_{\cc, b}) \in \operatorname{NN}_{k}(\vz_{\theta}(\vX_{\cc}))].
+\end{equation}
+Aici, \(\vone(i) \in \Delta_{N_{\cls}}\) este (prin abuz de notație, cf.~variabile indicator) vectorul de probabilitate one-hot susținut la \(i\), adică, \(1\) în coordonata \(i\) și \(0\) în altă parte. Adică, această procedură ia eticheta cea mai comună dintre cele \(k\) puncte cele mai apropiate în spațiul caracteristicilor. Acuratețea clasificării \(k\)-vecini cei mai apropiați este doar acuratețea acestei etichete prezise, anume,
+\begin{equation}
+    \Ex_{\vX, \vy}[\indvar(\hat{\vy}_{\theta}(\vX \mid \{(\vX_{b}, \vy_{b})\}_{b = 1}^{B}) = \vy)]
+\end{equation}
+sau mai frecvent versiunea sa empirică corespunzătoare, unde \((\vX, \vy)\) variază peste un set de date finit (\textit{nu} mostrele existente \((\vX_{b}, \vy_{b})\) care sunt folosite pentru cei \(k\) vecini).
+
+\paragraph{Fidelitatea hărților de atenție.}
+
+Un alt mod de a verifica performanța reprezentărilor, pentru un encoder bazat pe transformer, este să examinăm fidelitatea hărților de atenție \(\vA^{L, k} \in \R^{n \times n}\) așa cum sunt definite în \Cref{eq:attention_map}, la ultimul strat \(L\), și date de următorul pipeline:
+\begin{align}
+    \vX \mapsto \cdots \mapsto \vZ^{L - 1} = [\underbrace{\vz_{1}^{L - 1}}_{\text{token clasă}}, \underbrace{\vz_{2}^{L - 1} \dots, \vz_{n}^{L - 1}}_{\text{token-uri patch}}] \mapsto \vA^{k, L} = \mat{\vA_{1, 1}^{k, L} & \vA_{1, 2:}^{k, L} \\ \vA_{2:, 1}^{k, L} & \vA_{2:, 2:}^{k, L}}.
+\end{align}
+În special, examinăm ce dezvăluie hărțile de atenție pentru o intrare dată despre obiectele saliente din imaginea de intrare, adică, care părți ale imaginii oferă cele mai relevante informații global pentru token-ul de clasă. O modalitate particulară de a face acest lucru este să examinăm componenta hărții de atenție unde token-ul de clasă este extras ca interogare și eliminat din matricea de valori, adică, \(\vA_{2:, 1}^{k, L} \in \R^{1 \times (n - 1)} = \R^{1 \times N}\) sau transpusa sa \(\va^{k, L} = (\vA_{2:, 1}^{k, L})^{\top} \in \R^{N}\). Observați că acest vector \(\va^{k, L}\), pe care îl etichetăm ca „\textit{vectorul de saliență} la al \(k\)-lea cap de atenție la stratul \(L\)," are o valoare pentru fiecare patch, \(1, \dots, N\), și folosim această valoare pentru a descrie cât de relevant este fiecare patch pentru informația globală. În special, pentru vizualizare, creăm o nouă imagine unde fiecare patch este înlocuit cu valoarea sa corespunzătoare din vectorul de saliență, prezentând contribuția fiecărui patch; numim această imagine „\textit{harta de saliență} la al \(k\)-lea cap de atenție la stratul \(L\)". Pentru a vizualiza relevanța totală a fiecărui patch pentru informația globală în toate capetele, putem media vectorul de saliență, adică, \(\tilde{\va}^{L} \doteq \frac{1}{K}\sum_{k = 1}^{K}\va^{k, L}\) și extinde în \textit{harta de saliență medie}. Hărțile de saliență medie ar trebui să evidențieze părțile relevante ale imaginii de intrare.
+
+
+\paragraph{Detectarea și segmentarea obiectelor.}
+
+Putem evalua cum captează reprezentările proprietățile fine (adică, mai mici sau mai detaliate) ale intrării folosindu-le pentru \textit{segmentare semantică}. În linii mari, aceasta înseamnă că folosim caracteristicile pentru a construi casete de delimitare pentru toate obiectele din intrare. Există mai multe moduri de a face acest lucru și mai multe moduri de a scora casetele de delimitare rezultate comparativ cu adevărul de bază. Fiecare combinație de metode corespunde unei metrici particulare de segmentare. Nu le descriem formal aici, deoarece nu sunt deosebit de perspicace, dar lucrarea DINO \citep{caron2021emerging} și lucrarea DINOv2 \citep{oquab2023dinov2} conțin referințe la toate metricile care sunt folosite în practică.
+
+\subsection{Configurare Experimentală și Rezultate} \label{sub:contrastive_learning_experiment_results}
+
+Deoarece SimDINO este construit direct pe DINO, comparăm setările optime pentru DINO așa cum sunt date de lucrarea lor originală \citep{caron2021emerging} cu aceleași setări aplicate la SimDINO pentru o comparație corectă.
+
+\paragraph{Funcție obiectiv.} Folosim \(10\) vederi locale (adică, \(M_{\loc} = 10\)) de rezoluție \(96 \times 96\) (adică, \(S_{\loc} = 96\)) și \(2\) vederi globale (adică, \(M_{\glo} = 2\)) de rezoluție \(224 \times 224\) (adică, \(S_{\glo} = 224\)) pentru toate experimentele. Porțiunile corespunzătoare ale imaginilor originale decupate pentru vederile locale și globale sunt \(p_{\loc} \in [\frac{1}{20}, \frac{3}{10}]\) și \(p_{\glo} \in [\frac{3}{10}, 1]\) (alese aleatoriu per-vedere). Dimensiunea marginii mai mici în decupările redimensionate este \(S_{\rsz} = 256\), iar dimensiunea marginii vederii de decupare centrală (evaluare) este \(S_{\cc} = 224\). Toate aceste setări se aplică atât la DINO, cât și la SimDINO.
+
+\paragraph{Arhitectura modelului.} Pentru toate intrările, setăm dimensiunea patch-ului să fie \(16 \times 16\) (anume, \(P_{H} = P_{W} = 16\)). Folosim modelele mici, de bază și mari ale arhitecturii ViT \citep{dosovitskiy2020image} ca încorporare și coloană vertebrală. Extractorul de caracteristici este un MLP cu trei straturi cu o dimensiune ascunsă de \(2048\) și o dimensiune de ieșire de \(256\), urmată de o normalizare \(\ell^{2}\), așa cum este specificat în \Cref{sub:contrastive_learning_architecture}. Pentru arhitecturile DINO (adică, nu arhitecturile SimDINO), capul DINO \(\vW\) este o matrice în \(\R^{65536 \times 256}\), iar parametrul \(\vmu\) este un vector în \(\R^{65536}\).
+
+\paragraph{Seturi de date și optimizare.} Pentru pre-antrenament, atât reproducerea noastră DINO, cât și SimDINO folosesc setul de date ImageNet-1K pentru toate metodele. Folosim AdamW \citep{Loshchilov2017DecoupledWD} ca optimizator, care este o alegere foarte standard. Urmăm următoarele recomandări de hiperparametri:
+\begin{itemize}
+    \item Dimensiunea lotului este \(B = 1024\).
+    \item Rata de învățare (pentru AdamW și modelul student) are valoarea „de bază" \(2 \times 10^{-3}\). În primele \(10\) epoci, rata de învățare crește liniar de la \(0\) la valoarea de bază (adică, la epoca \(i\), rata de învățare este \((i/10) \cdot 2 \times 10^{-3}\), pentru \(1 \leq i \leq 10\)). Apoi, în următoarele \(90\) de epoci, rata de învățare scade printr-un așa-numit \textit{program cosinus} înapoi la \(0\). Definiția unui program cosinus este dată în multe locuri, inclusiv \href{https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.CosineAnnealingLR.html}{documentația PyTorch}, și este folosit frecvent când se antrenează modele de viziune profundă.
+    \item Decăderea ponderilor (W în AdamW) urmează un program cosinus de la 0.04 la \(0.4\) pe parcursul antrenamentului.
+    \item Rata EMA \(\nu\) urmează un program cosinus de la \(0.996\) la \(1.0\) pe parcursul antrenamentului. În mod specific pentru DINO, rata EMA de centrare \(\rho\) este fixată la \(0.9\).
+    \item În mod specific pentru DINO, temperatura profesorului \(\tau_{\teacher}\) este fixată la \(0.1\), în timp ce temperatura studentului \(\tau_{\student}\) crește liniar de la \(0.04\) la \(0.07\) în primele \(30\) de epoci și este fixată la \(0.07\) după aceea.
+\end{itemize}
+Folosim unele augmentări de date (în esență care păstrează informația), cum ar fi răsturnări, jittering de culoare, blur Gaussian și solarizare, pentru fiecare imagine văzută în timpul antrenamentului, înainte de a lua vederile locale și globale. Hiperparametrii exacți care guvernează acestea nu sunt listați aici, dar sunt referențiați în lucrarea DINO \citep{caron2021emerging}.
+
+Pentru sondarea liniară, sonda liniară este de obicei antrenată folosind optimizatorul AdamW cu rata de învățare \(2 \times 10^{-4}\), decăderea ponderilor \(0.01\) și dimensiunea lotului \(512\), dar acestea sunt adesea modificate de la caz la caz pentru a minimiza pierderea.
+
+
+\begin{table}
+    \centering
+    \begin{tabular}{@{}lcccc@{}} %
+        \toprule
+        Metodă & Model & Epoci & 20-NN & Sondare Liniară 
+        \\
+        \midrule 
+        DINO & ViT-B & 100 & 72.9 & 76.3 \\
+        SimDINO & ViT-B & 100 & \bf 74.9 & \bf 77.3 \\
+        DINO & ViT-L & 100 & -- & -- \\
+        SimDINO & ViT-L & 100 & \bf 75.6 & \bf 77.4 \\
+        \midrule
+        \color{gray} SwAV & \color{gray} ViT-S & \color{gray} 800 & \color{gray} 66.3 & \color{gray} 73.5 \\
+        \color{gray} MoCov3 & \color{gray} ViT-B & \color{gray} 300  & \color{gray} -- & \color{gray} 76.7 \\
+        \bottomrule
+    \end{tabular}
+    \caption{\small\textbf{Performanța de clasificare} pe date de test holdout pentru DINO și SimDINO, folosind atât acuratețea \(k\)-vecini cei mai apropiați (\(k = 20\)) cât și sondarea liniară. La același număr de iterații (\(100\)), SimDINO este în mod clar mai bun în termeni de performanță și este mai stabil (antrenamentul DINO care rulează pe coloana vertebrală ViT-L cu setările furnizate are optimizare foarte instabilă și obține pierdere NaN în scurt timp). Comparăm de asemenea cu alte metode remarcabile, anume SwAV și MoCov3, pe care DINO a fost construit.}
+    \label{tab:dino_imagenet_linear_probing}
+\end{table}
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/dino_attention_maps.png}
+    \caption{\small\textbf{O comparație calitativă a hărților de saliență} generate de DINO \textit{(rândul din mijloc)} și de SimDINO \textit{(rândul de jos)}. Pentru fiecare imagine, calculăm și afișăm harta de saliență medie în ultimul strat \(L\). Hărțile de saliență sunt similare între modele, ceea ce înseamnă că toate modelele converg la o noțiune similară despre ce obiecte sunt importante. Rețineți că, deși \(X_{\evaluation}\) este o imagine pătrată, este interpolată înapoi în formă dreptunghiulară pentru a face această vizualizare.}
+    \label{fig:dino_attention_maps_saliency}
+\end{figure}
+
+\begin{table}
+    \centering 
+    \begin{tabular}{@{}llcccccccc@{}}
+        \toprule
+         &  & \multicolumn{3}{c}{Detecție $\uparrow$} &  \multicolumn{3}{c}{Segmentare $\uparrow$} \\ 
+        Metodă & Model & AP$_{50}$  & AP$_{75}$ & AP & AP$_{50}$ & AP$_{75}$ & AP  \\ 
+        \midrule
+        SimDINO &ViT-L/16 &\bf 5.4 &1.9 &2.4 &4.5 &1.4 &1.9 \\
+        SimDINO &ViT-B/16 &5.2 & \bf 2.0 & \bf 2.5 & \bf4.7 & \bf 1.5 & \bf 2.0 \\
+        DINO &ViT-B/16 &3.9 &1.5 &1.8 &3.1 &1.0 &1.4 \\
+        \midrule
+        \color{gray} DINO & \color{gray} ViT-B/8 & \color{gray}5.1 & \color{gray}2.3 & \color{gray}2.5 & \color{gray}4.1 & \color{gray}1.3 & \color{gray}1.8 \\
+        \bottomrule
+    \end{tabular}
+    \caption{\small\textbf{Performanța de segmentare} a modelelor DINO și SimDINO pre-antrenate pe COCO val2017 \citep{lin2014microsoft}, un set de date de segmentare care conține metadate de localizare a obiectelor. Nu antrenăm pe COCO, folosind doar încorporarea și coloana vertebrală pre-antrenate, iar casetele de delimitare sunt extrase din caracteristici printr-o metodă numită MaskCut \citep{wang2023cut}. Cu toate acestea, SimDINO depășește DINO la detecția și segmentarea obiectelor sub comparație corectă și chiar depășește DINO cu dimensiune mai mică a patch-ului (lungime laterală \(8\) în loc de \(16\)). Dimensiunile mai mici ale patch-urilor sunt cunoscute că ajută performanța, în special cu sarcinile de detecție și segmentare, așa că acest rezultat este destul de surprinzător și încurajator.}
+    \label{tab:dino_segmentation}
+\end{table}
+
+\paragraph{Rezultatele evaluării.} În ceea ce privește performanța de clasificare în aval, obținem performanța din \Cref{tab:dino_imagenet_linear_probing}. Observăm că performanța SimDINO este mult mai mare decât cea a DINO sub comparație corectă. De asemenea, este mult mai stabilă: setările prescrise ale DINO nu pot antrena un model ViT-L(arge). Pe de altă parte, \Cref{fig:dino_attention_maps_saliency} arată vizualizări ale hărților de saliență medie în DINO și DINO-ul nostru simplificat, observând că hărțile de saliență arată destul de similar între modele, indicând că modelele învață caracteristici care sunt cel puțin la fel de bune la captarea detaliilor fine. Performanțele de segmentare și detecție a obiectelor din \Cref{tab:dino_segmentation} confirmă această afirmație cantitativ, unde caracteristicile SimDINO arată o îmbunătățire substanțială față de cele ale DINO.
+
+
+
+\section{Clasificarea Imaginilor}\label{sec:image_classification}
+
+În secțiunea anterioară, am simplificat un obiectiv de învățare excesiv de complex folosind intuiția noastră despre învățarea reprezentărilor prin prisma compresiei. Cu toate acestea, multe dintre cele mai populare proceduri de învățare sunt incredibil de simple. În aceste cazuri, este dificil să simplificăm și mai mult obiectivul. Astfel, în aceasta și în secțiunile viitoare, ne vom concentra pe modalități principiale de a modifica \textit{arhitecturile de rețele profunde} pentru o varietate de sarcini.
+
+Să începem mai întâi cu, fără îndoială, cea mai clasică sarcină din învățarea automată: \textit{clasificarea imaginilor}, care este adesea folosită ca sarcină standard pentru a evalua algoritmii de recunoaștere a modelelor sau arhitecturile de rețele profunde. Din discuția noastră despre arhitecturi white-box din \Cref{ch:representation}, avem nevoie doar de o sarcină semnificativă semantic pentru a învăța reprezentări bune cu arhitecturi white-box. Vom valida această idee în această secțiune.
+
+Mai întâi, setul de date rămâne în mare parte același ca în \Cref{sub:contrastive_learning_data}. Atât datele de antrenament, cât și cele de test constau din imagini etichetate, adică perechi imagine-etichetă \((\vX, \vy) \in \R^{C \times H \times W} \times \{0, 1\}^{N_{\cls}}\). Aplicăm în continuare diverse augmentări de date (de exemplu, răsturnări, blur Gaussian, solarizare etc.) la fiecare mostră din fiecare lot nou.
+
+\subsection{Sarcină și Obiectiv} \label{sub:image_classification_objective}
+
+Spre deosebire de înainte, sarcina noastră nu este doar să învățăm o reprezentare bună a datelor, ci și să construim simultan un clasificator. Formal, avem perechi de date etichetate \((\vX, \vy)\), unde \(\vy \in \{0, 1\}^{N_{\cls}}\) este un vector one-hot care denotă apartenența la clasă a lui \(\vX\). Considerăm o \textit{vedere de decupare centrală} deterministă \(v_{\cc}\) a datelor de intrare \(\vX\) (cf \Cref{sub:contrastive_learning_objective}). Vrem să antrenăm împreună o mapare de caracteristici \((f_{\theta}, f_{\theta}^{\ext})\) și un \textit{cap de clasificare} \(h_{\theta}\), definit după cum urmează:
+\begin{equation}
+    h_{\theta}(\vz) \doteq \softmax(\vW^{\head}\vz + \vb^{\head}), \qquad  \forall \vz \in \R^{d}
+\end{equation}
+unde \((\vW^{\head}, \vb^{\head}) \in \R^{N_{\cls} \times d} \times \R^{N_{\cls}}\) sunt parametri antrenabili în setul de parametri \(\theta\), astfel încât harta \(\vX_{\cc} \mapsto \vp_{\theta}(\vX_{\cc}) \doteq h_{\theta}(\vz_{\theta}(\vX_{\cc}))\) prezice o etichetă netedă pentru vederea \(\vX_{\cc} = v_{\cc}(\vX)\) a intrării \(\vX\). Problema de învățare încearcă să minimizeze distanța dintre \(\vp_{\theta}\) și \(\vy\) măsurată prin entropie încrucișată:
+\begin{equation}\label{eq:classification_ce_loss}
+    \min_{\theta}\bc{\cL_{\CE}(\theta) \doteq \Ex[\CE(\vy, \vp_{\theta}(\vX_{\cc}))]}.
+\end{equation}
+
+
+\subsection{Arhitectura CRATE}\label{sub:image_classification_architecture}
+
+Arhitectura pe care o folosim este arhitectura CRATE, descrisă în detaliu în \Cref{ch:representation}. Configurarea generală este similară cu cea a transformerului obișnuit din \Cref{sub:contrastive_learning_architecture}, cu câteva modificări. În timp ce pasul de încorporare este același ca atât DINO, cât și SimDINO în \Cref{sub:contrastive_learning_architecture}, pasul de extracție a caracteristicilor este același ca SimDINO în \Cref{sub:contrastive_learning_architecture}, deoarece doar extrage caracteristica corespunzătoare token-ului de clasă, iar capul de clasificare este descris în \Cref{sub:image_classification_objective}, arhitectura coloanei vertebrale este diferită. Fiecare strat ia forma
+\begin{align}\label{eq:CARTE updates}
+    \vZ_{\theta}^{\ell + 1/2}(\vX)
+    &= \vZ_{\theta}^{\ell}(\vX) + \MSSA_{\theta}^{\ell}(\LN_{\theta}^{1, \ell}(\vZ_{\theta}^{\ell}(\vX))), \\ 
+    \vZ_{\theta}^{\ell + 1}(\vX)
+    &= \ISTA_{\theta}^{\ell}(\LN_{\theta}^{2, \ell}(\vZ_{\theta}^{\ell + 1/2}(\vX))),
+\end{align}
+unde blocurile \(\MSSA_{\theta}^{\ell}\) și \(\ISTA_{\theta}^{\ell}\) sunt așa cum sunt descrise în \Cref{ch:representation}, anume:
+\begin{itemize}
+    \item Operatorul \(\MSSA\) este auto-atenție multi-cap-subspațiu, definit după cum urmează:
+    \begin{equation}
+        \MSSA_{\theta}^{\ell}(\vZ) \doteq \vU_{\out}^{\ell}\mat{\SA([\vU^{1, \ell}]^{\top}\vZ, [\vU^{1, \ell}]^{\top}\vZ, [\vU^{1, \ell}]^{\top}\vZ)\\ \vdots \\ \SA([\vU^{K, \ell}]^{\top}\vZ, [\vU^{K, \ell}]^{\top}\vZ, [\vU^{1, \ell}]^{\top}\vZ)} + \vb_{\out}^{\ell}\vone_{n}^{\top}
+    \end{equation}
+    unde \(\vU^{k, \ell} \in \R^{d \times p}\), \(\vU_{\out}^{\ell} \in \R^{d \times Kp}\), și \(\vb_{\out}^{\ell} \in \R^{d}\) sunt parametri antrenabili aparținând setului de parametri \(\theta\), și (amintiți-vă) operatorul de auto-atenție \(\SA\) este definit în \eqref{eq:self_attention}.
+    \item Operatorul \(\ISTA\) este operatorul algoritm-iterativ-de-micșorare-pragare, definit după cum urmează:
+    \begin{equation}
+        \ISTA_{\theta}^{\ell}(\vZ) \doteq \ReLU(\vZ - \beta (\vD^{\ell})^{\top}(\vD^{\ell}\vZ - \vZ) + \beta\lambda \vone_{d}\vone_{n}^{\top}),
+    \end{equation}
+    numit astfel deoarece harta \(\vX \mapsto \ReLU(\vX - \beta \vD^{\top}(\vD\vX - \vZ) + \beta  \lambda \vone_{d}\vone_{n}^{\top})\) este un pas al algoritmului ISTA bine stabilit pentru a găsi o reprezentare rară non-negativă element cu element pentru \(\vZ\) în raport cu dicționarul complet \(\vD\) (cf \Cref{sec:dictionary_learning}).
+\end{itemize}
+
+Numim această arhitectură CRATE, iar un strat al coloanei vertebrale este ilustrat în \Cref{fig:crate_backbone}. Modelele CRATE, pe lângă faptul că sunt interpretabile, sunt în general și foarte performante și eficiente din punct de vedere al parametrilor.
+
+\subsection{Optimizare} \label{sub:image_classification_optimization}
+
+Antrenăm clasificatorul nostru folosind o procedură simplă de optimizare stocastică end-to-end, unde sub-eșantionăm date și vederi, calculăm pierderea medie și gradientul său peste aceste mostre și folosim un algoritm de optimizare pentru a schimba parametrii. La fiecare pas de timp \(k\):
+\begin{itemize}
+    \item Sub-eșantionăm \(B\) mostre etichetate diferite \(\{(\vX_{b}^{(k)}, \vy_{b}^{(k)})\}_{b = 1}^{B} \subseteq \cI \times \{0, 1\}^{N_{\cls}}\).
+    \item Pentru fiecare mostră etichetată \((\vX_{b}^{(k)}, \vy_{b}^{(k)})\), calculăm vederea de decupare centrală \(v_{b, \cc}^{(k)}\) și o aplicăm la \(\vX_{b}^{(k)}\) pentru a obține \(\vX_{b, \cc}^{(k)} \doteq v_{b, \cc}^{(k)}(\vX_{b}^{(k)})\).
+    \item Calculăm predicțiile \(\vp_{\theta}(\vX_{b, \cc}^{(k)}) \doteq (h_{\theta} \circ f_{\theta}^{\ext} \circ f_{\theta})(\vX_{b, \cc}^{(k)})\).
+    \item Formăm pierderea stocastică surogat 
+    \begin{equation}
+        \hat{\cL}_{\CE}^{(k)}(\theta) \doteq \frac{1}{B}\sum_{b = 1}^{B}\CE(\vy_{b}^{(k)}, \vp_{\theta}(\vX_{b, \cc}^{(k)})).
+    \end{equation}
+    \item Calculăm un pas al unui algoritm de optimizare pe \(\theta\), dând următoarea iterație:
+    \begin{equation}
+        \theta^{(k + 1)} \doteq \textsc{OptUpdate}^{(k)}(\theta^{(k)}; \nabla_{\theta}\hat{\cL}_{\CE}^{(k)}).
+    \end{equation}
+\end{itemize}
+
+
+\subsection{Metodologie de Evaluare} \label{sub:image_classification_evals}
+
+Folosim aceeași procedură de evaluare ca în \Cref{sub:contrastive_learning_evals}. Pentru a rezuma, pentru toate evaluările (precum și antrenamentul) folosim o vedere de decupare centrală \(v_{\cc}\) care redimensionează imaginea de intrare și ia o decupare centrală mare de dimensiune \((C, S_{\cc}, S_{\cc})\) unde \(C\) este numărul de canale din imaginea de intrare. Putem apoi face sondare liniară, vizualizare a hărților de atenție și benchmark-uri de detecție/segmentare, date ieșirea acestei vederi.
+
+\subsection{Configurare Experimentală și Rezultate}\label{sub:image_classification_experiments}
+
+Deoarece CRATE este bazat direct pe transformer, comparăm setările optime pentru ViT așa cum sunt date de \cite{dosovitskiy2020image,touvron2020training} cu aceleași setări aplicate la CRATE pentru o comparație corectă.
+
+\paragraph{Arhitectura modelului.} Decuparea centrală redimensionează întreaga imagine astfel încât marginea mai scurtă să fie de dimensiune \(256\) (adică, \(S_{\rsz} = 256\)) înainte de a lua o decupare centrală de dimensiune \(224 \times 224\) (adică, \(S_{\cc} = 224\)), atât în evaluare, cât și în antrenament. Luăm dimensiunea patch-ului \(16\) (adică, \(P_{H} = P_{W} = 16\)). Folosim modelele mici, de bază și mari ale arhitecturii ViT \cite{dosovitskiy2020image} ca încorporare și coloană vertebrală, înlocuind componentele MHSA și MLP cu MSSA și ISTA, respectiv, folosind același număr de capete și dimensiune a capului în cazul MSSA, și prin urmare reducând drastic numărul de parametri de antrenament. Pentru CRATE, setăm \((\beta, \lambda) = (1, 0.1)\).
+
+\paragraph{Seturi de date și optimizare.} Pentru pre-antrenament, folosim setul de date ImageNet-1K. Folosim optimizatorul LION \citep{chen2024symbolic} pentru a pre-antrena atât replicarea noastră ViT, cât și CRATE. Setăm rata de învățare de bază ca \(2.4 \times 10^{-4}\), decăderea ponderilor ca \(0.5\) și dimensiunea lotului ca \(B = 2048\). Programul nostru de rată de învățare crește rata de învățare liniar la rata de învățare de bază în primele \(5\) epoci și scade la \(0\) folosind un program cosinus în următoarele \(145\) epoci (antrenând toate modelele pentru \(150\) epoci fiecare). Pentru pre-antrenament, aplicăm un regim obișnuit de augmentări de date (răsturnări, blur-uri Gaussiene, solarizare etc.) la datele de imagine și adăugăm și zgomot mic la etichete (aceasta se numește \textit{netezirea etichetelor} \citep{muller2019does}).
+
+Pentru sondarea liniară, folosim mai multe seturi de date de evaluare, cum ar fi CIFAR10, Oxford-Flowers și Oxford-IIT-Pets. Folosim optimizatorul AdamW pentru a antrena sonda liniară, folosind rata de învățare \(5 \times 10^{-5}\), decăderea ponderilor \(0.01\) și dimensiunea lotului \(B = 256\). Aplicăm de asemenea augmentările de date menționate anterior la datele de imagine.
+
+\begin{table}
+    \centering
+    \begin{tabular}{@{}lcccc|cc@{}}
+    \toprule
+    \textbf{Model} & CRATE-T  &  CRATE-S & CRATE-B & CRATE-L & { \color{gray} ViT-T} &  { \color{gray}ViT-S } \\ 
+    \midrule
+    \midrule
+     \# parametri & 6.09M & 13.12M & 22.80M & 77.64M & { \color{gray} 5.72M} & { \color{gray} 22.05M} \\
+    \midrule
+     ImageNet-1K & 66.7 & 69.2 & 70.8 & 71.3 & { \color{gray} 71.5} & { \color{gray} 72.4} \\
+     ImageNet-1K ReaL & 74.0 & 76.0 & 76.5 & 77.4 & { \color{gray} 78.3 } & { \color{gray} 78.4} \\
+     CIFAR10 & 95.5 & 96.0 & 96.8 & 97.2 & { \color{gray} 96.6} & { \color{gray} 97.2} \\
+     CIFAR100 & 78.9 & 81.0 & 82.7 & 83.6 & { \color{gray} 81.8} & { \color{gray} 83.2}\\
+     Oxford Flowers-102 & 84.6 & 87.1 & 88.7 & 88.3 & { \color{gray} 85.1} & { \color{gray} 88.5}\\
+     Oxford-IIIT-Pets & 81.4 & 84.9 & 85.3 & 87.4 & { \color{gray} 88.5} & { \color{gray} 88.6} \\
+     \bottomrule
+    \end{tabular}
+    \caption{\small \textbf{Acuratețea clasificării prin sondare liniară a CRATE și ViT} pe diverse seturi de date cu diferite dimensiuni de model când coloana vertebrală este pre-antrenată pentru clasificare pe ImageNet-1K. Observăm că, dată fiind aceeași configurație de model, CRATE are performanță de clasificare comparabilă cu un design mai simplu, mai principial și mai eficient din punct de vedere al parametrilor.}
+    \label{tab:crate_classification_linear_probing}
+\end{table}
+
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.8\textwidth]{\toplevelprefix/chapters/chapter7/figs/crate_semantic_heads.pdf}
+    \caption{\small\textbf{Hărți de saliență interpretabile în CRATE} cu dimensiunea patch-ului \(8\). Când sunt date imagini cu proprietăți similare (poate dar nu neapărat din aceeași clasă), hărțile de saliență corespunzătoare diferitelor capete de atenție din ultimul strat evidențiază fiecare o proprietate specifică. Se poate observa că harta de saliență medie (neinclusă) evidențiază apoi toate obiectele relevante din imagine, arătând că folosește toate detaliile fine ale imaginii de intrare pentru clasificare. Acesta este \textit{primul} sistem de învățare automată care face acest lucru, după cunoștințele autorilor, cu atât mai puțin automat fără antrenament pe date de segmentare.}
+    \label{fig:crate_semantic_heads}
+\end{figure}
+
+\begin{table}
+    \centering
+    \begin{tabular}{@{}lcccccccc@{}}
+    \toprule
+     &  \multicolumn{3}{c}{Detecție (\(\uparrow\))} &  \multicolumn{3}{c}{Segmentare (\(\uparrow\))} \\ 
+    Model & AP$_{50}$ & AP$_{75}$ & AP & AP$_{50}$ & AP$_{75}$ & AP  \\ 
+    \midrule
+    CRATE-S/8 & \textbf{2.9} & \textbf{1.0} & 1.1 & 1.8 & \textbf{0.7} & 0.8 \\
+    CRATE-B/8 & \textbf{2.9} & \textbf{1.0} & \textbf{1.3} & \textbf{2.2} & \textbf{0.7} & \textbf{1.0} \\
+    ViT-S/8 & 0.1& 0.1 & 0.0 & 0.0 & 0.0 & 0.0 \\
+    ViT-B/8 & 0.8 & 0.2 & 0.4 & 0.7 & 0.5 & 0.4 \\
+    \bottomrule
+    \end{tabular}
+    \caption{\small \textbf{Detecția obiectelor și segmentarea fină prin MaskCut pe COCO {val2017}~\citep{lin2014microsoft}}. Aici toate modelele sunt antrenate cu dimensiunea patch-ului \(8\) în loc de \(16\). CRATE performează concludent mai bine decât ViT la metricile de detecție și segmentare când ambele sunt antrenate folosind clasificare supervizată.}
+    \label{tab:crate_detection_segmentation}
+\end{table}
+
+
+\paragraph{Rezultate experimentale.} 
+
+\Cref{tab:crate_classification_linear_probing} demonstrează că modelele CRATE ating paritate sau îmbunătățire comparativ cu populara arhitectură Vision Transformer (ViT) la numere similare de parametri, cel puțin în termeni de separabilitate liniară a caracteristicilor lor în raport cu diferite clase. În ceea ce privește fidelitatea hărților de atenție, \Cref{fig:crate_semantic_heads} demonstrează un rezultat cu adevărat extraordinar: fără a fi nevoie să se antreneze pe date de segmentare sau detecție a obiectelor, \textit{nu doar} că hărțile de saliență captează eficient toate părțile relevante ale imaginii de intrare, hărțile de saliență \textit{se auto-organizează} pentru a corespunde fiecare unui set discret de concepte, chiar și între mostre și clase! Acesta este primul sistem care face acest lucru, după cunoștințele autorilor, și poate face acest lucru fără a folosi date suplimentare, cu excepția datelor de clasificare a imaginilor. \Cref{tab:crate_detection_segmentation} confirmă aceste perspective calitative cantitativ, arătând o îmbunătățire semnificativă față de ViT-urile antrenate în aceeași configurație de clasificare supervizată.
+
+\section{Modelarea Limbajului Cauzal}\label{sec:clm_text}
+
+Studiem acum \textit{modelarea limbajului cauzal}, o metodă pentru antrenarea modelelor mari de limbaj (LLM). Aceasta este aceeași configurare folosită pentru a antrena, printre multe altele, GPT-2 și multe alte modele de limbaj.
+
+\subsection{Date} \label{sub:clm_text_data}
+
+Datele pe care le vom folosi pentru a investiga performanța CRATE pentru sarcini de limbaj vor fi OpenWebText (OWT)~\cite{Gokaslan2019OpenWeb}, o reproducere open-source a setului de date WebText nedivulgat folosit de OpenAI pentru a antrena GPT2. Fiecare mostră din OWT este un document web, de obicei provenit din pagini web de înaltă calitate, bloguri, articole sau discuții online, care este scris în limbaj natural bine format. Setul de date OpenWebText conține aproximativ 8.01M documente de lungimi variate, totalizând aproximativ 41.70GB de text. Pentru evaluare, vom folosi mai multe seturi de date, cum ar fi WikiText~\cite{merity2016pointer}\footnote{Pentru WikiText2 și WikiText103~\cite{merity2016pointer}, împărțirile de test sunt aceleași, așa că le îmbinăm ca un singur set de date denumit WikiText.}, LAMBADA~\cite{paperno2016lambadadatasetwordprediction}\footnote{Pentru a obține acuratețea pe setul de date LAMBADA, folosim decodare lacomă.} și PTB~\cite{marcus-etal-1993-building}. PTB și OWT sunt în general mai ușoare comparativ cu alte seturi de date. PTB se concentrează pe text jurnalistic mai simplu, ideal pentru modelarea tradițională a limbajului, în timp ce OWT este divers și informal, acoperind diverse subiecte, dar cu mai puțină complexitate în structura limbajului sau dependențe pe termen lung. WikiText, cu structura sa formală și conținutul specific domeniului, necesită o înțelegere mai complexă decât OWT, dar rămâne gestionabil. LAMBADA este cel mai provocator, deoarece implică dependențe pe termen lung, necesitând ca modelul să înțeleagă informații contextuale mai largi pentru a completa propozițiile cu acuratețe.
+
+La un nivel mai formal, datele noastre \(\vX\) vor fi text sau șiruri de caractere; lăsăm \(\cT\) să fie setul tuturor șirurilor.
+
+\subsection{Sarcină și Obiectiv} \label{sub:clm_text_objective}
+
+Pentru pre-antrenamentul modelării limbajului cauzal, ideea este că vrem să \textit{antrenăm modelul să producă text asemănător cu cel uman}. Cea mai populară modalitate de a face acest lucru este să folosim un proces de antrenament în două etape:\footnote{Antrenamentul modern al modelelor de limbaj are mai multe etape suplimentare de antrenament care necesită distribuții de date diferite și abordări algoritmice diferite. Cu toate acestea, antrenarea unui model pentru a imita doar scrierea umană necesită doar acești câțiva pași prezentați.}
+\begin{itemize}
+    \item \textit{Mai întâi}, dorim să \textit{învățăm} o modalitate de a codifica optim documentele ca o secvență de șiruri de bază („blocuri de construcție"), numite \textit{token-uri}. Aceasta se numește \textit{tokenizare}, și construim un \textit{tokenizator}.
+    \item \textit{În al doilea rând}, dorim să \textit{învățăm} o modalitate de a \textit{prezice distribuția unui token dat toate token-urile anterioare}. Aceasta se numește \textit{predicție de următorul token}, și construim un \textit{model de limbaj}.
+\end{itemize}
+Această procedură datează de fapt de la Markov, care a observat pentru prima dată că limbajul natural ar putea fi modelat prin structura de lanț Markov eponimă \citep{markov2006example} dată o tokenizare adecvată, și apoi la Shannon, care a propus să facă exact această configurare de modelare a limbajului cu un tokenizator la nivel de caracter (adică, fiecare caracter este un token) și așa-numitele „\(n\)-grame" (adică, o tabelă de căutare explicită, calculată din datele de antrenament, pentru distribuția unui token dat cele \(n\) token-uri anterioare) în locul modelului de limbaj \citep{Shannon-1948}.\footnote{Un studiu recent \citep{liu2024infini} care scalează modelele \(n\)-gram a arătat că sunt capabile să modeleze textul rezonabil de bine pentru \(n\) mare, dar bineînțeles memoria necesară pentru a stoca o astfel de tabelă de căutare este de ordinul \(V^{n}\) și prin urmare complet intractabilă.}
+
+\subsubsection{Antrenarea unui Tokenizator}
+
+Pentru a construi un tokenizator înseamnă să construim un vocabular \(\cV\), care este un set de token-uri și are o dimensiune pre-specificată \(V\). Există mai multe metode pentru a face acest lucru. Un algoritm popular este cunoscut sub numele de Codare Pereche de Octeți (BPE), care poate fi descris ca:
+\begin{itemize}
+    \item Începem cu o listă a tuturor caracterelor unice din datele de antrenament și frecvențele lor. Asigurăm-ne că există mai puțin de \(V\) astfel de caractere și adăugăm fiecare caracter ca un șir separat („token") la vocabular împreună cu frecvența sa.
+    \item Până când există \(V\) token-uri în vocabular:
+    \begin{itemize}
+        \item Construim un token luând cele două token-uri existente cele mai frecvente și îmbinându-le.
+        \item Calculăm frecvența acestui token în setul de date.
+        \item Îl adăugăm la vocabular (împreună cu frecvența sa).
+    \end{itemize} 
+    \item În acest punct, informațiile de frecvență nu mai sunt necesare și pot fi eliminate.
+\end{itemize}
+Procesul general al BPE este în \Cref{fig:BPE}. Rețineți că această procedură este o modificare a unei proceduri clasice de compresie teoretico-informațională pentru \textit{învățarea unei codări fără pierderi} a datelor de flux de octeți (cum ar fi textul), și ca atare, se poate interpreta ca găsirea unei compresii optime fără pierderi a datelor. Observați că acest lucru este posibil deoarece (spre deosebire de imagini), datele aici sunt fundamental discrete și fără zgomot.
+\begin{figure}
+    \centering
+    \includegraphics[width=0.45\textwidth]{\toplevelprefix/chapters/chapter7/figs/BPE1.png}\hspace{0.6in} 
+    \includegraphics[width=0.45\textwidth]{\toplevelprefix/chapters/chapter7/figs/BPE2.png} 
+    \caption{\small {\bf Procesul de tokenizare a datelor text folosind BPE.} (Credit imagine la \url{https://huggingface.co/learn/nlp-course/chapter6/5}). (Stânga) Începem prin analizarea corpusului de text dat și construirea unui vocabular inițial care constă din caractere individuale (sau octeți în cazul BPE la nivel de octet). Apoi, calculăm frecvențele perechilor de caractere adiacente în corpus. Aceasta implică scanarea întregului text și numărarea de câte ori apare fiecare secvență de două caractere (bigramă). (Dreapta) După calcularea frecvențelor perechilor de caractere adiacente, identificăm perechea cea mai frecventă în corpus. Această pereche este apoi îmbinată într-o nouă unitate de subcuvânt, care este adăugată la vocabular ca un singur token. Acest proces este repetat iterativ până când se atinge dimensiunea vocabularului predefinită.}
+    \label{fig:BPE}
+\end{figure}
+După ce un astfel de vocabular este construit, un tokenizator poate descompune un document în token-uri (adică, să îl „tokenizeze"). BPE folosește o procedură similară pentru a tokeniza datele ca în antrenament:
+\begin{itemize}
+    \item Separăm documentul într-o listă lungă de token-uri de un caracter. Adică, dacă documentul este „Hello", atunci lista inițială este `H', `e', `l', `l', `o'. 
+    \item În timp ce oricare două token-uri adiacente pot fi concatenate și concatenarea lor este un alt token, o facem, adică înlocuim această pereche de token-uri cu token-ul îmbinat. Anume, dacă `He' este un token în vocabular, `H', `e', `l', `l', `o' ar deveni `He', `l', `l', `o'.
+    \item Repetăm procesul de mai sus până când nu se mai pot face îmbinări. În acest punct, documentul este partiționat în lista finală (secvența) de token-uri.
+\end{itemize}
+
+Există multe considerații practice și bazate pe eficiență de luat în considerare în timpul tokenizării. Algoritmul de mai sus, așa cum este prezentat, este \textit{foarte departe de a fi optim} dacă este implementat naiv, de exemplu. Nu acoperim acest subiect în detaliu mare; există multe resurse online pentru a învăța mai mult, cum ar fi \href{https://huggingface.co/learn/nlp-course/en/chapter6/5}{tutorialele HuggingFace}.
+
+De exemplu, fiecare token are un \textit{index} corespunzător care este doar indexul său în vocabular (care, la urma urmei, este doar o listă de lungime \(V\)). Astfel, ieșirea majorității tokenizatoarelor este o listă de indici, să zicem un element al \([V]^{*}\). Țineți minte că acestea corespund sub-șirurilor documentului original, așa cum s-a arătat mai sus.
+
+Odată ce un tokenizator este învățat, poate fi folosit ca o cutie neagră de orice model de limbaj. De exemplu, multe modele au același tokenizator (bazat pe OpenAI) bazat pe biblioteca \texttt{tiktoken}. În restul acestei secțiuni, vom folosi un astfel de tokenizator fix și pre-construit pentru totul și astfel identificăm fiecare document text \(\vX \in \cT\) cu versiunea sa tokenizată în \([V]^{*}\). Prin urmare, am putea la fel de bine să considerăm spațiul text \(\cT\) ca \textit{egal} cu spațiul secvențelor de token-uri \([V]^{*}\) (și nu pierdem nimic esențial).
+
+\subsubsection{Antrenarea unui Model de Limbaj}
+
+Odată ce avem fiecare document ca o secvență de token-uri \(\vX \in [V]^{N} \subseteq [V]^{*} = \cT\), dorim să efectuăm predicția următorului token. Adică, dat un \textit{context} \(\vX_{:n} \in [V]^{n}\) (adică, primele \(n\) token-uri \(\vx_{1}, \dots, \vx_{n} \in [V]\) din document)\footnote{Rețineți incongruența cu notația Python: aici notația \textit{include} indexul \(n\).}, dorim să prezicem token-ul \(\vx_{n + 1} \in [V]\) la poziția \(n + 1\). Pentru a face acest lucru, calculăm caracteristica agregată a lui \(\vX_{:n}\) prin \(\vz_{\theta}(\vX_{:n}) \doteq (f_{\theta}^{\ext} \circ f_{\theta})(\vX_{:n}) \in \R^{d}\), și folosim un cap de clasificare \(h_{\theta} \colon \R^{d} \to \Delta_{V}\) (implementat ca un strat liniar, MLP sau ceva puțin mai complicat) pentru a proiecta această caracteristică în simplexul de probabilitate \(V\)-dimensional \(\Delta_{V}\). Această proiecție \(\vp_{\theta}(\vX_{:n}) \doteq h_{\theta}(\vz_{\theta}(\vX_{:n}))\) servește ca o distribuție de probabilitate estimată a următorului token. Apoi, folosind notația \(\vone(\vx_{n + 1}) \in \Delta_{V}\) pentru a fi \(1\) în componenta \(\vx_{n + 1}\) și \(0\) în altă parte, pierderea de modelare a limbajului cauzal este
+\begin{equation}\label{eq:clm_loss}
+    \min_{\theta}\bc{\cL_{\mathrm{CLM}}(\theta) \doteq \Ex_{\vX}\rs{\frac{1}{N - 1}\sum_{n = 1}^{N - 1}\CE(\vone(\vx_{n + 1}), \vp_{\theta}(\vX_{:n}))}}
+\end{equation}
+Observați cât de similară este aceasta cu o pierdere de clasificare (să zicem pentru imagini); se folosește entropia încrucișată și se încearcă alinierea unui vector de probabilitate prezis cu adevărul de bază. Diferența majoră între aceste două pierderi este că în aceasta, calculăm pierderea pe o întreagă secvență, unde fiecare predicție este corelată cu celelalte (spre deosebire de cazul de clasificare i.i.d.).
+
+Optimizarea acestei pierderi este de obicei numită „pre-antrenament" în comunitatea modelelor de limbaj (în contrast cu „post-antrenament" și, mai recent, „mid-antrenament", care sunt metodologii pentru a modifica un predictor de următorul-token pentru sarcini utile).
+
+\textit{Notă marginală:} De ce primul termen din \eqref{eq:clm_loss} prezice \(\vone(\vx_{2})\), și nu există niciun termen care măsoară pierderea pentru a prezice primul token? Este pentru că dacă am dori să prezicem primul token, am avea \textit{secvența goală} ca context și, prin urmare, am face această primă predicție de token folosind un mecanism calitativ diferit de cel care se aplică celorlalte token-uri. Deci, de fapt, acest model nu este antrenat să prezică \textit{primul} token al oricărui document. Motivul pentru care acest lucru este OK se datorează unui detaliu de implementare al tokenizatorului: adesea, după construirea tokenizatorului, inserăm un token \textit{special} în vocabularul său, numit token-ul \textit{început-de-șir (sau document)} și etichetat \texttt{<|bos|>}.\footnote{Există de obicei mai multe token-uri speciale pentru scopuri diferite. Textul existent care conține token-urile speciale este procesat special.} Apoi, în timp ce procesăm fiecare document, adăugăm token-ul \texttt{<|bos|>} la începutul secvenței de token-uri a documentului, crescând lungimea secvenței tokenizate cu \(1\). Astfel, obiectivul de modelare a limbajului cauzal de mai sus are un termen care implică încercarea de a prezice primul token al documentului dat doar token-ul \texttt{<|bos|>} ca context, și astfel este o pierdere corectă conceptual.
+
+\subsection{Arhitectură: CRATE Cauzal}
+
+Pentru arhitectură, folosim un transformer standard în stil GPT-2, substituind straturile CRATE pentru straturile transformer.\footnote{În contravenție directă cu convențiile din această carte și cele ale multor alte comunități, comunitatea NLP numește astfel de transformeri în stil GPT-2 (cuprinzând aproape toate LLM-urile actuale) transformeri „doar-decoder". Transformerii „doar-encoder" au o arhitectură diferită, iar transformerii „encoder-decoder" concatenează un transformer „doar-encoder" cu un transformer „doar-decoder". Acest lucru în ciuda faptului că transformerii „doar-decoder" \textit{de asemenea} calculează o codificare a datelor!} Pentru completitudine, specificăm arhitectura aici.
+
+\paragraph{Încorporare.} Mai întâi încorporăm secvența de token-uri \(\vX \in [V]^{N}\) în spațiul Euclidian. Acest lucru se face adesea asociind fiecare index din \([V]\) cu un vector în \(\R^{d}\) folosind o matrice \textit{masivă}\footnote{Prin „masivă" înțelegem că o astfel de structură este adesea o fracțiune mare din dimensiunea totală a modelului de limbaj.} \(\vE \in \R^{V \times d}\), și formând direct secvența \([\vE_{\vx_{1}}, \dots, \vE_{\vx_{N}}] \in \R^{d \times N}\). Harta completă de încorporare \(f_{\theta}^{\emb}\) aplică de asemenea o codare pozițională \(\vE^{\pos} \in \R^{d  \times N_{\max}}\) unde \(N_{\max}\) este numărul maxim de token-uri care sunt posibile de procesat,\footnote{Metodele moderne de codare pozițională au rezolvat de atunci această problemă și au permis (în teorie) extrapolare infinită, dar astfel de metode sunt mai complexe de dezvoltat, și pentru simplitate introducem aici doar codarea pozițională aditivă absolută.} ceea ce produce harta de încorporare
+\begin{equation}
+    f_{\theta}^{\emb}(\vX) \doteq [\vE_{\vx_{1}}, \dots, \vE_{\vx_{N}}] + \vE_{:N}^{\pos}
+\end{equation}
+Parametrii \(\vE\) și \(\vE^{\pos}\) sunt direct antrenabili. Deoarece \(\vE\) este atât de mare (și actualizarea gradientului este foarte rară în raport cu aceasta, deoarece doar o mică fracțiune din vocabular este folosită în fiecare mostră), se folosește software specializat pentru a se asigura că actualizările de memorie nu sunt prea oneroase. Observați de asemenea că nu folosim un token de clasă ca în celelalte secțiuni; mai multe despre aceasta mai târziu.
+
+\paragraph{Coloană vertebrală.} Procesăm încorporările folosind o coloană vertebrală de tip CRATE care folosește mascare cauzală. Pentru a motiva mascarea cauzală, considerați pierderea de modelare a limbajului cauzal \(\cL_{\mathrm{CLM}}\) definită în \eqref{eq:clm_loss}. Cea mai naivă implementare ar necesita să calculăm trecerea înainte de \(N\) ori pentru a backpropaga o dată. Evident, acest lucru este extrem de ineficient, deoarece \(N\) poate fi adesea în mii. Pentru a scala antrenamentul cu această pierdere eficient, impunem o constrângere \textit{cauzală}, adică,
+\begin{equation}\label{eq:causal_backbone_def}
+    \vZ_{\theta}(\vX_{:n}) = \vZ_{\theta}(\vX)_{:n}
+\end{equation}
+adică, cele \(n\) coloane ale caracteristicilor token \(\vZ_{\theta}(\vX_{:n}) \in \R^{d \times n}\) ar trebui să fie aceleași cu primele \(n\) coloane ale caracteristicilor token \(\vZ_{\theta}(\vX) \in \R^{d \times N}\) indiferent de valorile pozitive ale lui \(n\) și \(N\) astfel încât \(N \geq n\). În efect, aceasta înseamnă că putem aplica coloana vertebrală \textit{o singură dată} la întreaga secvență și calculăm \(\vZ_{\theta}(\vX)\), apoi aplicăm \(f_{\theta}^{\ext}\) la fiecare subset crescător \(\vZ_{\theta}(\vX_{:n}) = \vZ_{\theta}(\vX)_{:n}\) pe măsură ce \(n\) crește la lungimea secvenței \(N\). Apoi putem folosi toate acestea pentru a calcula pierderea.
+
+Deci, acum că vrem o arhitectură cauzală pentru coloana vertebrală, cum o putem obține? Deoarece MLP-ul și normalizările de strat din fiecare strat transformer afectează fiecare token individual, singurul lucru care contează pentru cauzalitate este blocul de atenție (sau \(\MSSA\) în cazul CRATE). Pentru a face \(\MSSA\) cauzal, definim blocul \(\mathrm{CausalMSSA}\) ca
+\begin{align}
+    &\operatorname{CausalMSSA}_{\theta}^{\ell}(\vZ) \doteq \vU_{\out}^{\ell}\mat{\operatorname{CausalSA}([\vU^{1, \ell}]^{\top}\vZ, [\vU^{1, \ell}]^{\top}\vZ, [\vU^{1, \ell}]^{\top}\vZ) \\ \vdots \\ \operatorname{CausalSA}([\vU^{K, \ell}]^{\top}\vZ, [\vU^{K, \ell}]^{\top}\vZ, [\vU^{1, \ell}]^{\top}\vZ)} + \vb_{\out}^{\ell}\vone_{N}^{\top} \\ 
+    \text{unde} \quad & \operatorname{CausalSA}(\vQ, \vK, \vV) \doteq \vV\softmax\rp{\frac{\operatorname{CausalMask}(\vK^{\top}\vQ)}{\sqrt{p}}} \\ 
+    \text{unde} \quad & \operatorname{CausalMask}(\vM)_{ij} = \casework{M_{ij}, & \text{dacă}\ i \geq j, \\ -\infty, & \text{dacă}\ i < j}.
+\end{align}
+Aici, practicienii spun că masca cauzală \textit{permite token-urilor viitoare \(i\) să fie atente la token-urile trecute \(j\), dar nu și invers}. Pentru a vedea de ce, să scriem expresia pentru coloana \(t\) a lui \(\operatorname{CausalSA}(\vQ, \vK, \vV)\):
+\begin{equation}
+    \operatorname{CausalSA}(\vQ, \vK, \vV)_{t} = \sum_{i = 1}^{t}\vV_{i}\softmax\rp{[\vK_{:t}]^{\top}\vQ_{t}}_{i}
+\end{equation}
+(unde aici indicele fără două puncte denotă coloana). Această expresie pentru token-ul \(t\) nu folosește nicio informație despre niciun token dincolo de indexul \(t\). Prin urmare \(\operatorname{CausalSA}\), deci \(\operatorname{CausalMSSA}\), deci întreaga coloană vertebrală CRATE cauzală este cauzală în termenii definiției din \eqref{eq:causal_backbone_def}, și deblocăm câștigurile considerabile de eficiență care ne-au fost promise.
+
+\paragraph{Extractor de caracteristici.} Folosim un pas de post-procesare \(f_{\theta}^{\ext}\) care extrage \textit{vectorul de caracteristici al ultimului token cunoscut} pentru a prezice următorul token. În teorie, aceasta înseamnă că fiecare token \(\vZ_{\theta}(\vX)_{n}\) ar trebui să conțină informații bogate despre toate token-urile care vin înainte sau la indexul \(n\), adică, \(\vx_{1}, \dots, \vx_{n}\), deoarece toate aceste informații ar trebui să fie disponibile pentru prezicerea următorului token la indexul \(n + 1\). În practică, doar câteva dintre aceste token-uri sunt într-adevăr necesare pentru fiecare sarcină de predicție. Oricum, ecuația pentru \(f_{\theta}^{\ext}\) este
+\begin{equation}
+    f_{\theta}^{\ext}(\vZ_{\theta}(\vX_{:n})) \doteq (\vZ_{\theta}(\vX))_{n}
+\end{equation}
+unde (din nou) indicele fără două puncte este coloana. În acest caz, așa cum am promis, extragem direct vectorul de caracteristici al ultimului token din secvență.
+
+\paragraph{Cap specific sarcinii.} Pentru capul nostru de clasificare \(h_{\theta}\), arhitectura GPT-2 folosește un strat liniar simplu și un softmax pentru a obține vectorii de probabilitate doriți:
+\begin{equation}
+    h_{\theta}(\vz) \doteq \softmax(\vW^{\out}\vz + \vb^{\out}),
+\end{equation}
+unde \(\vW^{\out} \in \R^{V \times d}, \vb^{\out} \in \R^{V}\). Unele alte arhitecturi mai moderne folosesc MLP-uri mici și normalizări de strat, dar ideea este foarte mult aceeași. Rețineți că aceste straturi liniare au de asemenea o utilizare mare a memoriei (deoarece \(V\) este foarte mare) și formează un gât de sticlă în antrenament; au existat eforturi semnificative încercând să o ocolească.
+
+Toate aceste alegeri arhitecturale înseamnă că antrenamentul cauzal este extrem de eficient în raport cu antrenamentul non-cauzal:
+\begin{itemize}
+    \item Avem nevoie doar de \textit{o singură trecere înainte} prin coloana vertebrală pentru a calcula pierderea pentru întreaga secvență.
+    \item Extracția caracteristicilor este practic \textit{gratuită}.
+    \item Toate token-urile pot fi împinse prin capul specific sarcinii \textit{în paralel}.
+\end{itemize}
+
+\subsection{Strategie de Optimizare}
+
+Antrenăm modelul nostru de limbaj folosind optimizare stocastică end-to-end. O problemă rămasă este că, în practică, diferite documente dintr-un lot au lungimi diferite (în termeni de numărul de token-uri necesare pentru fiecare secvență), dar la momentul scrierii acestei cărți, principalele framework-uri de învățare profundă permit în mare parte doar tensori „dreptunghiulari", care nu acomodează acest comportament. Pentru a încerca să rezolvăm această problemă, inserăm pur și simplu un token special de umplutură \texttt{<|pad|>} pentru toate mostrele mai scurte din lot, astfel încât să putem procesa totul în loturi folosind tensori dreptunghiulari. La fiecare pas de timp \(k\):
+\begin{itemize}
+    \item Sub-eșantionăm \(B\) documente tokenizate diferite \(\{\vX_{b}^{(k)}\}_{b = 1}^{B} \subseteq \cT = [V]^{*}\), fiecare cu lungimea \(N_{b}^{(k)}\).
+    \item Calculăm \(N_{\max}^{(k)} \doteq \max_{b \in [B]}N_{b}^{(k)}\) și umplem fiecare \(\vX_{b}^{(k)}\) la lungimea \(N_{\max}^{(k)}\) folosind un token special de umplutură.
+    \item Calculăm caracteristicile \(\vZ_{\theta}(\vX_{b}^{(k)})\).
+    \item Calculăm distribuțiile prezise \(\vp_{\theta}(\vX_{b, :n}^{(k)}) \doteq (h_{\theta} \circ f_{\theta}^{\ext})(\vZ_{\theta}(\vX_{b}^{(k)})_{:n})\).
+    \item Formăm pierderea stocastică surogat
+    \begin{equation}
+        \hat{\cL}_{\mathrm{CLM}}^{(k)}(\theta) \doteq \frac{1}{B(N_{\max}^{(k)} - 1)}\sum_{b = 1}^{B}\sum_{n = 1}^{N_{\max}^{(k)}-1}\CE(\vone(\vx_{b, n + 1}^{(k)}), \vp_{\theta}(\vX_{b, :n}^{(k)}))).
+    \end{equation}
+    \item Calculăm un pas al unui algoritm de optimizare pe \(\theta\), dând următoarea iterație:
+    \begin{equation}
+        \theta^{(k + 1)} \doteq \textsc{OptUpdate}^{(k)}(\theta^{(k)}; \nabla_{\theta}\hat{\cL}_{\mathrm{CLM}}^{(k)}).
+    \end{equation}
+\end{itemize}
+
+\subsection{Metodologie de Evaluare} \label{sub:clm_text_evals}
+
+Există mai multe moduri de a evalua un model de limbaj transformer antrenat.
+\begin{itemize}
+    \item Pe un set de date holdout de text arbitrar, putem evalua \(\cL_{\mathrm{CLM}}\) pe acesta; pierderile mai mici sunt mai bune, deoarece înseamnă că eșantionarea modelului produce performanță mai bună.
+    \item Pe un set de date cu întrebări cu răspunsuri multiple, pentru fiecare întrebare o putem pune ca context și verifica probabilitatea estimată ca răspunsul corect să fie generat.
+    \item Putem testa de asemenea capacitățile de \textit{generare de text}. Anume, putem eșantiona în mod repetat din distribuția de probabilitate a modelului peste următorul token dat contextul. De fiecare dată când eșantionăm, generăm un nou token, pe care îl afișăm și îl adăugăm la context. Acest lucru ne permite să eșantionăm din LLM și să judecăm mostrele generate după cum dorim.\footnote{A trebui să re-rulăm modelul pe fiecare token de fiecare dată poate deveni prohibitiv de scump. Stocări inteligente ale diferitelor caracteristici interne ale modelului de limbaj (cum ar fi așa-numitul \textit{cache \(K\)-\(V\)}), împreună cu cauzalitatea arhitecturii, pot reduce dramatic costul eșantionării.}
+\end{itemize}
+În această secțiune, efectuăm exclusiv primul tip de evaluare.
+
+\subsection{Configurare Experimentală și Rezultate}
+
+Deoarece arhitectura noastră CRATE cauzală este construită direct pe GPT-2, comparăm setările optime pentru GPT-2 așa cum sunt date de repository-ul NanoGPT \citep{nanogpt} cu aceleași setări aplicate la CRATE pentru o comparație corectă.
+
+\paragraph{Arhitectura modelului.} Folosim tokenizatorul GPT-2, care are dimensiunea vocabularului \(V = 50257\), inclusiv un token special pentru \texttt{<|pad|>}.\footnote{Token-ul \texttt{<|bos|>} nu este inclus în această configurare, deși este foarte comun în modelele moderne de limbaj.} Lungimea contextului este \(N_{\max} = 1024\). Modelul coloanei vertebrale urmează arhitectura GPT2-Base \citep{radford2019language} cu modificările adecvate pentru a avea straturi CRATE cauzale, și comparăm cu GPT2-Small și GPT2-Base.
+
+\paragraph{Seturi de date și optimizare.} Pentru antrenarea CRATE cauzal, urmăm implementările din repository-ul NanoGPT \citep{nanogpt}. În mod specific, folosim o dimensiune a lotului de 384 și antrenăm pentru 600.000 de pași cu optimizatorul Adam~\citep{kingma2014adam}. Pentru optimizatorul Adam, folosim $(\beta_1, \beta_2)=(0.9, 0.95)$ și decăderea ponderilor de $0.1$. Pentru programul ratei de învățare, aplicăm o încălzire liniară și decădere cosinus, cu o valoare de vârf de $\eta=6\times 10^{-4}$ la a $2.000$-a iterație și valoare minimă $6\times 10^{-5}$. Pierderile de antrenament și validare pe parcursul iterațiilor sunt prezentate în \Cref{fig:crate-text-evals}. Pierderea de antrenament/validare converge în jurul valorii de $3.37$ după antrenament cu o dimensiune a lotului de $384$ și $600.000$ iterații. În comparație, implementarea deschisă GPT-2 este pre-antrenată pe OpenWebText cu o dimensiune a lotului de $512$ și $600.000$ pași și converge la o pierdere de validare de $2.85$ \citep{nanogpt}.
+
+\begin{figure}
+    \centering
+    \includegraphics[width=0.5\textwidth]{\toplevelprefix/chapters/chapter7/figs/gpt-loss.pdf}
+    \caption{\bf Curba de pierdere a CRATE-GPT-Base antrenat pe setul de date OpenWebText.}
+    \label{fig:crate-text-evals}
+\end{figure}
+
+\paragraph{Rezultate experimentale.}
+
+\Cref{tab:gpt-eval} demonstrează că modelele CRATE ating performanță rezonabilă la pierderea de modelare a limbajului cauzal pe o varietate de seturi de date comparativ cu modelele GPT-2 cu numere similare de parametri și arhitecturi similare.
+
+
+\begin{table}
+\def\arraystretch{1.1}
+    \small
+    \caption{\small Pierderea de entropie încrucișată zero-shot a modelului CRATE-GPT2-Base și modelelor GPT2-Small, GPT2-Base evaluate pe împărțirea de test a seturilor de date ($\downarrow$ mai mic este mai bine).
+    }
+    \centering
+    \begin{tabular}{ccccccc}
+    \hline
+    & \#parametri & \textbf{OWT} & \textbf{LAMBADA} & \textbf{WikiText} & \textbf{PTB} & \textbf{Med} \\
+     \hline
+     GPT2-Base  & {124M} & 2.85$\downarrow$ & 4.12$\downarrow$ & 3.89$\downarrow$ & 4.63$\downarrow$ & 3.87$\downarrow$ \\
+     {GPT2-Small } &  {64M} & {3.04} & {4.49} & {4.31} & {5.15} & {4.25} \\
+     Causal-CRATE-Base & {60M} & 3.37 & 4.91 & 4.61 & 5.53 & 4.61 \\
+     \hline
+    \end{tabular}
+    \label{tab:gpt-eval}
+\end{table} 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+\section{Scalarea Transformerilor White-Box}\label{sec:scalable}
+
+În această secțiune, vom discuta trei moduri în care diverse părți ale modelelor de tip CRATE pot fi scalate sau făcute mai eficiente, rămânând în același timp white-box. Aceste dezvoltări combină atât perspective conceptuale, cât și empirice, și pot fi văzute ca studii de caz despre cum să folosim înțelegerea white-box pentru a îmbunătăți modelele de învățare profundă în practică. Sarcinile pe care le folosim pentru a evalua metodele vor fi clasificarea imaginilor și predicția următorului token, datele vor fi ImageNet și OpenWebText respectiv, procedura de optimizare va fi aceeași backpropagare, iar singurul lucru care se schimbă este arhitectura.
+
+\subsection{Creșterea Lățimii Rețelei: CRATE-\texorpdfstring{\(\alpha\)}{alpha}}\label{sub:crate_alpha_experiments}
+
+\begin{figure}[t]
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/crate_alpha_backbone.pdf}
+    \caption{\small\textbf{Un strat al coloanei vertebrale CRATE-\(\alpha\).} Diferența față de CRATE este că blocul \(\ISTA_{\theta}^{\ell}\) este înlocuit cu blocul \(\operatorname{ODL}_{\theta}^{\ell}\), care efectuează mai mulți pași \(\ISTA\) cu un dicționar supracomplet.}
+    \label{fig:crate_alpha_backbone}
+\end{figure}
+
+
+O decizie de design impusă de cadrul CRATE este \textit{lățimea} neliniarității din rețea. Într-un transformer obișnuit, lățimea este de obicei setată la \(4\), \(8\) sau \(\frac{11}{3}\) ori dimensiunea caracteristicii. Cu toate acestea, CRATE impune ca lățimea să fie exact egală cu dimensiunea caracteristicii, adică dicționarele \(\vD^{\ell}\) sunt pătrate, ceea ce ar putea duce la performanță redusă. Motivul fundamental pentru care cadrul CRATE ne constrânge la această alegere este următorul:
+\begin{itemize}
+    \item Blocul ISTA ia un \textit{singur} pas de optimizare pentru învățarea dicționarului.
+    \item De obicei, un pas al oricărui algoritm de optimizare iterativ nu poate optimiza efectiv obiectivul. Atunci de ce funcționează acest lucru?
+    \item Algoritmii de optimizare converg de obicei foarte repede dacă și numai dacă au inițializări bune sau \textit{porniri calde}. Blocul ISTA are o pornire caldă --- tratează caracteristicile de intrare ca o inițializare pentru codurile rare rezultate.
+    \item Acest lucru impune ca caracteristicile de intrare și codurile rare să aibă aceeași dimensiune. Anume, ISTA învață un dicționar de rarefiere complet (cf \Cref{ch:classic}).
+\end{itemize}
+Astfel, dacă vrem să folosim un dicționar larg, avem nevoie ca ISTA să efectueze învățarea dicționarului \textit{supracomplet}. Aceasta înseamnă că nu putem avea aceeași pornire caldă (deoarece codurile noastre rare au o dimensiune mai mare decât caracteristicile noastre) și avem nevoie de mai multe iterații pentru a converge la un cod rar. Prin urmare, pasul de la caracteristici \(\vZ_{\theta}^{\ell + 1/2}\) la coduri rare \(\vZ_{\theta}^{\ell + 1}\) nu ar mai fi
+\begin{equation}
+    \vZ_{\theta}^{\ell + 1} = \ISTA_{\theta}^{\ell}(\vZ_{\theta}^{\ell + 1/2} \mid \vZ_{\theta}^{\ell + 1/2})
+\end{equation}
+unde funcția \(\ISTA_{\theta}^{\ell}\) este definită ca (printr-un abuz de notație din secțiunile anterioare)
+\begin{equation}
+    \ISTA_{\theta}^{\ell}(\vZ \mid \vY) \doteq \ReLU(\vZ - \beta (\vD^{\ell})^{\top}(\vD^{\ell}\vZ - \vY) + \beta \lambda \vone_{s}\vone_{n}^{\top})
+\end{equation}
+ci mai degrabă următoarea iterație:
+\begin{equation}
+    \vZ_{\theta}^{\ell + 1} = \vA_{\theta}^{\ell, T}; \qquad \vA_{\theta}^{\ell, t + 1} = \ISTA_{\theta}^{\ell}(\vA_{\theta}^{\ell, t} \mid \vZ_{\theta}^{\ell + 1/2}) \quad \forall 0 \leq t < T; \qquad \vA_{\theta}^{\ell, 0} = \vzero_{s \times n},
+\end{equation}
+adică, rulând gradient proximal pe obiectivul LASSO pentru \(T \geq 1\) pași în trecerea înainte la fiecare strat, inițializat la \(\vzero_{s \times n}\). În această circumstanță, dicționarul poate fi atât de larg cât este necesar, adică, \(\vD^{\ell} \in \R^{s \times d}\) unde \(s \geq d\) (de obicei se ia \(s = 4d\) în practică).
+
+\begin{table}[b]
+    \centering
+    \begin{tabular}{@{}lcccccccc@{}}
+    \toprule
+     &  & \multicolumn{3}{c}{Detecție} &  \multicolumn{3}{c}{Segmentare} \\ 
+    Model & AP$_{50} \uparrow $ & AP$_{75} \uparrow $ & AP $\uparrow$ & AP$_{50} \uparrow$ & AP$_{75} \uparrow $ & AP $\uparrow$ \\ 
+    \midrule
+    \midrule
+    CRATE-\(\alpha\)-B/8 & 3.5 & 1.1 & 1.5 & 2.2 & 1.0 & 1.1 \\
+    CRATE-\(\alpha\)-L/8 & \textbf{4.0} & \textbf{1.7} & \textbf{2.0} & \textbf{2.7} & \textbf{1.1} & \textbf{1.4} \\
+    \midrule
+    \color{gray}CRATE-B/8 & \color{gray}2.9 & \color{gray}1.0 & \color{gray}1.3 & \color{gray}2.2 & \color{gray}0.7 & \color{gray}1.0 \\
+    \color{gray}ViT-B/8 & \color{gray}0.8 & \color{gray}0.2 & \color{gray}0.4 & \color{gray}0.7 & \color{gray}0.5 & \color{gray}0.4 \\
+    \bottomrule
+    \end{tabular}
+    \caption{\small \textbf{Detecția obiectelor și segmentarea fină prin MaskCut pe COCO val2017~\citep{lin2014microsoft}}. Aici toate modelele sunt antrenate cu dimensiunea patch-ului \(8\) în loc de \(16\). Comparativ cu modelele existente precum CRATE și ViT, familia de modele CRATE-\(\alpha\) are în mod notabil performanță îmbunătățită precum și scalabilitate.}
+    \label{tab:crate_alpha_detection_segmentation}
+\end{table}
+
+Cu toate acestea, acest lucru prezintă o problemă empirică. Folosind configurația de mai sus, dacă \(\vZ^{\ell + 1/2} \in \R^{d \times n}\), atunci \(\vZ^{\ell + 1} \in \R^{s \times n}\), care poate avea o dimensiune a caracteristicii arbitrar de mare. În practică, vrem ca dimensiunea caracteristicii la fiecare strat să fie aceeași. Deci acest lucru stabilește o trihotomie practică pentru proiectarea rețelei, anume, \textit{nu putem} avea \textit{toate} următoarele deziderate:
+\begin{enumerate}
+    \item Dimensiunea caracteristicii la fiecare strat este aceeași.
+    \item Dicționarul este larg, adică supracomplet.
+    \item Ieșirea neliniarității sunt codurile rare ale intrării în raport cu dicționarul.
+\end{enumerate}
+În practică, renunțarea la (1) este mai puțin tractabilă din motive de eficiență. Renunțarea la (2) duce la cadrul CRATE obișnuit. Renunțarea la (3) duce la o versiune largă a CRATE, adică CRATE-\(\alpha\), care are următoarea neliniaritate pentru a obține de la \(\vZ^{\ell + 1/2}\) la \(\vZ^{\ell + 1}\):
+\begin{equation}
+    \vZ_{\theta}^{\ell + 1} = \vD^{\ell}\vA_{\theta}^{\ell, T}; \qquad \vA_{\theta}^{\ell, t + 1} = \ISTA_{\theta}^{\ell}(\vA_{\theta}^{\ell, t} \mid \vZ_{\theta}^{\ell + 1/2}); \qquad \vA_{\theta}^{\ell, 0} = \vzero,
+\end{equation}
+adică, ia codurile rare obținute prin gradient descendent proximal și înmulțește cu dicționarul pentru a obține versiunea denoisificată a intrării. Astfel, neliniaritatea CRATE-\(\alpha\) calculează o versiune denoisificată a intrării care este amenabilă codării rare, nu codurile rare propriu-zise. Harta de la \(\vZ_{\theta}^{\ell + 1/2}\) la \(\vZ_{\theta}^{\ell + 1}\) aici se numește blocul de Învățare a Dicționarului Supracomplet (ODL) și este notată \(\operatorname{ODL}_{\theta}^{\ell}\), adică,
+\begin{equation}
+    \vZ_{\theta}^{\ell + 1}(\vX) \doteq \operatorname{ODL}_{\theta}^{\ell}(\vZ_{\theta}^{\ell + 1/2}(\vX)).
+\end{equation}
+
+
+
+\begin{figure}[t]
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/crate_alpha_semantic_heads.pdf}
+    \caption{\small\textbf{Hărți de saliență de la CRATE-\(\alpha\) cu dimensiunea patch-ului \(8\).} Fiecare rând este o imagine diferită și fiecare coloană corespunde unui cap de atenție diferit în ultimul strat. Observăm că hărțile de saliență corespund puternic obiectelor din imaginea de intrare.}
+    \label{fig:crate_alpha_saliency_maps}
+\end{figure}
+
+
+
+\begin{table}
+    \centering 
+    \begin{tabular}{@{}lcccc@{}}
+    \toprule
+    Model & GPT-2-B(ază) & CRATE-B & CRATE-\(\alpha\)-S(mic) & CRATE-\(\alpha\)-B \\ 
+    \midrule
+    \midrule
+    \# parametri & 124M & 60M & 57M & 120M \\
+    Pierd. val. OWT & 2.85 & 3.37 & 3.28 & 3.14 \\
+    \bottomrule
+    \end{tabular}
+    \caption{\small\textbf{Pierderea de validare în modelarea limbajului.} Aici toate modelele sunt pre-antrenate pe majoritatea OpenWebText, iar pierderea de entropie încrucișată de validare este măsurată pe un subset holdout al OpenWebText. CRATE-\(\alpha\) arată o îmbunătățire semnificativă față de designul CRATE, deși încă există un decalaj cu transformerii tradiționali precum GPT-2.}
+    \label{tab:crate_alpha_lm}
+\end{table}
+
+Stratul CRATE-\(\alpha\) este prezentat în \Cref{fig:crate_alpha_backbone}. În practică, această modificare a CRATE performează foarte bine la scale mai mari. De exemplu, când pre-antrenăm modele CRATE-\(\alpha\) pe ImageNet-21K, sarcinile nesupervizate precum segmentarea (vezi \Cref{fig:crate_alpha_saliency_maps} și \Cref{tab:crate_alpha_detection_segmentation}) au în general performanță semnificativ îmbunătățită comparativ cu CRATE. Tendințe similare sunt prezente în antrenamentul modelului de limbaj folosind auto-atenție cauzală (vezi \Cref{tab:crate_alpha_lm}). În general, este o cale promițătoare pentru scalarea performanței pentru a egala modelele black-box precum transformerii.\footnote{Rețineți că rezultatele experimentale din această secțiune folosesc o arhitectură de model ușor diferită, care adaugă câștiguri empirice foarte ușoare. Modificările sunt: (1) o conexiune reziduală suplimentară pe blocul ODL, (2) modificarea \(\ISTA\) pentru a folosi două dicționare separate în loc de \(\vD^{\ell}\) și \((\vD^{\ell})^{\top}\).}
+
+
+\subsection{Transformeri cu Complexitate de Timp Liniară}\label{sub:tost_experiments}
+
+În practică, modelele de învățare profundă suferă de blocaje în complexitatea spațiului și timpului, reprezentând dimensiuni ale problemei dincolo de care nu pot scala date resursele fixe. Un astfel de blocaj, deosebit de semnificativ când se ocupă cu date unde fiecare mostră este ea însăși de dimensiune înaltă și bogată (cum ar fi fluxuri lungi de text sau videoclipuri), este \textit{complexitatea de timp} a procesării secvențelor lungi de date. Pentru a atenua complexitatea de timp a procesării datelor folosind transformeri, în \Cref{sub:tost} am propus un operator \textit{auto-atenție cu statistici de token} \(\TSSA_{\theta}^{\ell}\). Acum construim un \textit{transformer cu statistici de token}, numit ToST, în jurul acestuia, pe care îl putem folosi pentru sarcini cu context lung. În special, putem folosi următorul strat (ilustrat în \Cref{fig:tost_backbone}) ca înlocuitor direct pentru un strat de coloană vertebrală în CRATE:
+\begin{align}
+    \vZ_{\theta}^{\ell + 1/2}(\vX)
+    &= \vZ_{\theta}^{\ell}(\vX) + \TSSA_{\theta}^{\ell}(\LN_{\theta}^{1, \ell}(\vZ_{\theta}^{\ell}(\vX))) \\ 
+    \vZ_{\theta}^{\ell + 1}(\vX)
+    &= \vZ_{\theta}^{\ell + 1/2}(\vX) + \MLP_{\theta}^{\ell}(\LN_{\theta}^{2, \ell}(\vZ_{\theta}^{\ell + 1/2}(\vX)))
+\end{align}
+unde blocul \(\TSSA\) este definit ca în \Cref{sub:tost}. Observați că aceasta este exact aceeași cu arhitectura vision transformer discutată în \Cref{sub:contrastive_learning_architecture}, cu excepția faptului că \(\TSSA\) înlocuiește blocul convențional de auto-atenție multi-cap \(\MHSA\). Indiferent, complexitatea computațională a trecerii înainte a acestui strat este liniară în toate variabilele problemei --- lungimea secvenței, dimensiunea caracteristicii, numărul de capete și dimensiunea capului.
+
+\begin{figure}[!htbp]
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/tost_backbone.pdf}
+    \caption{\small\textbf{Un strat al coloanei vertebrale ToST}. Reprezentările token trec prin normalizări de strat, operatorul de auto-atenție cu statistici de token (TSSA) și un MLP, pentru a forma ieșirea stratului.}
+    \label{fig:tost_backbone}
+\end{figure}
+
+\begin{table}[t]
+    \centering 
+    \resizebox{\textwidth}{!}{
+    \begin{tabular}{@{}lccc|cc|cc@{}}
+    \toprule
+    Seturi de date & ToST-T(mic) & ToST-S(mic) & ToST-M(ediu) &  { \color{gray} XCiT-S} &  { \color{gray}XCiT-M} &  {\color{gray}ViT-S} & {\color{gray}ViT-B(ază)}\\ 
+    \toprule
+     \# parametri & 5.8M & 22.6M & 68.1M &  { \color{gray}24.9M }& { \color{gray}80.2M } & { \color{gray} 22.1M } & { \color{gray}86.6 M } \\
+    \midrule
+     ImageNet & 67.3 & 77.9 & 80.3 &  { \color{gray} 80.5} & { \color{gray} 81.5 } & { \color{gray} 79.8} & { \color{gray} 81.8} \\
+     ImageNet ReaL & 72.2  & 84.1 & 85.6 &  { \color{gray} 85.6 } & { \color{gray} 85.9} & { \color{gray} 85.6 } & { \color{gray} 86.7 }\\
+     \midrule
+     CIFAR10 & 95.5 & 96.5 & 97.5 &  { \color{gray} 98.1} & { \color{gray} 98.3} & { \color{gray} 98.6} & { \color{gray} 98.8}\\
+     CIFAR100 & 78.3 & 82.7 & 84.5 &  { \color{gray} 86.1} & { \color{gray} 87.6} & { \color{gray} 88.8} & { \color{gray} 89.3}\\
+     Oxford Flowers-102 & 88.6 & 92.8 & 94.2 &  { \color{gray} 93.9} & { \color{gray} 94.0} & { \color{gray} 94.0}& { \color{gray} 95.7}\\
+     Oxford-IIIT-Pets & 85.6 & 91.1 & 92.8 &  { \color{gray} 92.9} & { \color{gray} 94.0} & { \color{gray} 92.8} & { \color{gray} 94.1} \\
+     \bottomrule
+    \end{tabular}%
+    }
+    \caption{\small \textbf{Acuratețea clasificării prin sondare liniară a ToST} pe diverse seturi de date cu diferite dimensiuni de model când coloana vertebrală este pre-antrenată pentru clasificare ImageNet-1K. Observăm că, comparativ cu XCiT (o arhitectură de tip transformer proiectată empiric specializată pentru procesarea eficientă a secvențelor lungi) și ViT, ToST menține performanță relativ similară, chiar și bucurându-se de beneficii precum timp de rulare mai rapid și design white-box.}
+    \label{tab:tost_linear_probing}
+\end{table}
+
+\begin{table}[!htbp]
+    \centering 
+    \begin{tabular}{@{}lcccccc@{}}
+        \toprule
+        Model & \# param & OWT & Lambada & Wikitext & PTB & Med $\downarrow$ \\ \midrule
+        GPT-2-Base & 124M & 2.84 & 4.32 & 4.13 & 5.75 & 4.26 \\
+        ToST-Base & 110M & 3.20 & 4.98 & 4.77 & 6.39 & 4.84 \\
+        ToST-Medium & 304M & 2.88 & 4.45 & 4.30 & 5.64 & 4.32 \\
+        ToST-Large & 655M & 2.72 & 4.32 & 3.99 & 5.03 & 4.02 \\ \bottomrule
+    \end{tabular}%
+    \caption{\small\textbf{Pierderea de validare a modelării limbajului} calculată pe (seturi holdout ale) unei varietăți de seturi de date de limbaj natural, după pre-antrenarea modelului pe acel set de date. Observăm că ToST scalează bine, astfel încât ToST-Large depășește GPT-2-Base de bază în modelarea limbajului cauzal, bucurându-se în același timp de eficiență superioară în contexte lungi.}
+    \label{tab:tost_lm}
+\end{table}
+
+\begin{table}
+    \centering
+    
+    \begin{tabular}{@{}lccccccc@{}}
+            \toprule
+            Model        & ListOps  & Text     & Regăsire & Imagine    & Pathfinder & Medie      \\
+            \midrule
+            \midrule
+            Reformer              & \textbf{37.27} & 56.10             & 53.40              & 38.07             & 68.50               & 50.56             \\
+            BigBird               & 36.05             & 64.02             & 59.29              & 40.83             & 74.87                & 54.17             \\
+            LinFormer         & 16.13             & \underline{65.90} & 53.09              & 42.34             & \underline{75.30}               & 50.46             \\
+            Performer             & 18.01             & 65.40             & 53.82              & 42.77             & \textbf{77.05}                & 51.18             \\
+            Transformer           & 37.11             & 65.21             & \underline{79.14}              & \underline{42.94}             & 71.83              & \underline{59.24}            \\
+            ToST & \underline{37.25}    & \textbf{66.75}    & \textbf{79.46}     & \textbf{46.62}    &    69.41      &     \textbf{59.90}\\
+            
+            \bottomrule
+        \end{tabular}%
+    \caption{\small \textbf{Comparația performanței Long-Range Arena (LRA) a ToST(-B) versus cele mai bune variante de transformer optimizate pentru context lung.} Long-Range Arena este o familie de teste de referință care testează capacitatea de modelare a secvențelor lungi a algoritmilor și arhitecturilor, prin fixarea setului de date și a mecanismului de evaluare. ToST obține scoruri de top în clasament comparativ cu toate variantele cunoscute de transformer, inclusiv XCiT și transformer-ul regular (ViT) (cf. \Cref{tab:tost_linear_probing}). Mai mult, ToST are cea mai mică complexitate de timp și spațiu la inferență. (În acest tabel, cel mai bun scor pentru un anumit test de referință este îngroșat, iar al doilea cel mai bun scor este subliniat.)}
+    \label{tab:tost_lra_results}
+\end{table}
+
+Mai mult, arhitectura propusă, numită ToST (pentru ``Token Statistics Transformer'') performează bine la sarcini de viziune (adică, \Cref{tab:tost_linear_probing}) și sarcini de limbaj (adică, \Cref{tab:tost_lm}). Acest lucru este valabil în special pentru sarcinile cu lungime mare de secvență (cf. \Cref{tab:tost_lra_results}), unde este atât mai performantă, cât și mult mai eficientă decât transformer-ele convenționale și toate celelalte arhitecturi de tip transformer.
+
+\subsection{Transformere doar cu atenție} \label{sub:aot_experiments}
+
+Un alt blocaj de eliminat din modelele de învățare profundă, în special din arhitecturile de tip transformer, este blocajul de memorie care provine din înmulțirile masive de matrici în MLP-uri, unde dimensiunea internă este cu mult mai mare decât dimensiunea caracteristicilor \(d\). Astfel, este o întrebare interesantă și importantă de pus: avem \textit{într-adevăr} nevoie de MLP în interiorul unui transformer și cât de bună poate fi performanța fără el? Pentru a explora această întrebare, folosim arhitectura transformer-doar-cu-atenție (AoT) (vezi \Cref{sub:aot}), ilustrată în \Cref{fig:aot_backbone}. Mai exact, fiecare strat este pur și simplu de forma 
+\begin{equation}
+    \vZ_{\theta}^{\ell + 1}(\vX) = \vZ_{\theta}^{\ell}(\vX) + \MSSA_{\theta}^{\ell}(\LN_{\theta}^{\ell}(\vZ_{\theta}^{\ell}(\vX))).
+\end{equation}
+În implementarea noastră, am experimentat și cu utilizarea auto-atenției multi-cap (MHSA) în locul MSSA. Se dovedește că această arhitectură este \textit{de asemenea} viabilă, deși adâncimea rețelei trebuie să fie mult mai mare pentru a obține performanță echivalentă cu arhitectura obișnuită CRATE sau transformer. %
+
+\begin{figure}[!htbp]
+    \centering 
+    \includegraphics[width=0.7\textwidth]{\toplevelprefix/chapters/chapter7/figs/aot_backbone.pdf}
+    \caption{\small\textbf{Un strat al backbone-ului AoT.} Reprezentările token-urilor trec doar printr-o normalizare pe straturi și operatorul de auto-atenție multi-cap (subspațiu) pentru a forma ieșirea stratului. Observați că nu există neliniaritate la nivel de token precum MLP sau ISTA sau ODL.}
+    \label{fig:aot_backbone}
+\end{figure}
+
+
+Efectuăm experimente folosind arhitectura AoT propusă și demonstrăm potențialul acesteia. Pre-antrenăm modelele AoT-MSSA și AoT-MHSA de diferite dimensiuni, împreună cu GPT-2, pe OpenWebText~\citep{Gokaslan2019OpenWeb}. Reprezentăm grafic pierderea de antrenare și pierderea de validare în funcție de numărul de iterații de antrenare în \Cref{fig:loss}(a) și, respectiv, (b). Se observă că modelele bazate pe AoT de dimensiuni medii și mari obțin pierderi de antrenare și validare comparabile cu cele ale modelului de bază GPT-2. În plus, comparativ cu modelul de bază GPT-2, modelul AoT-MHSA este identic cu modelul de bază GPT-2, cu excepția absenței straturilor MLP din arhitectură. După cum se arată în \Cref{fig:loss}, încorporarea straturilor MLP poate accelera procesul de antrenare. Folosind modelele pre-antrenate de mai sus, calculăm pierderea de validare cu entropie încrucișată fără antrenare pe diferite seturi de date în \Cref{tab:zeroshot}. Se observă că modelele AoT cu dimensiuni medii și mari de parametri pot obține performanță comparabilă cu modelul de bază GPT-2. Mai mult, am constatat că adăugarea straturilor MLP la AoT nu îmbunătățește performanța zero-shot. Aceste rezultate evidențiază potențialul modelelor doar-cu-atenție de a obține rezultate competitive menținând în același timp interpretabilitatea.  
+
+\begin{table*}[!htbp]
+\caption{Rezultate zero-shot pe mai multe seturi de date și sarcini de referință pentru limbaj: Evaluarea diferitelor dimensiuni de AoT cu operatorii MSSA și MHSA și comparație cu modelul GPT2.}\vskip 0.1in
+\centering
+\begin{small}
+\begin{tabular}{l|cccccc}
+\toprule
+ Models  & {\bf LAMBADA} & {\bf PTB} & {\bf WikiText} & {\bf LAMBADA} & {\bf CBT CN} & {\bf CBT NE} \\
+ \# of parameters  & (val loss) $\downarrow$ &  (val loss) $\downarrow$ &(val loss) $\downarrow$ & (acc) $\uparrow$ &(acc) $\uparrow$ &(acc) $\uparrow$ \\
+ \midrule
+ AoT-MSSA Base (102M) & 4.70 & 6.03 & 4.65 & 0.25 & 0.80 & 0.74\\
+ AoT-MSSA Medium (182M) & 4.47 & 5.08 & 4.22 & 0.29 & 0.84 & 0.77 \\
+ AoT-MHSA Base (122M) & 4.42 & 5.52 & 4.19 & 0.38 & 0.86 & 0.82\\
+ GPT-2 Base (124M) & 4.32 & 5.75 & 4.13 &  0.40 &  0.87 &  0.84 \\
+\bottomrule
+\end{tabular}
+\label{tab:zeroshot}
+\end{small}
+\end{table*} 
+\vspace{-0.05in} 
+
+
+\begin{figure*}[t]
+\begin{center}
+\includegraphics[width=0.4\linewidth]{\toplevelprefix/chapters/chapter7/figs/training_loss.png} \hspace{0.4in}
+\includegraphics[width = 0.4\linewidth]{\toplevelprefix/chapters/chapter7/figs/val_loss.png}
+    \vspace{-0.15in}
+\caption{\centering \textbf{Evaluarea modelelor pe sarcini de limbaj.} Reprezentăm grafic pierderea de antrenare (stânga) și pierderea de validare (dreapta) a modelelor AoT și GPT-2 pre-antrenate pe OpenWebText.}  \label{fig:loss} 
+\end{center}
+\vspace{-0.15in}
+\end{figure*} 
+
+
+
+
+ 
+
+\section{Autocodare cu măscări pentru date de imagini}\label{sec:image_completion}
+
+A doua aplicație pe care o discutăm este \textit{completarea neliniară a imaginilor}, cunoscută și sub numele de \textit{autocodare cu măscări} (MAE), care este o generalizare directă a problemei de completare a matricilor de rang mic discutată în \Cref{ch:classic}. Autocodarea cu măscări, de la introducerea sa în contextul învățării profunde de către \cite{he2022masked}, a fost o metodă de bază și simplă de învățare a reprezentărilor auto-supervizată, care își propune să înzestreze fiecare caracteristică de patch din \(\vZ_{\theta}\) cu informații agregate, precum și cu informații despre vecinii săi, astfel încât atât caracteristica patch-ului, cât și caracteristicile agregate să fie surse bogate de informații pentru întreaga probă. 
+
+Setul de date este păstrat la fel ca seturile de date de imagini discutate în \Cref{sub:contrastive_learning_data}. Ca de obicei, aplicăm în continuare augmentări de date la fiecare probă din fiecare batch nou. 
+
+\subsection{Sarcină și obiectiv}\label{sub:image_completion_objective}
+
+După cum sugerează numele, autocodarea cu măscări implică o vedere \(v_{m}\) care, având o intrare, efectuează o decupare redimensionată aleatorie (cf. \Cref{sub:contrastive_learning_objective}) pentru a transforma imaginea de intrare într-o imagine pătrată de dimensiune \((C, S_{\mask}, S_{\mask})\), apoi \textit{maschează} (adică setează la zero) un procent fix \(p_{\mask} \in [0, 1]\) de pixeli din intrare. Din motive de eficiență\footnote{Implementarea originală a MAE de către \cite{he2022masked} încorporează întreaga imagine, \textit{elimină} token-urile care ar fi mascate, trece setul de token-uri rezultat prin encoder, adaugă înapoi token-uri de substituție învățate în locurile mascate și adaugă înapoi codarea pozițională corespunzătoare, și trece setul de token-uri rezultat prin decoder pentru a obține predicția de autocodare. Aceasta este mai eficientă deoarece encoder-ul are mai puține token-uri de procesat, dar conceptual este aceeași cu metoda discutată în text, iar performanța modelelor rezultate în sarcina de autocodare cu măscări și evaluările ulterioare este foarte similară.}, mascarea se face pe patch-uri, adică după încorporarea întregii imagini, un procent \(p_{\mask}\) de \textit{patch-uri} sunt setate la zero. Scopul MAE este de a antrena un encoder \(f_{\theta} \colon \cI \to (\R^{d})^{*}\) și un decoder \(g_{\eta} \colon (\R^{d})^{*} \to \cI\) care pot reconstrui o intrare din mascarea sa, adică scriind \(\hat{\vX}_{\theta, \eta} \doteq g_{\eta} \circ f_{\theta}\), avem
+\begin{equation}
+    \min_{\theta, \eta}\bc{\cL_{\mathrm{MAE}}(\theta, \eta) \doteq \Ex\norm{\hat{\vX}_{\theta, \eta}(\vX_{m}) - \vX}_{F}^{2}}
+\end{equation}
+În esență, aceasta înseamnă că caracteristicile \(\vZ_{\theta}(\vX_{m})\) ale vederii \(\vX_{m} \doteq v_{m}(\vX)\) trebuie să conțină informații despre \textit{patch-urile mascate}, precum și despre patch-urile existente. Din perspectiva modelelor cu cutie albă bazate pe compresie din \Cref{ch:representation}, dacă un autoencoder cu cutie albă \((f_{\theta}, g_{\eta})\) reușește la această sarcină, înseamnă că subspațiile și dicționarele învățate efectuează o codare \textit{redundantă} a datelor, astfel încât poate reconstrui părțile lipsă ale datelor din alte părți codate ale datelor. Aceasta înseamnă că informațiile despre fiecare patch sunt stocate în alte patch-uri. Prin urmare, fiecare caracteristică de patch ar trebui să conțină atât informații despre patch, cât și informații despre statisticile întregii imagini. Astfel, din nou, ne așteptăm ca reprezentările să conțină atât informații locale, cât și globale relevante semantic, și, prin urmare, reprezentările diferitelor patch-uri cu informații locale și globale similare ar trebui să fie legate (în același subspațiu sau codate împreună de un dicționar).
+
+\subsection{Arhitectură}\label{sub:image_completion_architecture}
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/crate_ae_backbone.pdf}
+    \caption{\small\textbf{Un strat al encoder-ului și decoder-ului într-un backbone de autoencoder CRATE.} Straturile encoder-ului și decoder-ului alimentează ambele intrările lor prin auto-atenție de subspațiu multi-cap și un pas de învățare de dicționar sau codare de dicționar. Observați că straturile encoder-ului și decoder-ului sunt proiectate simetric; scopul conceptual al fiecărui strat de decoder este de a inversa un strat de encoder, așa că această simetrie este foarte mult prin design (vezi, de exemplu, \Cref{ch:autoencoding}).}
+\end{figure}
+
+Folosim un encoder și decoder CRATE, ilustrat în \Cref{fig:transformer_backbone}, deși, bineînțeles, este posibil să folosim un encoder și decoder transformer obișnuit. Detaliile urmează.
+
+\paragraph{Encoder-ul.} Encoder-ul este același cu encoder-ul CRATE din \Cref{sub:image_classification_architecture}, cu mențiunea că nu există extractor de caracteristici \(f_{\theta}^{\ext}\). Totuși, atât încorporarea \(f_{\theta}^{\emb}\), cât și backbone-ul \(f_{\theta}^{\backbone}\) sunt aceleași.
+
+\paragraph{Backbone-ul decoder-ului.} Backbone-ul decoder-ului este decoder-ul CRATE descris în \Cref{ch:autoencoding}. Pentru completitudine, îl descriem acum. Având o secvență de caracteristici \(\vZ_{\theta}(\vX) \doteq f_{\theta}(\vX) \in (\R^{d})^{*}\), o putem procesa folosind backbone-ul decoder-ului \(g_{\eta}^{\backbone}\) după cum urmează. Funcția \(g_{\eta}^{\backbone}\) este compusă din \(L\) straturi \(g_{\eta}^{\ell}\), adică,
+\begin{equation}
+    g_{\eta}^{\backbone} = g_{\eta}^{L} \circ \cdots \circ g_{\eta}^{1}.
+\end{equation}
+Stratul \(g_{\eta}^{\ell}\) are următoarea implementare. Mai întâi, definim \(\tilde{\vZ}_{\theta, \eta}^{1}(\vX) \doteq \vZ_{\theta}(\vX)\). Apoi, obținem
+\begin{align}
+    \tilde{\vZ}_{\theta, \eta}^{\ell + 1/2}(\vX) 
+    &= [\tilde{\vD}^{\ell}]^{\top}\LN_{\eta}^{1, \ell}(\tilde{\vZ}_{\theta, \eta}^{\ell}(\vX)) \\ 
+    \tilde{\vZ}_{\theta, \eta}^{\ell + 1}(\vX)
+    &= \tilde{\vZ}_{\theta, \eta}^{\ell + 1/2}(\vX) - \MSSA_{\eta}^{\ell}(\LN_{\eta}^{2, \ell}(\tilde{\vZ}_{\theta, \eta}^{\ell + 1/2}))
+\end{align}
+și \(g_{\eta}^{\ell}\) este definit astfel încât \(g_{\eta}^{\ell}(\tilde{\vZ}_{\theta, \eta}^{\ell}) \doteq \tilde{\vZ}_{\theta, \eta}^{\ell + 1}(\vX)\). Aici, conceptul relevant este că \(g_{\eta}^{\ell}\) ar trebui să învețe o inversă aproximativă a \(f_{\theta}^{L + 1 - \ell}\), ca discretizări ale unui proces de difuzie în timp direct și, respectiv, invers. În special, \(\tilde{\vD}^{\ell}\) ar trebui să aproximeze \(\vD^{L + 1 - \ell}\), și, în mod similar, parametrii \(\MSSA_{\eta}^{\ell}\) ar trebui să fie similari cu parametrii \(\MSSA_{\theta}^{L + 1 - \ell}\). Ieșirea este \(\tilde{\vZ}_{\theta, \eta} \doteq \tilde{\vZ}_{\theta, \eta}^{L + 1}\).
+
+\paragraph{Modulul de des-încorporare.} Pentru a transforma \(\tilde{\vZ}_{\theta, \eta}(\vX)\) înapoi într-o estimare pentru \(\vX\), trebuie să anulăm efectul modulului de încorporare \(f_{\theta}^{\emb}\) folosind modulul de des-încorporare \(g_{\eta}^{\unemb}\). Ca atare, refăcând la forma funcțională a modulului de încorporare din \eqref{eq:definition_of_embedding_module}, adică,
+\begin{equation}
+    f_{\theta}^{\emb}(\vX) \doteq \mat{\vz_{\cls}^{1}, \vW^{\emb}f^{\patch}(\vX) + \vE^{\pos}}
+\end{equation}
+implică că operația noastră inversă \(g_{\eta}^{\unemb}\) arată astfel:
+\begin{equation}
+    g_{\eta}^{\unemb}(\tilde{\vZ}) \doteq g_{\eta}^{\unemb}(\mat{\tilde{\vz}^{1}, \dots, \tilde{\vz}^{n}}) = g^{\unpatch}(\vW^{\unemb}([\tilde{\vz}^{2}, \dots, \tilde{\vz}^{n}] - \tilde{\vE}^{\pos})),
+\end{equation}
+unde \(g^{\unpatch}\) face operația inversă a operației de derulare și aplatizare pe care o face \(f^{\patch}\).\footnote{Din nou, ``codarea pozițională inversă'' \(\tilde{\vE}^{\pos}\) este învățată pentru o intrare mare și pentru intrări mai mici poate fi interpolată. Este chiar posibil să setăm direct \(\tilde{\vE}^{\pos}\) egal cu codarea pozițională \(\vE^{\pos}\) și să folosim aceleași codări poziționale interpolate pentru fiecare intrare atât în encoder, cât și în decoder.}
+
+Această arhitectură este un autoencoder cu cutie albă \((f_{\theta}, g_{\eta})\) unde (reamintim) \(f_{\theta} = f_{\theta}^{\backbone} \circ f_{\theta}^{\emb}\) și \(g_{\eta} = g_{\eta}^{\unemb} \circ g_{\eta}^{\backbone}\). În special, îl putem folosi pentru a calcula o estimare pentru o vedere mascată \(\hat{\vX}_{\theta, \eta}(\vX_{m}) = (g_{\eta} \circ f_{\eta})(\vX_{m})\) care ar trebui să fie aproximativ egală cu \(\vX\) însăși.
+
+\subsection{Optimizare}\label{sub:image_completion_optimization}
+
+Ca în \Cref{sub:image_classification_optimization}, folosim o configurație simplă de optimizare: eșantionăm imagini și măști, calculăm pierderea pe acele eșantioane și gradienții acestei pierderi și actualizăm parametrii folosind un algoritm de optimizare generic și gradienții menționați mai sus. Pentru fiecare pas de timp \(k\), noi:
+\begin{itemize}
+    \item Subeșantionăm \(B\) eșantioane diferite \(\{\vX_{b}^{(k)}\}_{b = 1}^{B} \subseteq \cI\).
+    \item Pentru fiecare eșantion \(\vX_{b}^{(k)}\), calculăm o decupare redimensionată aleatorie diferită și mască \(v_{b, m}^{(k)}\) și o aplicăm la \(\vX_{b}^{(k)}\) pentru a obține \(\vX_{b, m}^{(k)} \doteq v_{b, m}^{t}(\X_{b}^{(k)})\).
+    \item Calculăm autocodarea estimată \(\hat{\vX}_{\theta, \eta}(\vX_{b, r}^{(k)}) \doteq (g_{\eta} \circ f_{\theta})(\vX_{b, r}^{(k)})\).
+    \item Formăm pierderea stocastică surogat 
+    \begin{equation}
+        \hat{\cL}_{\mathrm{MAE}}^{(k)}(\theta, \eta) \doteq \frac{1}{B}\sum_{b = 1}^{B}\norm{\hat{\vX}_{\theta, \eta}(\vX_{b, r}^{(k)}) - \vX_{b}^{(k)}}_{F}^{2}.
+    \end{equation}
+    \item Calculăm un pas al unui algoritm de optimizare pe \((\theta, \eta)\), dând următoarea iterație:
+    \begin{equation}
+        (\theta^{(k + 1)}, \eta^{(k + 1)}) \doteq \textsc{OptUpdate}^{(k)}(\theta^{(k)}, \eta^{(k)}; \nabla_{(\theta, \eta)}\hat{\cL}_{\mathrm{MAE}}^{(k)}).
+    \end{equation}
+\end{itemize}
+
+\subsection{Evaluare} \label{sub:image_completion_optimization_1}
+
+Aceasta este prima rețea de autoencoder pe care o discutăm în acest capitol. Folosim aceeași vedere de decupare centrală \(v_{\cc}\) ca în \Cref{sub:contrastive_learning_evals,sub:image_classification_evals}, redimensionând imaginea finală la un pătrat cu lungimea laturii de \(S_{\cc} = S_{\mask}\) pixeli pentru a potrivi formele imaginilor de intrare văzute în timpul antrenării. 
+
+În plus față de evaluarea pierderii de autocodare cu măști în sine, este de asemenea posibil să evaluăm direct caracteristicile \(\vZ_{\theta}(\vX_{\cc})\) ale vederii \(\vX_{\cc} \doteq v_{\cc}(\vX)\) a datelor \(\vX\). Pentru evaluarea fidelității hărții de atenție, obținerea \(\vZ_{\theta}(\vX_{\cc})\) este suficientă, dar pentru sondarea liniară trebuie să extragem o caracteristică rezumată sau agregată din \(\vZ_{\theta}\). Pentru a face acest lucru, putem folosi o hartă de extracție a caracteristicilor (fără parametri) care returnează caracteristica corespunzătoare token-ului de clasă, adică,
+\begin{equation}
+    f_{\theta}^{\ext}(\vZ) \doteq f_{\theta}^{\ext}([\vz^{1}, \dots, \vz^{n}]) = \vz^{1},
+\end{equation}
+ca în (de exemplu) \Cref{sub:image_classification_objective,sub:image_classification_architecture}. Cu aceasta, avem o modalitate de a obține caracteristici agregate \(\vz_{\theta}(\vX_{\cc}) \doteq (f_{\theta}^{\ext} \circ f_{\theta})(\vX_{\cc})\), moment în care putem efectua sondare liniară, evaluări de segmentare și așa mai departe.
+
+\subsection{Experimente}\label{sub:image_completion_experiments}
+
+Deoarece CRATE-MAE se bazează direct pe ViT-MAE, comparăm setările optime pentru ViT-MAE, așa cum sunt date de \citep{he2022masked}, cu aceleași setări aplicate la CRATE-MAE pentru o comparație echitabilă.
+
+\paragraph{Arhitectura modelului.} În timpul antrenării, decuparea mascată \(v_{m}\) redimensionează întreaga imagine astfel încât marginea mai scurtă să fie de dimensiune \(256\) (adică, \(S_{\rsz} = 256\)) înainte de a lua o decupare aleatorie de dimensiune \(224 \times 224\) (adică, \(S_{\mathrm{mask}} = 224\)), și mascând \(p_{\mathrm{mask}} = \frac{3}{4}\) din patch-uri. Luăm dimensiunea patch-ului \(16\) (adică, \(P_{H} = P_{W} = 16\)). Folosim variantele mici și de bază ale arhitecturii ViT-MAE ca încorporare și backbone atât pentru encoder, cât și pentru decoder, schimbând componentele MHSA și MLP pentru MSSA, ISTA și, respectiv, straturi liniare. Folosim același număr de capete și dimensiune a capului în cazul MSSA. Totuși, ViT-MAE original folosește un encoder care folosește aproape toate straturile totale și un decoder care folosește doar câteva straturi; alocăm jumătate din numărul total de straturi (care rămâne același de la ViT-MAE la CRATE-MAE) encoder-ului și decoder-ului nostru, după cum sugerează cadrul conceptual și teoretic din \Cref{ch:autoencoding}. Pentru CRATE-MAE setăm \((\beta, \lambda) = (1, 0.1)\).
+
+\paragraph{Seturi de date și optimizare.} Pentru pre-antrenare, folosim setul de date ImageNet-1K. Folosim optimizatorul AdamW pentru a pre-antrena atât replicația noastră ViT-MAE, cât și CRATE-MAE. Setăm rata de învățare de bază ca \(3 \times 10^{-5}\), decadența ponderii ca \(0.1\) și dimensiunea batch-ului ca \(B = 4096\). Programul nostru de rată de învățare crește rata de învățare liniar până la rata de învățare de bază pe parcursul primelor \(40\) de epoci și scade la \(0\) folosind o programare cosinus pe parcursul următoarelor \(760\) de epoci (antrenând toate modelele pentru \(800\) de epoci fiecare). Pentru pre-antrenare, aplicăm regimul obișnuit de augmentări de date (răsturnări, estompare gaussiană, solarizare etc.) la datele de imagine.
+
+Pentru sondarea liniară, folosim mai multe seturi de date de evaluare, cum ar fi CIFAR10, CIFAR100, Oxford-Flowers și Oxford-IIT-Pets. Pentru sondarea liniară, precalculăm caracteristicile tuturor eșantioanelor din setul de date țintă și aplicăm un rezolvator de regresie liniară rapid, de exemplu, dintr-un pachet standard precum Scikit-Learn.
+
+\paragraph{Rezultatele experimentului.} \Cref{tab:crate_mae_linear_probing} demonstrează că modelele CRATE-MAE obțin, în linii mari, paritate cu populara arhitectură ViT-MAE la număr similar de parametri și, de asemenea, că performanța de învățare a caracteristicilor (măsurată prin performanța la sarcinile de clasificare ulterioare) crește cu scala. Între timp, \Cref{fig:crate_mae_semantic_heads} demonstrează că hărțile de saliență ale encoder-ului (și, prin urmare, caracteristicile fine învățate de encoder) într-adevăr izolează și evidențiază părțile cheie ale imaginii de intrare.
+
+
+\begin{table}
+    \centering 
+    \begin{tabular}{@{}lcc|cc@{}}
+        \toprule 
+        \textbf{Model} & CRATE-MAE-S(mall) & CRATE-MAE-B(ase) & {\color{gray} ViT-MAE-S} & {\color{gray} ViT-MAE-B} \\
+        \midrule
+        \midrule
+        \# parametri & 25.4M & 44.6M & 47.6M & {\color{gray}143.8M} \\
+        \midrule
+        CIFAR10 & 79.4 & 80.9 & {\color{gray} 79.9} & {\color{gray} 87.9} \\
+        CIFAR100 & 56.6 & 60.1 & {\color{gray} 62.3} & {\color{gray} 68.0} \\
+        Oxford Flowers-102 & 57.7 & 61.8 & {\color{gray} 66.8} & {\color{gray} 66.4} \\
+        Oxford-IIIT-Pets & 40.6 & 46.2 & {\color{gray} 51.8} & {\color{gray} 80.1} \\
+        \bottomrule
+    \end{tabular}
+    \caption{\small\textbf{Acuratețea de clasificare prin sondare liniară a CRATE-MAE și ViT-MAE} pe diverse seturi de date cu diferite dimensiuni ale modelului când backbone-ul este pre-antrenat pentru autocodare cu măști pe ImageNet-1K. Dat fiind același număr de parametri, CRATE-MAE obține performanță aproximativ similară, bucurându-se simultan de un design de arhitectură mai simplu și mai principial.}
+    \label{tab:crate_mae_linear_probing}
+\end{table}
+
+\begin{figure}
+    \centering 
+    \includegraphics[width=\textwidth]{\toplevelprefix/chapters/chapter7/figs/crate_mae_semantic_heads.pdf}
+    \caption{\small\textbf{Hărți de saliență ale CRATE-MAE.} Fiecare pereche de imagini constă din imaginea originală (stânga) și o hartă de saliență selectată (dreapta) corespunzătoare unui cap de atenție din ultimul strat. După cum este obișnuit pentru modelele CRATE, dar neobișnuit pentru modelele generale de tip transformer, hărțile de saliență corespund obiectelor din imaginea de intrare.}
+    \label{fig:crate_mae_semantic_heads}
+\end{figure}
+
+
+
+
+
+\section{Rezumat și note}
+
+Toate lucrările din acest capitol sunt derivate din arhitectura Transformer, care a fost introdusă de \citet{vaswani2017attention}. Arhitectura Transformer este descrisă formal în \Cref{sec:contrastive_learning}. O inovație empirică principală din ultimii ani, stimulată de prevalența și performanța arhitecturii Transformer, este de a formula o problemă de învățare dată ca o problemă secvență-la-secvență și de a aplica arhitectura Transformer. Aceasta a permis arhitecturii Transformer să fie esențial omniprezentă în (aproape) toate aplicațiile de învățare profundă. Ca atare, îmbunătățirile directe ale Transformer-ului pot să se propage pentru a deveni soluții la multe probleme și au un impact considerabil; în mod similar, putem aplica înțelegerea noastră cu cutie albă a arhitecturilor de tip transformer la multe probleme moderne. Materialul acoperit în acest capitol este doar un subset al muncii care a fost deja făcută; alte lucrări includ completarea cu măști pentru date text (adică, BERT) \citep{devlin2019bert,yu2024white}, interpretabilitatea (mecanicistă) a modelelor de limbaj și viziune \citep{bai2024improving} și codarea de corecție a erorilor \citep{zheng2025white}. Există mult mai multe de făcut.
+
+Există, de asemenea, multă mai multă teorie specifică despre practica scalării rețelelor neuronale, care este enorm de viabilă practic, și cel puțin o menționăm aici. Această linie de lucru a fost popularizată de linia de lucru ``Tensor Programs'' \citep{yang2022tensor}. Prescripția de bază este că dorim ca actualizările inițiale ale gradientului într-un transformer să fie de dimensiune constantă și, lucrând cu atenție prin ecuațiile de backpropagare (\Cref{app:optimization}), putem determina scala inițializării și ratele de învățare (alese pe straturi) care sunt necesare pentru a realiza acest lucru. În practică, astfel de prescripții cresc foarte mult stabilitatea și convergența antrenării la scală mare; ele prescriu, de asemenea, o modalitate de a găsi hiperparametrii ``optimi''\footnote{Cuvântul ``optim'' este folosit între ghilimele deoarece lucrările pe acest subiect folosesc doar niște deziderate despre dimensiunea ponderii, dimensiunea caracteristicii și dimensiunea gradientului la inițializare pentru a determina ``optimitatea'', spre deosebire de, să spunem, pierderea de testare la convergență.} pentru antrenarea la scară mare folosind doar antrenare la scară mică. Lucrările ulterioare acestei lucrări încearcă să acomodeze geometria caracteristicilor \citep{bernstein2024oldoptimizernewnorm}, care ar putea fi informată de lucrările din această carte despre învățarea reprezentărilor. Alte lucrări ulterioare încorporează aceste informații despre ponderi în optimizatorul însuși pentru a obține aceste beneficii de scalare automat, obținând optimizatori precum Muon \citep{jordan6muon}, care au fost recent folosite pentru antrenarea modelelor de trilioane de parametri foarte stabil \citep{moonshot2025kimi}. În general, cele două abordări ale teoriei învățării profunde sunt ortogonale sau complementare.
+
+
+\section{Exerciții și extinderi}
+
+\begin{exercise}
+    Citește lucrarea DINO \cite{caron2021emerging}.
+\end{exercise}
+
+\begin{exercise}
+    DINO v2 \cite{oquab2023dinov2} folosește totul din DINO v1, dar și, în timpul fazei de augmentare a datelor, maschează aleatoriu patch-uri în cadrul fiecărei vederi. Acest tip de augmentare ar trebui să impună ca caracteristicile imaginilor cu informații locale similare să fie similare. Formulează o problemă de optimizare care promovează aceasta în encoder și implementeaz-o.
+\end{exercise}
+
+
+\begin{exercise}
+    Acest exercițiu consideră implementarea algoritmilor de optimizare stocastică pentru minimizarea pierderilor care implică așteptări.
+    \begin{enumerate}[(a)]
+        \item Propune o alternativă la termenul care implică \(R_{\eps}\) din \eqref{eq:simdino_loss_teacherstudent_empirical} pentru aproximarea termenului de regularizare a covarianței din \eqref{eq:simdino_loss_teacherstudent}. Evaluează complexitatea de timp necesară pentru a calcula termenul propus și gradientul său. Include o analiză pentru calcularea acestuia pe un singur nod de calcul vs. mai multe noduri.
+        \item Evaluează complexitatea de timp necesară pentru a calcula termenul existent din \eqref{eq:simdino_loss_teacherstudent_empirical} și gradientul său.
+    \end{enumerate}
+\end{exercise}
+
+\begin{exercise}
+    Demonstrează că \eqref{eq:linear_probing} și \eqref{eq:linear_probing_empirical} sunt probleme de optimizare convexe.
+\end{exercise}
+
+\begin{exercise}
+    \phantom{}
+    \begin{enumerate}[(a)]
+        \item Implementează modelele CRATE și CRATE-\(\alpha\).
+        \item Compară performanța și eficiența lor pe setul de date CIFAR-10.
+        \item Compară interpretabilitatea lor în două moduri:
+        \begin{itemize}
+            \item Sparsitatea \(\norm{\vZ}_{0}\) a reprezentării \(\vZ\)
+            \item Hărțile de atenție \(\va_{\theta}^{k, \ell}\)
+        \end{itemize}
+    \end{enumerate}
+\end{exercise}
+
+\end{document}

--- a/chapters/chapter8/future_ro.tex
+++ b/chapters/chapter8/future_ro.tex
@@ -1,0 +1,183 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter{Studiul viitor al inteligenței}
+\label{ch:future}
+
+
+  
+
+\begin{quote}
+``{\em Studiul urmează să fie realizat pe baza conjecturii că fiecare aspect al învățării sau orice altă caracteristică a inteligenței poate fi în principiu descris atât de precis încât o mașină poate fi făcută să îl simuleze. Se va încerca să se descopere cum să facă mașinile să folosească limbajul, să formeze abstracții și concepte, să rezolve tipuri de probleme acum rezervate oamenilor și să se îmbunătățească pe ele însele.}''
+
+$~$\hfill -- Propunere pentru programul de IA Dartmouth, 1956
+ \end{quote}
+\vspace{5mm}
+
+
+În general vorbind, acest manuscris este menit să introducă sistematic principii matematice și mecanisme computaționale pentru modul în care memoria sau cunoașterea pot fi dezvoltate din observații empirice. Capacitatea de a căuta parsimonie într-o lume aparent aleatorie este o caracteristică fundamentală a oricărei inteligențe, naturale sau artificiale. Credem că principiile și mecanismele prezentate în această carte sunt destul de unificatoare și universale și sunt aplicabile atât animalelor, cât și mașinilor.
+
+Sperăm că această carte poate ajuta cititorii să clarifice pe deplin misterul din jurul practicilor moderne de rețele neuronale artificiale profunde prin dezvoltarea unei înțelegeri riguroase a funcțiilor și rolurilor lor în atingerea obiectivului de învățare a distribuțiilor de dimensiune mică din date de dimensiune mare. Cu o astfel de înțelegere, ar trebui să devenim destul de clari atât despre capacitățile, cât și despre limitările modelelor și sistemelor AI existente:
+\begin{enumerate}
+    \item Modelele și sistemele existente sunt departe de a fi complete în ceea ce privește un sistem de memorie care este capabil de auto-învățare și auto-îmbunătățire.
+    \item Realizările existente ale acestor funcții sunt încă destul de primitive și prin forță brută și cu siguranță departe de a fi optime în ceea ce privește strategiile de optimizare și, prin urmare, arhitecturile de rețea.
+    \item Modelele AI existente învață doar distribuția datelor și efectuează inferență inductivă (bayesiană), care este diferită de inteligența umană de nivel înalt.
+\end{enumerate} 
+
+Unul dintre obiectivele acestei cărți este ca oamenii să stabilească o înțelegere obiectivă și sistematică a tehnologiilor actuale de inteligență artificială și să realizeze ce probleme deschise și provocări rămân în față pentru avansarea ulterioară a inteligenței artificiale. În ultimul capitol al cărții, oferim câteva dintre punctele noastre de vedere și proiecții pentru viitor.
+
+\section{Către inteligența autonomă: Închiderea buclei?}
+Din practica inteligenței artificiale din ultimul deceniu, a devenit clar că, dacă ar exista suficiente date și resurse computaționale, s-ar putea construi un model suficient de mare și să-l pre-antrenezi pentru a învăța distribuția {\em a priori} a tuturor datelor, să zicem $p(\x)$. Teoretic, un astfel de model mare poate memoriza aproape toate cunoștințele existente despre lume care au fost codificate în limbaje și texte masive. După cum am discutat la începutul cărții, într-un fel, un astfel de model mare joacă un rol similar cu ADN-ul pe care viața îl folosește pentru a înregistra și transmite cunoștințe despre lume.
+
+Modelul și distribuția învățate în acest fel pot fi apoi folosite pentru a regenera noi eșantioane de date bazate pe aceeași distribuție. Se poate folosi, de asemenea, modelul pentru a efectua inferență (de exemplu, estimare, predicție) cu cunoștințele memorate în diferite condiții, să zicem prin eșantionarea distribuției {\em a posteriori} $p(\x\mid \y)$ sub o nouă observație $\y$. Strict vorbind, o astfel de inferență este statistică.
+
+Orice model pre-antrenat, oricât de mare, nu poate garanta că distribuția pe care a învățat-o până acum este complet corectă sau completă. În cazul în care eșantioanele noastre $\hat{\x}_t$ din {\em a priori} curent $p_t(\x)$ sau estimările $\hat{\x}_t(\y)$ bazate pe {\em a posteriori} $p_t(\x\mid \y)$ sunt inconsistente cu adevărul $\x$, am dori foarte mult să corectăm distribuțiile învățate:
+\begin{equation}
+    p_t(\x) \rightarrow p_{t+1}(\x) \quad \mbox{sau}\quad p_t(\x\mid \y) \rightarrow p_{t+1}(\x\mid \y),
+\end{equation}
+pe baza erorii $\boldsymbol{e}_t = \x_t - \hat{\x}_t$. Aceasta este cunoscută ca corecție a erorii bazată pe feedback de eroare, un mecanism omniprezent în natură pentru învățare continuă. Cu toate acestea, după cum știm, orice model cu capăt deschis în sine nu are mecanismul de a revizui sau îmbunătăți distribuția învățată când este incorectă sau incompletă. Îmbunătățirea modelelor AI actuale depinde încă în mare măsură de implicarea umană: experimentare, evaluare și selecție. Putem numi acest proces ``selecție artificială'' a modelelor mari, spre deosebire de selecția naturală pentru evoluția vieții.
+
+După cum am studiat mai devreme în această carte (Capitolul \ref{ch:closed-loop} în special), sistemele cu buclă închisă ne permit să aliniem o reprezentare internă cu observațiile (percepute) ale lumii externe. Poate continua să îmbunătățească distribuția învățată intern și reprezentarea sa pentru a obține consistență sau auto-consistență. Un pas imediat înainte pentru viitor este să dezvoltăm și să construim sisteme de memorie cu buclă închisă cu adevărat, așa cum se arată în Figura \ref{fig:open-to-closed}, care sunt capabile să învețe și să îmbunătățească distribuții de date mai generale în mod autonom și continuu pe baza feedback-ului de eroare.
+
+Prin urmare, tranziția de la modelele populare actuale cu capăt deschis antrenate de la un capăt la altul la sistemele cu buclă închisă care învață continuu:
+\begin{equation}
+   \mbox{\textbf{modele cu capăt deschis}} \; \Longrightarrow \; 
+   \mbox{\textbf{sisteme cu buclă închisă}}
+\end{equation}
+este cheia pentru ca mașinile să emuleze cu adevărat modul în care creierul (animal) învață și aplică cunoștințe într-o lume deschisă. Credem că
+\begin{quote}
+\begin{center}
+        {\em modelele cu capăt deschis sunt pentru o lume închisă, oricât de mare; \\ sistemele cu buclă închisă sunt pentru o lume deschisă, oricât de mică.}
+\end{center}
+\end{quote}
+De fapt, ``inteligența generală'' nu ar putea fi niciodată obținută prin simpla memorare a tuturor cunoștințelor existente ale lumii. În schimb, inteligența generală poate fi obținută doar având mecanismele pentru a-și îmbunătăți memoria existentă astfel încât să poată să se adapteze la orice medii și sarcini noi.
+
+\begin{figure}[t]
+    \centering    
+    \includegraphics[width=0.9\linewidth]{\toplevelprefix/chapters/chapter8/figs/open-to-closed.png}
+    \caption{De la o rețea profundă cu capăt deschis la un sistem cu buclă închisă.}
+    \label{fig:open-to-closed}
+\end{figure}
+
+
+
+\section{Către inteligența naturii: Dincolo de propagarea înapoi?}
+Practica inteligenței artificiale din ultimii ani i-a determinat pe mulți să creadă că trebuie să construiască un singur model mare pentru a învăța distribuția tuturor datelor și a memoriza toate cunoștințele. Chiar dacă acest lucru ar putea fi posibil din punct de vedere tehnologic, este probabil că o astfel de soluție este departe de a fi necesară și eficientă. După cum am știut din practica antrenării rețelelor profunde, singura metodă scalabilă cunoscută pentru a antrena astfel de rețele la scară este prin propagare înapoi (BP) \cite{Back-Prop}. Deși BP a oferit o modalitate de a corecta erorile prin semnale de gradient propagate înapoi prin întregul model, este totuși destul de prin forță brută și diferă semnificativ de modul în care natura învață: BP este o opțiune pe care natura nu și-o poate permite în ceea ce privește costul său ridicat sau pur și simplu nu o poate implementa din cauza limitărilor fizice.
+
+Mai general, nu putem înțelege cu adevărat inteligența decât dacă înțelegem și cum poate fi implementată eficient. Adică, trebuie să abordăm complexitatea computațională a realizării mecanismelor asociate cu atingerea obiectivelor inteligenței. Rețineți că, din punct de vedere istoric, înțelegerea noastră a inteligenței (artificiale) a evoluat precis prin mai multe faze, de la complexitatea Kolmogorov incalculabilă la entropia lui Shannon, de la calculabilitatea lui Turing la înțelegerea ulterioară a tractabilității,\footnote{Spunem că o problemă este tractabilă dacă permite un algoritm a cărui complexitate este polinomială în dimensiunea problemei.} și la accentul puternic pe scalabilitatea algoritmului în practica modernă a inteligenței artificiale. Această evoluție poate fi rezumată ca următoarea diagramă:
+\begin{equation}
+   \mbox{\textbf{incalculabil}} \;
+   \Longrightarrow \; \mbox{\textbf{calculabil}} \;
+   \Longrightarrow \; \mbox{\textbf{tractabil}} \; \Longrightarrow \; 
+   \mbox{\textbf{scalabil}}.
+\end{equation}
+Într-o mare măsură, succesul și popularitatea învățării profunde și a propagării înapoi se datorează precis faptului că au oferit o implementare scalabilă cu platforme de calcul moderne (cum ar fi GPU-urile) pentru procesarea și comprimarea datelor masive. Cu toate acestea, o astfel de implementare este încă mult prea scumpă în comparație cu modul în care natura realizează inteligența.
+
+Rămâne un spațiu imens pentru îmbunătățirea eficienței inteligenței artificiale, astfel încât să poată emula nivelul de eficiență al inteligenței naturale, care ar trebui să fie cu ordine de mărime mai eficient decât implementările actuale prin forță brută. În acest scop, trebuie să descoperim noi arhitecturi de învățare și mecanisme de optimizare care să permită învățarea distribuțiilor de date în condiții fizice naturale și constrângeri de resurse, similare cu cele pentru ființele inteligente din natură, să zicem, fără a accesa toate datele simultan sau a actualiza toți parametrii modelului simultan (prin BP).
+
+Cadrul și abordarea principială prezentate în această carte ne pot ghida să descoperim astfel de arhitecturi și mecanisme noi. Aceste arhitecturi și mecanisme noi ar trebui să permită învățarea continuă online și pot fi actualizate prin optimizare înainte sau înapoi extrem de localizată și rară. Până acum, pentru învățarea unei distribuții, singurul caz pentru care știm că există o astfel de soluție este cel mai simplu caz al PCA, cu metoda PCA online introdusă în Capitolul \ref{ch:autoencoding}.
+
+\begin{figure}[t]
+\centering
+\includegraphics[width=0.99\linewidth]{\toplevelprefix/chapters/chapter8/figs/loops.png}
+    \caption{Arhitectura conjecturată a cortexului cerebral: Cortexul este un sistem de auto-codare masiv paralel și distribuit care constă dintr-o ierarhie de autocodoare cu buclă închisă care extrag informații din mai multe simțuri și maximizează câștigul de informații al reprezentărilor rezultate la mai multe niveluri de ierarhie și granularitate.}
+    \label{fig:loops}
+\end{figure}
+După cum am învățat din neuroștiință, cortexul creierului nostru constă din zeci de mii de coloane corticale. Toate coloanele corticale au structuri și funcții fizice similare. Ele sunt extrem de paralele și distribuite, deși interconectate rar. Prin urmare, credem că pentru a dezvolta un sistem de memorie mai scalabil și structurat, trebuie să luăm în considerare arhitecturi care emulează pe cele ale cortexului. Figura \ref{fig:loops} arată o astfel de arhitectură ipotezată, un sistem masiv distribuit și ierarhic care constă din multe module de auto-codare cu buclă închisă în mare parte paralele. Aceste module învață să codifice diferite modalități senzoriale sau multe proiecții ale datelor din fiecare modalitate senzorială. Discuția noastră din Secțiunea \ref{sec:measurement-self-consistency} din Capitolul \ref{ch:conditional-inference} sugerează că o astfel de detecție și învățare paralelă a unei distribuții de dimensiune mică este teoretic posibilă. Autocodoarele de nivel superior (cu pierderi) pot fi apoi învățate pe baza ieșirilor celor de nivel inferior pentru a dezvolta ``abstracții'' mai rare și de nivel superior ale reprezentărilor învățate de nivelurile inferioare.
+
+
+Arhitectura de sistem distribuită, ierarhică și cu buclă închisă ilustrată în Figura \ref{fig:loops} împărtășește multe caracteristici ale cortexului cerebral. O astfel de arhitectură de sistem poate deschide mult mai multe posibilități decât arhitectura actuală cu un singur model mare. Face posibilă explorarea unor mecanisme de învățare și optimizare mult mai eficiente și are ca rezultat o organizare modulară mai structurată a distribuției datelor învățate și a cunoștințelor. Aceasta ne-ar permite să aducem implementarea inteligenței artificiale la următorul nivel de evoluție:
+\begin{equation}
+   \mbox{\textbf{incalculabil}} \;
+   \Longrightarrow \; \mbox{\textbf{calculabil}} \;
+   \Longrightarrow \; \mbox{\textbf{tractabil}} \; \Longrightarrow \; 
+   \mbox{\textbf{scalabil}} \; \Longrightarrow \; 
+   \mbox{\textbf{natural}}.
+\end{equation}
+
+\section{Către inteligența artificială umană: Dincolo de testul Turing?}
+După cum am discutat la începutul acestei cărți, Capitolul \ref{ch:intro}, inteligența în natură a evoluat prin mai multe faze și s-a manifestat în patru forme diferite:
+\begin{equation}
+\mbox{\textbf{filogenetică}} \;
+   \Longrightarrow \; \mbox{\textbf{ontogenetică}} \; \Longrightarrow \; 
+   \mbox{\textbf{societală}}
+   \; \Longrightarrow \; 
+   \mbox{\textbf{inteligență artificială}}.
+\end{equation}
+Toate formele de inteligență împărtășesc obiectivul comun de a învăța cunoștințe utile ca anumite distribuții de dimensiune mică ale datelor de dimensiune mare percepute despre lume. Cu toate acestea, ele pot diferi semnificativ în schemele specifice de codare adoptate, informațiile codificate, mecanismele computaționale pentru învățare și îmbunătățire și implementările fizice ale acestor mecanisme. Folosind conceptele și terminologiile dezvoltate în această carte, din perspectiva învățării și reprezentării informațiilor sau cunoștințelor din distribuția datelor percepute, cele patru etape de mai sus ale inteligenței dezvoltate în natură diferă în următoarele trei aspecte:
+\begin{enumerate}
+    \item Cartea de coduri pe care o folosește pentru a învăța și codifica informațiile sau cunoștințele intenționate.
+    \item Informațiile sau cunoștințele care sunt codificate și reprezentate folosind cartea de coduri.
+    \item Mecanismele de optimizare folosite pentru a îmbunătăți informațiile sau cunoștințele codificate.
+\end{enumerate}
+Mai specific, următorul tabel rezumă caracteristicile lor principale în cele trei aspecte de mai sus:
+\begin{center}
+\begin{tabular}{| c | c | c | c | c |}
+\hline & \textbf{Filogenetică} & \textbf{Ontogenetică} & \textbf{Societală} & \textbf{Artificială}\\
+\hline
+\textbf{Carte de coduri}  & Aminoacizi & Neuroni & Alfabet și cuvinte & Matematică/Logică \\ [0.5ex]
+  \hline 
+\textbf{Informație} & Gene/ADN & Memorie & Limbaje/Texte & Fapte științifice\\ [0.5ex]
+  \hline
+\textbf{Optimizare} & Învățare prin întărire & Feedback de eroare & Încercare și eroare & Testarea ipotezelor \\  [0.5ex]
+\hline
+\end{tabular}
+\end{center}
+
+
+
+
+
+După cum știm acum, oamenii au realizat două salturi cuantice în inteligență în istorie.
+Primul este dezvoltarea limbajelor vorbite și scrise cu aproximativ cinci până la zece mii de ani în urmă. Aceasta a permis oamenilor să împărtășească și să transmită cunoștințe învățate pentru generații, similar cu rolul ADN-ului în natură. Al doilea este dezvoltarea matematicii și logicii cu aproximativ trei mii de ani în urmă, care au devenit un limbaj precis pentru știința modernă. Acest nou limbaj ne-a eliberat de rezumarea cunoștințelor din observații în forme empirice și ne-a permis să formalizăm cunoștințele ca teorii verificabile sau falsificabile prin deducție matematică sau verificare experimentală. Prin formularea ipotezelor, deducția logică și testarea experimentală, suntem capabili să descoperim proactiv noi cunoștințe care erau imposibile anterior prin învățarea pasivă din distribuția datelor.\footnote{cum ar fi relațiile cauzale}
+
+După cum am discutat în Introducere (Capitolul \ref{ch:intro}), programul de ``inteligență artificială'' (IA) din 1956 a urmărit precis să studieze funcții de nivel înalt, cum ar fi abstracțiile matematice, inferența logică și rezolvarea problemelor care se crede că diferențiază oamenii de animale:
+\begin{equation}
+   \mbox{inteligență \textbf{de nivel scăzut} (animală)} \; \Longrightarrow \; 
+   \mbox{inteligență \textbf{de nivel înalt} (umană).}
+\end{equation}
+După cum am clarificat în mod repetat în această carte, multe dintre progresele tehnologice în inteligența artificială din ultimele decenii, deși realizate sub numele de ``IA'', sunt de fapt mai strâns legate de inteligența de nivel scăzut împărtășită atât de animale, cât și de oameni, care este în principal inductivă. Până acum, nu au existat dovezi care să sugereze că aceste mecanisme singure ar fi suficiente pentru a obține inteligența umană de nivel înalt pe care programul original de IA urmărește cu adevărat să o înțeleagă și să o emuleze.
+
+De fapt, știm puțin despre cum să verificăm riguros dacă un sistem este cu adevărat capabil de o anumită inteligență de nivel înalt, în ciuda faptului că testul Turing a fost propus încă din 1950 \cite{Turing-1950}.\footnote{În propunerea lui Turing, evaluatorul este un om. Cu toate acestea, pregătirea științifică și cunoștințele majorității evaluatorilor umani pot fi limitate și concluziile lor pot fi subiective.} Pentru mult timp, un astfel de test nu a fost considerat necesar, deoarece capacitățile mașinilor erau cu mult sub cele ale unui om (sau chiar animal). Cu toate acestea, având în vedere progresele tehnologice recente, multe modele și sisteme au pretins că ating și chiar depășesc inteligența umană. Prin urmare, este timpul să dăm o definiție științifică și executabilă a testului Turing. Adică, cum evaluăm sistematic și obiectiv nivelul de inteligență pentru un model sau sistem dat? De exemplu, cum putem verifica riguros dacă un sistem inteligent a înțeles cu adevărat un anumit concept abstract, cum ar fi noțiunea de numere naturale sau reale, sau a memorat doar un număr mare de instanțe? Rețineți că modelele de limbaj de ultimă generație încă se luptă cu întrebări matematice simple precum: ``3.11 este mai mare sau mai mic decât 3.9?''\footnote{Rețineți că unele modele și-au corectat răspunsurile la întrebări de acest gen prin inginerie post. Sau unele modele au încorporat mecanisme de raționament suplimentare bazate pe verificarea răspunsurilor imediate produse și corectarea lor în timpul raționamentului. Cu toate acestea, lăsăm cititorului ca exercițiu să testeze riguros dacă vreunul dintre modelele de limbaj de ultimă generație înțelege cu adevărat noțiunea de numere (naturale, raționale, reale și complexe) și aritmetica asociată.}
+Cum verificăm dacă un sistem înțelege cu adevărat regulile logicii și știe cum să le aplice riguros sau a memorat pur și simplu un număr mare de instanțe de practică a logicii? Mai mult, este un astfel de sistem chiar capabil să-și corecteze propriile cunoștințe sau să dezvolte noi cunoștințe, cum ar fi legi fizice, concepte matematice sau relații cauzale? În rezumat, este timpul să dezvoltăm metode riguroase de evaluare care pot spune căruia dintre următoarele aparține capacitatea aparent inteligentă a unui sistem/model:
+\begin{enumerate}
+    \item pur și simplu a memorat distribuția unor date purtătoare de cunoștințe și o regenerează;
+    \item poate dezvolta autonom și continuu noi cunoștințe din observații noi;
+    \item a înțeles cu adevărat anumite cunoștințe abstracte și știe cum să le aplice corect;
+    \item poate genera noi ipoteze științifice sau conjecturi matematice și să le verifice.
+\end{enumerate}
+
+\begin{figure}[t]
+    \centering
+    \includegraphics[width=0.95\linewidth]{\toplevelprefix/chapters/chapter8/figs/tests.png}
+    \caption{Trei teste pentru diferite niveluri sau tipuri de capacități de inteligență: testul Wiener pentru inteligența de bază, testul Turing pentru inteligența artificială la nivel uman și testul Popper pentru inteligența la nivel de om de știință.}
+    \label{fig:three-tests}
+\end{figure}
+
+Figura \ref{fig:three-tests} ilustrează că probabil ar trebui să existe cel puțin trei tipuri diferite de teste pentru a evalua și diferenția diferite tipuri de capacități de inteligență:
+\begin{enumerate}
+    \item {\em Testul Norbert Wiener:} Pentru a evalua dacă un sistem este capabil să îmbunătățească și să dezvolte noi cunoștințe proprii sau pur și simplu primește informații prin învățare întărită sau supervizată;
+    \item {\em Testul Alan Turing:} Pentru a evalua dacă un sistem poate înțelege cunoștințe abstracte sau pur și simplu învață statisticile sale și le folosește pentru inferență bayesiană.
+    \item {\em Testul Karl Popper:} Pentru a evalua dacă un sistem este capabil să exploreze noi cunoștințe prin formarea și verificarea de noi teorii bazate pe auto-consistență.
+\end{enumerate}
+Credem că, pentru astfel de metode de evaluare, evaluatorul nu ar trebui să fie un om, ci mai degrabă un protocol și un proces științific solid.
+
+
+
+După cum am văzut pe parcursul acestei cărți întregi, {\em compresia} a jucat un rol cel mai fundamental în învățare. Este principiul guvernator și un mecanism unificat pentru identificarea unei distribuții de date (empirice) și organizarea informațiilor codificate în ea. Într-o mare măsură, explică cea mai mare parte a practicii ``inteligenței artificiale'' din ultimul deceniu sau cam așa ceva. Aici cuvântul ``artificial'' înseamnă în mare parte ``făcut de om''. O întrebare remarcabilă pentru studiul viitor este dacă {\em compresia singură} este suficientă pentru a obține toate capacitățile de nivel superior ale inteligenței enumerate mai sus.
+\begin{quote}
+\begin{center}
+        {\em Este compresia tot ce există?}
+\end{center}
+\end{quote}
+Sunt abstracția, inferența cauzală, raționamentul logic și generarea de ipoteze și deducția ulterioară anumite forme extinse sau extreme de compresie? Există o diferență fundamentală între identificarea distribuțiilor de date empirice prin compresie și formarea de concepte și teorii abstracte de nivel înalt? Filozoful Sir Karl Popper a sugerat odată:
+\begin{quote}
+    \begin{center}
+    {\em ``Știința poate fi descrisă ca arta simplificării sistematice excesive.''}
+    \end{center}
+\end{quote}
+Într-o mare măsură, știința și cartea sa de coduri asociată, matematica, pot fi văzute ca cea mai avansată formă de inteligență, prin urmare, partea cu adevărat ``artificială'' a inteligenței noastre. Aici cuvântul ``artificial'' înseamnă ceea ce este unic pentru oamenii educați și iluminați, aproape ca o formă de artă înaltă. Credem că descoperirea și înțelegerea principiilor matematice de bază și a mecanismelor computaționale ale unei astfel de inteligențe de nivel superior vor fi frontiera finală pentru Știință, Matematică și Calcul în totalitate!
+
+\end{document}

--- a/chapters/declaration/declaration_ro.tex
+++ b/chapters/declaration/declaration_ro.tex
@@ -1,0 +1,14 @@
+\providecommand{\toplevelprefix}{../..}
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter*{Declarație Open Source}
+
+Această carte este menită să fie un ``proiect open-source'' care va fi pus la dispoziția publicului pe site-ul web:
+\begin{center}
+    \url{https://ma-lab-berkeley.github.io/deep-representation-learning-book/}
+\end{center}
+pentru toți oamenii care sunt interesați de principiile științifice și matematice ale inteligenței. Cartea va fi actualizată continuu și periodic de toți cei care sunt dispuși să contribuie la acest proiect, inclusiv versiunile traduse, materialele didactice și diverse instrumente AI care urmează să fie dezvoltate pentru a sprijini studiul, predarea și cercetarea acestui subiect.
+
+\end{document}

--- a/chapters/preface/preface_ro.tex
+++ b/chapters/preface/preface_ro.tex
@@ -1,0 +1,46 @@
+\providecommand{\toplevelprefix}{../..}  %
+\documentclass[../../book-main_ro.tex]{subfiles}
+
+\begin{document}
+
+\chapter*{Prefață}
+
+\begin{center}
+``{\em Toate drumurile duc la Roma}.''
+
+\end{center}
+\vspace{5mm}
+
+Această carte dezvăluie și studiază o problemă comună și fundamentală din spatele aproape tuturor practicilor moderne de inteligență (artificială). Aceasta este: {\em cum să învățăm eficient și eficace o distribuție de dimensiune redusă a datelor într-un spațiu cu dimensiuni mari și apoi să transformăm distribuția într-o reprezentare compactă și structurată?} Pentru orice sistem inteligent, natural sau creat de om, o astfel de reprezentare poate fi considerată în general ca o {\em memorie} sau {\em cunoaștere} învățată din datele percepute din lumea exterioară.
+
+Acest manual își propune să ofere o introducere sistematică în principiile matematice și computaționale pentru învățarea reprezentărilor (profunde) ale acestor distribuții de date pentru {\em studenții din ultimii ani de licență și studenții începători de masterat}. Principalele cerințe preliminare pentru această carte sunt algebra liniară de nivel licență, probabilități/statistică și optimizare. O oarecare familiaritate cu conceptele de bază din procesarea semnalelor (în special reprezentarea rară și detectarea comprimată), teoria informației și controlul cu feedback ar îmbunătăți aprecierea dumneavoastră.
+
+Principala motivație pentru scrierea acestei cărți este că au existat dezvoltări extraordinare în ultimii câțiva ani, de către autori și mulți colegi, care urmăresc să stabilească o abordare principială și riguroasă pentru înțelegerea rețelelor neuronale profunde și, mai general, a inteligenței în sine. Metodologia deductivă promovată de această nouă abordare este în contrast direct și foarte complementară cu metodologia dominantă din spatele practicilor actuale de inteligență artificială, care este în mare parte inductivă și bazată pe încercare și eroare. Lipsa de înțelegere a unor astfel de modele și sisteme AI puternice a condus la creșterea entuziasmului excesiv și a temerilor în societate. Credem că o încercare serioasă de a stabili o abordare principială pentru înțelegerea inteligenței este mai necesară ca niciodată. Un obiectiv general al acestei cărți este să ofere dovezi teoretice și experimentale solide care arată că acum este posibil să studiem inteligența ca un subiect științific și matematic. Prin urmare, se poate vedea această carte ca o primă încercare de a dezvolta {\em o Teorie Matematică a Inteligenței}.
+
+La nivel tehnic, cadrul teoretic prezentat în această carte ajută la reconcilierea unei lacune de lungă durată între abordarea clasică de modelare a structurilor de date care se bazează în principal pe modele geometrice, algebrice și probabilistice analitice (de exemplu, subspații, gaussiene și ecuații) și abordarea „modernă" care se bazează pe modele non-parametrice proiectate empiric (de exemplu, rețele profunde). După cum se dovedește, o unificare a celor două metodologii aparent separate devine posibilă și chiar naturală dacă cineva realizează că toate încearcă să modeleze și să învețe structuri {\em cu dimensiuni reduse} în distribuția de date de interes. Acestea sunt doar modalități diferite de a urmări, reprezenta și exploata structurile cu dimensiuni reduse. Din această perspectivă, chiar și multe tehnici computaționale aparent fără legătură, dezvoltate independent în domenii separate în momente diferite, pot fi acum mai bine înțelese într-un cadru computațional comun și probabil pot fi studiate împreună de acum înainte. După cum vom vedea în această carte, aceste tehnici includ, dar nu se limitează la, codarea-decodarea compresivă cu pierderi dezvoltată în teoria informației și teoria codării, difuzia și îndepărtarea zgomotului în procesarea semnalelor și învățarea automată, și tehnicile de continuare precum metodele Lagrangiene augmentate pentru optimizarea constrânsă.
+
+Credem că cadrul conceptual și computațional unificat prezentat în această carte va fi de mare valoare pentru cititorii care doresc cu adevărat să clarifice misterele și neînțelegerile despre rețelele neuronale profunde și inteligența (artificială). În plus, cadrul este menit să ofere cititorilor principii directoare pentru dezvoltarea unor sisteme semnificativ mai bune și cu adevărat inteligente în viitor. Mai specific, pe lângă o introducere informală (capitol), conținutul tehnic principal al cărții va fi organizat în șase subiecte strâns legate (capitole):
+\begin{enumerate}
+\item Vom începe cu modelele clasice și cele mai de bază de Analiză a Componentelor Principale (PCA), Analiză a Componentelor Independente (ICA) și Învățarea Dicționarului (DL), care presupun că distribuțiile cu dimensiuni reduse de interes au structuri liniare și independente. Din aceste modele idealiste simple care sunt bine studiate și înțelese în procesarea semnalelor și detectarea comprimată, vom introduce ideile cele mai de bază și importante pentru cum să învățăm distribuții cu dimensiuni reduse.
+
+\item Pentru a generaliza aceste modele clasice și soluțiile lor la distribuții generale cu dimensiuni reduse, introducem un principiu computațional universal pentru învățarea acestor distribuții: {\em compresia}. După cum vom vedea, compresia datelor oferă o viziune unificatoare a tuturor abordărilor clasice și moderne aparent diferite pentru învățarea distribuției sau reprezentării, inclusiv reducerea dimensionalității, minimizarea entropiei, potrivirea scorului pentru îndepărtarea zgomotului și compresia cu pierderi cu distorsiune de rată.
+
+\item În cadrul acestui cadru unificator, Rețelele Neuronale Profunde moderne (DNN), cum ar fi ResNet, CNN și Transformer, pot fi toate interpretate matematic ca algoritmi de optimizare (desfășurați) care obțin iterativ o compresie mai bună și reprezentări mai bune prin reducerea lungimii/ratei de codare sau obținerea de informații. Nu numai că acest cadru ajută la explicarea arhitecturilor de rețea profundă proiectate empiric până acum, dar conduce și la noi designuri de arhitectură care pot fi semnificativ mai simple și mai eficiente.
+
+\item În plus, pentru a asigura că reprezentarea învățată pentru o distribuție de date este corectă și consistentă, arhitecturile de {\em auto-codare} care constau atât din codare, cât și din decodare devin necesare. Pentru ca un sistem de învățare să fie complet automat și continuu, vom introduce un cadru puternic de {\em transcriere în buclă închisă} care permite unui sistem de auto-codare să se auto-corecteze și astfel să se auto-îmbunătățească printr-un joc minimax între codificator și decodificator.
+
+\item Vom studia, de asemenea, cum distribuția și reprezentarea datelor învățate pot fi utilizate ca o prioritate sau constrângere puternică pentru a efectua inferența Bayesiană care facilitează aproape toate tipurile de sarcini și setări care sunt populare în practica inteligenței artificiale moderne, inclusiv estimarea condiționată, completarea și generarea de date din lumea reală cu dimensiuni mari, cum ar fi imagini și texte.
+
+\item Nu în ultimul rând, pentru a conecta teoria cu practica, vom demonstra pas cu pas cum să învățăm eficient și eficace reprezentări profunde ale distribuțiilor de date cu dimensiuni reduse cu seturi de date la scară largă, inclusiv atât imagini, cât și texte, și să le folosim în multe aplicații practice, cum ar fi clasificarea imaginilor, completarea imaginilor, segmentarea imaginilor, generarea imaginilor și sarcini similare pentru date text.
+\end{enumerate}
+
+Pentru a rezuma, conținutul tehnic prezentat în această carte stabilește conexiuni conceptuale și tehnice puternice între abordarea analitică clasică și abordarea computațională modernă, între modele parametrice simple și modele non-parametrice profunde, între diverse practici inductive și un cadru deductiv unificat din principii prime. Vom dezvălui că multe abordări aparent fără legătură sau chiar concurente, deși dezvoltate în domenii separate în momente diferite, toate se străduiesc să atingă un obiectiv comun:
+\begin{quote}
+\centering{\em urmărirea și exploatarea distribuțiilor intrinseci cu dimensiuni reduse ale datelor cu dimensiuni mari.}
+\end{quote}
+În acest scop, cartea ne va purta printr-o călătorie completă de la formularea teoretică la verificarea matematică la realizarea computațională la aplicații practice.
+
+
+
+
+\end{document}

--- a/website/html/common_components.js
+++ b/website/html/common_components.js
@@ -158,6 +158,7 @@
           desc: 'PRs: <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/14">#14</a>',
         },
         "kerui-min": { desc: "Chinese translation." },
+        "jan-cavel": { desc: "Romanian translation." },
         "kevin-murphy": {
           desc: 'Extensive feedback. Issues: <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/3">#3</a>, <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/4">#4</a>, <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/5">#5</a>, <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/8">#8</a>, <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/10">#10</a>, <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/11">#11</a>, <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/12">#12</a>, <a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/13">#13</a>',
         },

--- a/website/html/contributors.js
+++ b/website/html/contributors.js
@@ -70,6 +70,12 @@
       url: "https://yaodongyu.github.io/",
       affil: "University of Maryland, College Park",
     },
+    {
+      id: "jan-cavel",
+      name: "Jan Cavel",
+      url: "https://piatra.institute/",
+      affil: "Piatra Institute",
+    },
   ];
 
   const INFRA_CONTRIBUTORS = [

--- a/website/html/zh/common_components.js
+++ b/website/html/zh/common_components.js
@@ -136,6 +136,7 @@
           desc: 'PR：<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/14">#14</a>',
         },
         "kerui-min": { desc: "中文翻译。" },
+        "jan-cavel": { desc: "罗马尼亚语翻译." },
         "kevin-murphy": {
           desc: '大量反馈。Issues：<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/3">#3</a>、<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/4">#4</a>、<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/5">#5</a>、<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/8">#8</a>、<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/10">#10</a>、<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/11">#11</a>、<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/12">#12</a>、<a href="https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/13">#13</a>',
         },


### PR DESCRIPTION
## Add Romanian Translation

This PR adds a complete Romanian translation, except for the images.

### Summary

- Translated all 8 chapters, 2 appendices, and front matter (preface, declaration, acknowledgments)
- Added `book-main_ro.tex` configured with LuaLaTeX for proper Unicode support of Romanian diacritics (ș, ț, ă, î, â)

### Technical Notes

- **Compile with LuaLaTeX** for proper Unicode support:
```bash
latexmk -lualatex -interaction=nonstopmode --shell-escape -f book-main_ro.tex
```
- Uses Unicode characters U+0218/0219 (Ș/ș) and U+021A/021B (Ț/ț) for correct Romanian comma-below diacritics

### Citation

The Romanian translation is available at: https://doi.org/10.5281/zenodo.17024756

### Test Plan

- All chapters compile without errors
- Table of contents generates correctly in Romanian
- Bibliography compiles and displays properly
- Romanian diacritics render correctly and are copyable from the PDF
- Cross-references and citations work throughout the document