### PR TITLE
Fix three small text errors in Chapter 4

### DIFF
--- a/chapters/chapter4/lossy-compression.tex
+++ b/chapters/chapter4/lossy-compression.tex
@@ -1509,7 +1509,7 @@ independent, as illustrated before in
 \Cref{fig:representation-learning}. \Cref{chap4-fig:mcr-diagram}
 illustrates  when the data distribution is actually a mixture of
 low-dimensional submanifolds.  Through compression (denoising or
-clustering), we first identify that the true data distribution
+clustering), we first identify the true data distribution
 (left). We then would like to transform the distribution so that the
 submanifolds eventually become mutually incoherent/independent linear
 subspaces (right).

--- a/chapters/chapter4/lossy-compression.tex
+++ b/chapters/chapter4/lossy-compression.tex
@@ -1079,7 +1079,7 @@ the two coding lengths:
     L(\vX_k \cup \vX_l) - L^c(\vX_k, \vX_l)
 \end{equation}
 is positive or negative and $\vX_k \cup \vX_l$ denotes the union of the
-sets of samples in $\bm X_k$ and $\bm X_l$. If it is positive , it
+sets of samples in $\bm X_k$ and $\bm X_l$. If it is negative, it
 means the coding length would become smaller if we merge the two
 clusters into one. This simple fact leads to the following clustering
 algorithm proposed by \cite{ma2007segmentation}:

--- a/chapters/chapter4/lossy-compression.tex
+++ b/chapters/chapter4/lossy-compression.tex
@@ -1235,8 +1235,8 @@ The fundamental question of representation learning is
     \centering
     \includegraphics[width=0.8\linewidth]{\toplevelprefix/chapters/chapter4/figs/Gaussian-Subspaces.png}
     \caption{Identifying a low-dimensional distribution with two
-        subspaces (left) via denoising or clustering, starting from a
-    generic random Gaussian distribution (right).}
+        subspaces (right) via denoising or clustering, starting from a
+    generic random Gaussian distribution (left).}
     \label{fig:Gaussian-Subspaces}
 \end{figure}
 


### PR DESCRIPTION
## Fix 1: Merge criterion description (equation 4.1.40)
The paragraph following the merge criterion equation states:
> "If it is positive, it means the coding length would become smaller if we merge the two clusters into one."

Since the quantity is `L(X_k ∪ X_l) - L^c(X_k, X_l)` (merged cost minus separate cost), a **positive** value means merging is **more** expensive, not less.

This is confirmed by Algorithm 4.1 (Pairwise Steepest Descent of Coding Length), which:
- Returns early (stops merging) when `min[L(merged) - L^c(separate)] >= 0`
- Merges the pair that achieves the most **negative** difference

Changed "positive" to "negative" to align with the algorithm.

## Fix 2: Figure 4.11 caption (left/right swapped)
The caption for Figure 4.11 describes "two subspaces (left)" and "generic random Gaussian distribution (right)", but the figure shows the opposite: the unstructured Gaussian is on the left, and the identified subspaces S'_1 and S'_2 are on the right.

Swapped "left" and "right" in the caption to match the figure.

## Fix 3: Grammar fix in Section 4.2
> "Through compression (denoising or clustering), we first identify **that** the true data distribution (left)."

The extraneous "that" makes this sentence ungrammatical. Fixed to:

> "Through compression (denoising or clustering), we first identify the true data distribution (left)."