### PR TITLE
Add Bill Mark to contributors page

### DIFF
--- a/website/html/common_components.js
+++ b/website/html/common_components.js
@@ -232,6 +232,7 @@ This book would have not been possible without the financial support for these r
                 "jan-cavel": {
                     desc: "Romanian translation. PRs: [#16](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/16)",
                 },
+                "bill-mark": { desc: "Extensive technical feedback on Chapters 4–5 and Appendix B." },
                 "kevin-murphy": {
                     desc: "Extensive feedback. Issues: [#3](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/3), [#4](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/4), [#5](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/5), [#8](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/10), [#10](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/10), [#11](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/11), [#12](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/12), [#13](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/13)",
                 },

--- a/website/html/contributors.js
+++ b/website/html/contributors.js
@@ -78,6 +78,12 @@
             affil: "University of Hong Kong",
         },
         {
+            id: "bill-mark",
+            name: "Bill Mark",
+            url: "https://www.linkedin.com/in/bill-mark-a51142/",
+            affil: "Independent",
+        },
+        {
             id: "kerui-min",
             name: "Kerui Min",
             url: "https://www.linkedin.com/in/kerui-min-b974b52a/",

--- a/website/html/zh/common_components.js
+++ b/website/html/zh/common_components.js
@@ -208,6 +208,7 @@
                 "jan-cavel": {
                     desc: "罗马尼亚语翻译. PRs：[#16](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/16)",
                 },
+                "bill-mark": { desc: "对第4–5章和附录B的大量技术反馈。" },
                 "kevin-murphy": {
                     desc: "大量反馈。Issues：[#3](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/3)、[#4](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/4)、[#5](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/5)、[#8](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/8)、[#10](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/10)、[#11](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/11)、[#12](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/12)、[#13](https://github.com/Ma-Lab-Berkeley/deep-representation-learning-book/pull/13)",
                 },


### PR DESCRIPTION
## Summary
- Add Bill Mark to the website contributors page, matching the preface-v2 acknowledgments
- Added entry in `contributors.js` (name, LinkedIn URL, affiliation "Independent")
- Added English and Chinese descriptions in `common_components.js` files