### PR TITLE
Fix PCA projection error equation

### DIFF
--- a/chapters/chapter1/introduction.tex
+++ b/chapters/chapter1/introduction.tex
@@ -1017,7 +1017,7 @@ The problem is to find the subspace basis \(\vU\) from many samples
 of \(\vx\). A typical approach is to minimize the projection error
 onto the subspace:
 \begin{equation}
-    \min_{\vU}\Ex[\|\vx - \vU\vU^{\top} \vz\|_{2}^{2}].
+    \min_{\vU}\Ex[\|\vx - \vU\vU^{\top} \vx\|_{2}^{2}].
 \end{equation}
 This is essentially a denoising task: once the basis \(\vU\) is
 correctly found, we can denoise the noisy sample \(\vx\) by


### PR DESCRIPTION
## Summary
- fix the PCA projection error objective in Chapter 1
- replace `UU^T z` with `UU^T x`, matching the projection/reconstruction described immediately below the equation

Fixes #86.

## Testing
- `git diff --check`
- `rg -n "\\vU\\vU\^\{\\top\} \\v[xyz]|min_\{\\vU\}" chapters/chapter1/introduction.tex`

AI disclosure: I used OpenAI Codex to help prepare this change.