### PR TITLE
Remove header border; revert padding edits

### DIFF
--- a/website/html/chapter.css
+++ b/website/html/chapter.css
@@ -220,7 +220,6 @@ img,
   top: 42px;
   z-index: 30;
   background: #fff;
-  border-bottom: 1px solid #e8edf6;
 }
 .ltx_page_header .ltx_align_center {
   display: flex;
@@ -900,6 +899,7 @@ body > *:first-child {
   z-index: 30;
   background: #fff;
   margin: 0 !important;
+  border-bottom: none !important;
   border-top: none !important;
 }
 .ltx_page_navbar,


### PR DESCRIPTION
This PR removes the 1px bottom border under the chapter header (.ltx_page_header) and reverts previous padding changes. The fixed header override explicitly sets border-bottom: none !important; to avoid any residual line when the header is fixed under the top bar.